### PR TITLE
Fix benchmarks and add info on how to run it manually

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -199,3 +199,16 @@ package, you can run the `Benchmark.yml` workflow from your PR.  To do
 that, add the command `/run-benchmark` as a comment in the PR.  This
 will trigger the workflow for your branch, and post the results as a
 comment in you PR.
+
+If you want to manually run the benchmarks, you can do the following:
+
+- Navigate to the benchmark folder
+- Run `julia --project=.`
+- Enter `pkg` mode by pressing `]`
+- Run `dev ..` to add the development version of TulipaEnergyModel
+- Now run
+
+  ```julia
+  tune!(SUITE)
+  results = run(SUITE, verbose=true)
+  ```

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,10 +3,10 @@ using TulipaEnergyModel
 
 const SUITE = BenchmarkGroup()
 
-SUITE["io"] = BenchmarkGroup(["data", "input", "output"])
+SUITE["io"] = BenchmarkGroup(["data", "input", "graph", "output"])
 SUITE["model"] = BenchmarkGroup(["model"])
 
-const INPUT_FOLDER = joinpath(@__DIR__, "..", "test", "inputs")
+const INPUT_FOLDER = joinpath(@__DIR__, "..", "test", "inputs", "tiny")
 const OUTPUT_FOLDER = joinpath(@__DIR__, "..", "test", "outputs")
 
 SUITE["io"]["input"] = @benchmarkable begin
@@ -14,11 +14,22 @@ SUITE["io"]["input"] = @benchmarkable begin
 end
 parameters, sets = create_parameters_and_sets_from_file(INPUT_FOLDER)
 
+SUITE["io"]["graph"] = @benchmarkable begin
+    create_graph(
+        $(joinpath(INPUT_FOLDER, "assets-data.csv")),
+        $(joinpath(INPUT_FOLDER, "flows-data.csv")),
+    )
+end
+graph = create_graph(
+    joinpath(INPUT_FOLDER, "assets-data.csv"),
+    joinpath(INPUT_FOLDER, "flows-data.csv"),
+)
+
 SUITE["model"]["all"] = @benchmarkable begin
-    optimise_investments($parameters, $sets)
+    optimise_investments($graph, $parameters, $sets)
 end
 
-solution = optimise_investments(parameters, sets)
+solution = optimise_investments(graph, parameters, sets)
 
 SUITE["io"]["output"] = @benchmarkable begin
     save_solution_to_file(


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

The benchmarks now run on the `tiny` data.
The benchmarks now run the `create_graph` function as well.
The old functions have been updated to use the `graph`.

## List of related issues or pull requests

Closes #146 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
