### PR TITLE
Use a random tmp dir to write the solver output in the benchmark

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -7,7 +7,7 @@ SUITE["io"] = BenchmarkGroup()
 SUITE["model"] = BenchmarkGroup()
 
 const INPUT_FOLDER_BM = joinpath(@__DIR__, "..", "test", "inputs", "Norse")
-const OUTPUT_FOLDER_BM = joinpath(@__DIR__, "..", "test", "outputs")
+const OUTPUT_FOLDER_BM = mktempdir()
 
 SUITE["io"]["input"] = @benchmarkable begin
     create_parameters_and_sets_from_file($INPUT_FOLDER_BM)


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Instead of writing to the test folder, write to some random place, since the output is ignored. This random place will be deleted after the Julia call is done, so it won't overflow the disk.
I haven't written to /dev/null because that would require changes to the write output function itself or some ugly workaround. Since the code is not a bottleneck, this should suffice.

## List of related issues or pull requests

Closes #230 
Closes #193 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
