### PR TITLE
Custom command to run benchmark from a PR

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -50,10 +50,6 @@ jobs:
               run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
             - name: Run benchmarks
               run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(baseline="origin/main")'
-            # - name: Post results
-            #   run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Results
               id: benched
               run: |

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,20 +1,47 @@
 name: Run benchmarks
+
 on:
-    pull_request:
-        paths:
-            - "src/**"
-            - "benchmark/**"
-            - "*.toml"
+    issue_comment:
+        types: [created, edited]
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: Git branch/tag/reference to benchmark
+                type: string
+                default: main
+
 concurrency:
     # Skip intermediate builds: always.
     # Cancel intermediate builds: only if it is a pull request build.
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
     benchmark:
+        if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/run-benchmark') }}
+
         runs-on: ubuntu-latest
+        permissions:
+            issues: write
+            pull-requests: write
+
         steps:
-            - uses: actions/checkout@v3
+            - name: Find PR repo and ref
+              uses: actions/github-script@v6
+              id: find-ref
+              with:
+                  script: |
+                      const pr = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.issue.number
+                      })
+                      core.setOutput('repo', pr.data.head.repo.full_name)
+                      core.setOutput('ref', pr.data.head.ref)
+            - uses: actions/checkout@v4
+              with:
+                  repository: ${{ steps.find-ref.outputs.repo }}
+                  ref: ${{ steps.find-ref.outputs.ref }}
             - uses: julia-actions/setup-julia@latest
               with:
                   version: 1
@@ -23,7 +50,26 @@ jobs:
               run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
             - name: Run benchmarks
               run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(baseline="origin/main")'
-            - name: Post results
-              run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            # - name: Post results
+            #   run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Results
+              id: benched
+              run: |
+                  {
+                    echo 'RESULT<<EOF';
+                    julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()';
+                    echo EOF;
+                  } >> result.txt
+                  cat result.txt >> "$GITHUB_OUTPUT"
+                  { echo '```'; sed -e '1d;$d' result.txt; echo '```'; } >> $GITHUB_STEP_SUMMARY
+            - uses: actions/github-script@v6
+              with:
+                  script: |
+                      github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        body: `\`\`\`\n${{ steps.benched.outputs.RESULT }}\n\`\`\``
+                      })

--- a/README.dev.md
+++ b/README.dev.md
@@ -183,3 +183,11 @@ git push --force
 
 After pushing, the PR will be automatically updated.
 If a review was made, re-request a review.
+
+## Performance considerations
+
+If you updated something that might impact the performance of the
+package, you can run the `Benchmark.yml` workflow from your PR.  To do
+that, add the command `/run-benchmark` as a comment in the PR.  This
+will trigger the workflow for your branch, and post the results as a
+comment in you PR.


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

This implements a `/run-benchmark` "command" that anyone can use in PRs to trigger the `Benchmark.yml` workflow.  After the workflow completes, it responds to the PR with a comment containing the results.  The results from `BenchmarkCI` doesn't seem like to be markdown formatted, so I wrapped it in a source block.  We could also try to parse it into nice markdown if we want.  The workflow also has an (incomplete) `workflow_dispatch` trigger, which could be used to manually run it for a specific branch/tag.  To support this use, the workflow also generates a "step summary" that is shown in the GH actions workflow run page.

You can see this in action in [this repo](https://github.com/suvayu/fictional-giggle/pull/5). In the example repo there's nothing to benchmark, so it just responds with the latest commit of the PR branch (this way you also know the correct version is being "benchmarked").

### Summary
#### Complete:
- [x] trigger with custom command: `/run-benchmark`
- [x] benchmark report as PR comment & step summary

#### Incomplete:
- [ ] trigger on a branch/tag with `workflow_dispatch`

#### Possible improvements:
- [ ] limit to members
- [ ] link back from the comment to the workflow run page
- [ ] parse and format report as markdown

## List of related issues or pull requests

Closes #59

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
