### PR TITLE
Add warning catch for infeasible test

### DIFF
--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -34,6 +34,5 @@ end
     parameters.peak_demand["demand"] = -1 # make it infeasible
     graph = create_graph(joinpath(dir, "assets-data.csv"), joinpath(dir, "flows-data.csv"))
     model = create_model(graph, parameters, sets)
-    solution = solve_model(model)
-    @test solution === nothing
+    @test_warn "Model status different from optimal" solve_model(model)
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request
The infeasible test used to produce a warning - now that warning is caught so the test passes without warning
Avoids having a "consistent warning"

## List of related issues or pull requests

Closes #190

## Collaboration confirmation

As a contributor I confirm

- [X] I read and followed the instructions in README.dev.md
- [X] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [X] Tests are passing
- [X] Lint is passing
