### PR TITLE
Store the solution inside the graph structure and the objective value inside the problem struct

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -25,8 +25,8 @@ SUITE["model"]["solve_model"] = @benchmarkable begin
     solve_model!($energy_problem)
 end
 
-solution = solve_model!(energy_problem)
+solve_model!(energy_problem)
 
 SUITE["io"]["output"] = @benchmarkable begin
-    save_solution_to_file($OUTPUT_FOLDER_BM, $(energy_problem.graph), $solution)
+    save_solution_to_file($OUTPUT_FOLDER_BM, $energy_problem)
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -145,7 +145,19 @@ function read_csv_with_schema(file_path, schema; csvargs...)
 end
 
 """
-    save_solution_to_file(output_folder, graph, solution)
+    save_solution_to_file(output_folder, energy_problem)
+
+Saves the solution from `energy_problem` in CSV files inside `output_file`.
+"""
+function save_solution_to_file(output_folder, energy_problem::EnergyProblem)
+    if !energy_problem.solved
+        error("The energy_problem has not been solved yet.")
+    end
+    save_solution_to_file(output_folder, energy_problem.graph)
+end
+
+"""
+    save_solution_to_file(output_file, graph)
 
 Saves the solution in CSV files inside `output_folder`.
 
@@ -155,7 +167,7 @@ The following files are created:
     `v` is the corresponding asset investment value, and `p` is the corresponding
     capacity value. Only investable assets are included.
 """
-function save_solution_to_file(output_folder, graph, solution)
+function save_solution_to_file(output_folder, graph)
     # Writing the investment results to a CSV file
     output_file = joinpath(output_folder, "investments.csv")
     output_table = DataFrame(; a = String[], InstalUnits = Int[], InstalCap_MW = Float64[])
@@ -163,7 +175,7 @@ function save_solution_to_file(output_folder, graph, solution)
         if !graph[a].investable
             continue
         end
-        v = solution.assets_investment[a]
+        v = graph[a].investment
         p = graph[a].capacity
         push!(output_table, (a, v, p * v))
     end

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -11,8 +11,8 @@ If the output_folder is specified, save the sets, parameters, and solution to th
 function run_scenario(input_folder::AbstractString; write_lp_file = false)
     energy_problem = create_energy_problem_from_csv_folder(input_folder)
     create_model!(energy_problem; write_lp_file = write_lp_file)
-    solution = solve_model!(energy_problem)
-    return energy_problem, solution
+    solve_model!(energy_problem)
+    return energy_problem
 end
 
 function run_scenario(
@@ -20,7 +20,7 @@ function run_scenario(
     output_folder::AbstractString;
     write_lp_file = false,
 )
-    energy_problem, solution = run_scenario(input_folder; write_lp_file)
-    save_solution_to_file(output_folder, energy_problem.graph, solution)
-    return energy_problem, solution
+    energy_problem = run_scenario(input_folder; write_lp_file)
+    save_solution_to_file(output_folder, energy_problem)
+    return energy_problem
 end

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -30,6 +30,9 @@ mutable struct GraphAssetData
     energy_to_power_ratio::Float64
     profiles::Dict{Int,Vector{Float64}}
     partitions::Dict{Int,Vector{TimeBlock}}
+    # Solution
+    investment::Int
+    storage_level::Dict{Tuple{Int,TimeBlock},Float64}
 
     # You don't need profiles to create the struct, so initiate it empty
     function GraphAssetData(
@@ -57,6 +60,8 @@ mutable struct GraphAssetData
             energy_to_power_ratio,
             profiles,
             partitions,
+            -1,
+            Dict{Tuple{Int,TimeBlock},Float64}(),
         )
     end
 end
@@ -78,6 +83,9 @@ mutable struct GraphFlowData
     efficiency::Float64
     profiles::Dict{Int,Vector{Float64}}
     partitions::Dict{Int,Vector{TimeBlock}}
+    # Solution
+    flow::Dict{Tuple{Int,TimeBlock},Float64}
+    investment::Int
 end
 
 function GraphFlowData(flow_data::FlowData)
@@ -95,6 +103,8 @@ function GraphFlowData(flow_data::FlowData)
         flow_data.efficiency,
         Dict{Int,Vector{Float64}}(),
         Dict{Int,Vector{TimeBlock}}(),
+        Dict{Tuple{Int,TimeBlock},Float64}(),
+        -1,
     )
 end
 
@@ -116,6 +126,7 @@ mutable struct EnergyProblem
     constraints_partitions::Dict{Tuple{String,Int},Vector{TimeBlock}}
     model::Union{JuMP.Model,Nothing}
     solved::Bool
+    objective_value::Float64
     termination_status::JuMP.TerminationStatusCode
     # solver_parameters # Part of #246
 
@@ -133,6 +144,7 @@ mutable struct EnergyProblem
             constraints_partitions,
             nothing,
             false,
+            NaN,
             JuMP.OPTIMIZE_NOT_CALLED,
         )
     end

--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -1,13 +1,13 @@
 @testset "Norse Case Study" begin
     dir = joinpath(INPUT_FOLDER, "Norse")
-    _, solution = run_scenario(dir)
-    @test solution.objective_value ≈ 1.64494182205421e8 atol = 1e-5
+    energy_problem = run_scenario(dir)
+    @test energy_problem.objective_value ≈ 1.64494182205421e8 atol = 1e-5
 end
 
 @testset "Tiny Case Study" begin
     dir = joinpath(INPUT_FOLDER, "Tiny")
-    _, solution = run_scenario(dir, OUTPUT_FOLDER; write_lp_file = true)
-    @test solution.objective_value ≈ 269238.43825 atol = 1e-5
+    energy_problem = run_scenario(dir, OUTPUT_FOLDER; write_lp_file = true)
+    @test energy_problem.objective_value ≈ 269238.43825 atol = 1e-5
 end
 
 @testset "Infeasible Case Study" begin

--- a/test/test-io.jl
+++ b/test/test-io.jl
@@ -15,8 +15,8 @@ end
         @test_throws Exception save_solution_to_file(output_dir, energy_problem)
         create_model!(energy_problem)
         @test_throws Exception save_solution_to_file(output_dir, energy_problem)
-        solution = solve_model!(energy_problem)
-        @test save_solution_to_file(output_dir, energy_problem.graph, solution) === nothing
+        solve_model!(energy_problem)
+        @test save_solution_to_file(output_dir, energy_problem) === nothing
     end
 end
 

--- a/test/test-model.jl
+++ b/test/test-model.jl
@@ -4,6 +4,6 @@
     @test !energy_problem.solved
     create_model!(energy_problem)
     @test !energy_problem.solved
-    solve_model!(energy_problem)
+    @test solve_model!(energy_problem) === energy_problem
     @test energy_problem.solved
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Edit: The old text is below the separator.

This PR stores the solution to the problem inside the graph structure.
It also saves the objective value inside the energy problem structure.

---

@datejada, this PR became too long, but splitting will take some time, and explaining in the parts will be hard. So I will explain it here, while I think of how to split this, ok?

This PR makes the structure EnergyProblem hold many things necessary to make it the center of attention. It still keeps the EnergyModel creation and solving separated with different functions. The benefits are not clear, since it depends if anyone will want to use these at all without the EnergyModel. Let me know if it is better to remove it.
Originally, it was meant to be #268, which involves changing the assets and flows structures, but they are inside the EnergyProblem, so it is harder to do it nicely.
More details below:

1. The solution values were moved to the asset and flow structures.
2. The `constraints_partitions` variable was a bit of lost, so moving it to the energy_problem makes sense. However, it is one of the few things that make energy_problem unavoidable.
3. Renamed `create_energy_model...` to `create_energy_problem...`.
4. Moved the `model` structure to EnergyProblem. Also created helper variables inside it: `solved`, `objective_value`, and `termination_status`.
5. Create `create_model!(energy_problem)` that calls `create_model` with the internal values of the energy problem and creates the internal model of energy_problem.
6. Create `solve_model!(energy_problem)` that calls `solve_model` with the interval model of the energy problem and solves it, and then updates the solution values.
7. Return a `solution` NamedTuple from `solve_model` with all variable values.
8. Change the parameters of the `save_solution_to_file` function to be only the `graph`, since the solution is in there. Also creates a version with the energy problem as input.

## List of related issues or pull requests

Closes #268

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
