### PR TITLE
Allow user to decide whether to use EnergyModel or not

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -1,12 +1,28 @@
 export create_energy_problem_from_csv_folder,
-    create_graph, save_solution_to_file, compute_assets_partitions!, compute_flows_partitions!
+    create_graph_and_representative_periods_from_csv_folder,
+    create_graph,
+    save_solution_to_file,
+    compute_assets_partitions!,
+    compute_flows_partitions!
 
 """
     energy_problem = create_energy_problem_from_csv_folder(input_folder)
 
 Returns the [`TulipaEnergyModel.EnergyProblem`](@ref) reading all data from CSV files
 in the `input_folder`.
+This is a wrapper around `create_graph_and_representative_periods_from_csv_folder` that creates
+the `EnergyProblem` structure.
+"""
+function create_energy_problem_from_csv_folder(input_folder::AbstractString)
+    graph, representative_periods =
+        create_graph_and_representative_periods_from_csv_folder(input_folder)
+    return EnergyProblem(graph, representative_periods)
+end
 
+"""
+    graph, representative_periods = create_graph_and_representative_periods_from_csv_folder(input_folder)
+
+Returns the `graph` structure that holds all data, and the `representative_periods` array.
 The following files are expected to exist in the input folder:
 
   - `assets-data.csv`: Following the [`TulipaEnergyModel.AssetData`](@ref) specification.
@@ -17,7 +33,7 @@ The following files are expected to exist in the input folder:
   - `flows-paritions.csv`: Following the [`TulipaEnergyModel.FlowPartitionData`](@ref) specification.
   - `rep-periods-data.csv`: Following the [`TulipaEnergyModel.RepPeriodData`](@ref) specification.
 
-The `energy_problem` contains:
+The returned structures are:
 
   - `graph`: a MetaGraph with the following information:
 
@@ -29,7 +45,7 @@ The `energy_problem` contains:
   - `representative_periods`: An array of
     [`TulipaEnergyModel.RepresentativePeriod`](@ref) ordered by their IDs.
 """
-function create_energy_problem_from_csv_folder(input_folder::AbstractString)
+function create_graph_and_representative_periods_from_csv_folder(input_folder::AbstractString)
     # Read data
     fillpath(filename) = joinpath(input_folder, filename)
 
@@ -119,7 +135,7 @@ function create_energy_problem_from_csv_folder(input_folder::AbstractString)
         graph[u, v].profiles[rp_id] = profile_data
     end
 
-    return EnergyProblem(graph, representative_periods)
+    return graph, representative_periods
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -287,9 +287,10 @@ function create_model(
 end
 
 """
-    solve_model!(energy_problem)
+    solution = solve_model!(energy_problem)
 
-Solve the internal model of an energy_problem.
+Solve the internal model of an energy_problem. The solution obtained by calling
+[`solve_model`](@ref) is returned.
 """
 function solve_model!(energy_problem::EnergyProblem)
     model = energy_problem.model
@@ -327,13 +328,45 @@ function solve_model!(energy_problem::EnergyProblem)
         end
     end
 
-    return energy_problem
+    return solution
 end
 
 """
     solution = solve_model(model)
 
 Solve the JuMP model and return the solution.
+
+The `solution` object is a NamedTuple with the following fields:
+
+  - `objective_value`: A Float64 with the objective value at the solution.
+
+  - `assets_investment[a]`: The investment for each asset, indexed on the investable asset `a`.
+    To create a traditional array in the order given by the investable assets, one can run
+
+    ```
+    [solution.assets_investment[a] for a in labels(graph) if graph[a].investable]
+    ```
+  - `flows_investment[u, v]`: The investment for each flow, indexed on the investable flow `(u, v)`.
+    To create a traditional array in the order given by the investable flows, one can run
+
+    ```
+    [solution.flows_investment[(u, v)] for (u, v) in edge_labels(graph) if graph[u, v].investable]
+    ```
+  - `flow[(u, v), rp, B]`: The flow value for a given flow `(u, v)` at a given representative period
+    `rp`, and time block `B`. The list of time blocks is defined by `graph[(u, v)].partitions[rp]`.
+    To create a vector with all values of `flow` for a given `(u, v)` and `rp`, one can run
+
+    ```
+    [solution.flow[(u, v), rp, B] for B in graph[u, v].partitions[rp]]
+    ```
+  - `storage_level[a, rp, B]`: The storage level for the storage asset `a` for a representative period `rp`
+    and a time block `B`. The list of time blocks is defined by `constraints_partitions`, which was used
+    to create the model.
+    To create a vector with the all values of `storage_level` for a given `a` and `rp`, one can run
+
+    ```
+    [solution.storage_level[a, rp, B] for B in constraints_partitions[(a, rp)]]
+    ```
 """
 function solve_model(model::JuMP.Model)
     # Solve model

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -7,7 +7,6 @@ export run_scenario
 Run the scenario in the given input_folder and return the sets, parameters, and solution.
 If the output_folder is specified, save the sets, parameters, and solution to the output_folder.
 """
-
 function run_scenario(input_folder::AbstractString; write_lp_file = false)
     energy_problem = create_energy_problem_from_csv_folder(input_folder)
     create_model!(energy_problem; write_lp_file = write_lp_file)

--- a/test/test-model.jl
+++ b/test/test-model.jl
@@ -1,9 +1,9 @@
-@testset "Test that solve_model! throws if model is not created" begin
+@testset "Test that solve_model! throws if model is not created but works otherwise" begin
     energy_problem = create_energy_problem_from_csv_folder(joinpath(INPUT_FOLDER, "Tiny"))
     @test_throws Exception solve_model!(energy_problem)
     @test !energy_problem.solved
     create_model!(energy_problem)
     @test !energy_problem.solved
-    @test solve_model!(energy_problem) === energy_problem
+    solution = solve_model!(energy_problem)
     @test energy_problem.solved
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Allow creating the graph and representative_periods without creating an EnergyProblem.
Return a solution from `solve_model!` so the solution object is not lost.
These changes mean that the user can follow the pipeline with or without the EnergyProblem.

## List of related issues or pull requests

Closes #293 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
