### PR TITLE
Multiply the time-resolution matrices by the rp time scale/duration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 CSV = "0.10"

--- a/test/test-time-resolution.jl
+++ b/test/test-time-resolution.jl
@@ -1,29 +1,35 @@
 @testset "Time resolution" begin
     @testset "resolution_matrix" begin
         rp_periods = [1:4, 5:8, 9:12]
-        time_steps = [1:4, 5:8, 9:12]
-        expected = [
-            1.0 0.0 0.0
-            0.0 1.0 0.0
-            0.0 0.0 1.0
-        ]
-        @test resolution_matrix(rp_periods, time_steps) == expected
+        for time_scale in [1e-4, 0.5, 1.0, 3.14, 1e4]
+            time_steps = [1:4, 5:8, 9:12]
+            expected = time_scale * [
+                1.0 0.0 0.0
+                0.0 1.0 0.0
+                0.0 0.0 1.0
+            ]
+            @test resolution_matrix(rp_periods, time_steps; rp_time_scale = time_scale) ≈
+                  expected
 
-        time_steps = [1:3, 4:6, 7:9, 10:12]
-        expected = [
-            1.0 1/3 0.0 0.0
-            0.0 2/3 2/3 0.0
-            0.0 0.0 1/3 1.0
-        ]
-        @test resolution_matrix(rp_periods, time_steps) == expected
+            time_steps = [1:3, 4:6, 7:9, 10:12]
+            expected = time_scale * [
+                1.0 1/3 0.0 0.0
+                0.0 2/3 2/3 0.0
+                0.0 0.0 1/3 1.0
+            ]
+            @test resolution_matrix(rp_periods, time_steps; rp_time_scale = time_scale) ≈
+                  expected
 
-        time_steps = [1:6, 7:9, 10:10, 11:11, 12:12]
-        expected = [
-            2/3 0.0 0.0 0.0 0.0
-            1/3 2/3 0.0 0.0 0.0
-            0.0 1/3 1.0 1.0 1.0
-        ]
-        @test resolution_matrix(rp_periods, time_steps) == expected
+            time_steps = [1:6, 7:9, 10:10, 11:11, 12:12]
+            expected =
+                time_scale * [
+                    2/3 0.0 0.0 0.0 0.0
+                    1/3 2/3 0.0 0.0 0.0
+                    0.0 1/3 1.0 1.0 1.0
+                ]
+            @test resolution_matrix(rp_periods, time_steps; rp_time_scale = time_scale) ≈
+                  expected
+        end
     end
 
     @testset "compute_rp_periods" begin


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Adds the arguments `rp_time_scale` to the time resolution matrix function.
This value is multiplied by the matrix.
The tests were updated to try different values for the time scale.
Also, since there is floating-point arithmetic going on now, the comparison has to be approximate, not equal anymore.

## List of related issues or pull requests

Closes #178 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
