### PR TITLE
Fix summation of flow profile over time block

### DIFF
--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -1,7 +1,7 @@
 @testset "Norse Case Study" begin
     dir = joinpath(INPUT_FOLDER, "Norse")
     _, _, _, solution = run_scenario(dir)
-    @test solution.objective_value ≈ 1.6443286362357396e8 atol = 1e-5
+    @test solution.objective_value ≈ 1.64494182205421e8 atol = 1e-5
 end
 
 @testset "Tiny Case Study" begin


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Creates a function for the sum of the flow profile over the time block.
Also changes the assets_profiles_sum to be a function instead of an expression, because it does not have any variables or expression, and therefore it can be immediately computed.

## List of related issues or pull requests

Closes #264 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
