### PR TITLE
Benchmark workflow runnable as workflow_dispatch

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -4,6 +4,10 @@ on:
         types: [created, edited]
     workflow_dispatch:
         inputs:
+            repo:
+                description: Fork to benchmark "user/repo", empty denotes current repo
+                type: string
+                default: ""
             ref:
                 description: Git branch/tag/reference to benchmark
                 type: string
@@ -19,23 +23,29 @@ concurrency:
     cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
     benchmark:
-        if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/run-benchmark') }}
-
+        if: |
+            (github.event.issue.pull_request && contains(github.event.comment.body, '/run-benchmark')) ||
+            github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
-
         steps:
             - name: Find PR repo and ref
               uses: actions/github-script@v6
               id: find-ref
               with:
                   script: |
-                      const pr = await github.rest.pulls.get({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        pull_number: context.issue.number
-                      })
-                      core.setOutput('repo', pr.data.head.repo.full_name)
-                      core.setOutput('ref', pr.data.head.ref)
+                      if (context.eventName == 'pull_request') {
+                          const pr = await github.rest.pulls.get({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            pull_number: context.issue.number
+                          })
+                          core.setOutput('repo', pr.data.head.repo.full_name)
+                          core.setOutput('ref', pr.data.head.ref)
+                      }
+                      if (context.eventName == 'workflow_dispatch') {
+                          core.setOutput('repo', '${{ inputs.repo }}')
+                          core.setOutput('ref', '${{ inputs.ref }}')
+                      }
             - uses: actions/checkout@v4
               with:
                   repository: ${{ steps.find-ref.outputs.repo }}
@@ -59,6 +69,7 @@ jobs:
                   cat result.txt >> "$GITHUB_OUTPUT"
                   { echo '```'; sed -e '1d;$d' result.txt; echo '```'; } >> $GITHUB_STEP_SUMMARY
             - uses: actions/github-script@v6
+              if: github.event.issue.pull_request
               with:
                   script: |
                       github.rest.issues.createComment({

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -11,7 +11,7 @@ on:
             ref:
                 description: Git branch/tag/reference to benchmark
                 type: string
-                default: main
+                default: ""
 permissions:
     contents: write
     issues: write
@@ -43,6 +43,9 @@ jobs:
                           core.setOutput('ref', pr.data.head.ref)
                       }
                       if (context.eventName == 'workflow_dispatch') {
+                          if ('${{inputs.repo}}' == "" && ["", "main"].includes('${{inputs.ref}}')) {
+                              core.setFailed("cannot run benchmark against current repo's main")
+                          }
                           core.setOutput('repo', '${{ inputs.repo }}')
                           core.setOutput('ref', '${{ inputs.ref }}')
                       }


### PR DESCRIPTION
## Describe the changes made in this pull request

The workflow_dispatch event accepts a fork and branch parameter,
and runs the benchmark workflow on it.  The results are shown in the
step summary

## List of related issues or pull requests

- #59

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
