### PR TITLE
Allow CompatHelper to use DOCUMENTER_KEY

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -41,5 +41,5 @@ jobs:
               shell: julia --color=yes {0}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  # COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+                  COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
                   # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Allow CompatHelper to use DOCUMENTER_KEY.
Hopefully solves it.

<!-- include screenshots if that helps the review -->

## List of related issues or pull requests

Related
- #39 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
