### PR TITLE
Precompute summation indices for the model expressions

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -56,10 +56,10 @@ function create_model(graph, representative_periods, constraints_partitions; wri
     end
 
     ## Sets unpacking
-    A = labels(graph)
-    F = edge_labels(graph)
-    filter_assets(key, value) = Iterators.filter(a -> getfield(graph[a], key) == value, A)
-    filter_flows(key, value) = Iterators.filter(f -> getfield(graph[f...], key) == value, F)
+    A = labels(graph) |> collect
+    F = edge_labels(graph) |> collect
+    filter_assets(key, value) = filter(a -> getfield(graph[a], key) == value, A)
+    filter_flows(key, value) = filter(f -> getfield(graph[f...], key) == value, F)
 
     Ac = filter_assets(:type, "consumer")
     Ap = filter_assets(:type, "producer")

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -140,6 +140,35 @@ function create_model(graph, representative_periods, constraints_partitions; wri
         end
     end
 
+    function add_to_flow!(flow_sum_indices, a, rp, P, f)
+        search_start_index = 1
+        flow_partitions = graph[f...].partitions[rp]
+        num_flow_partitions = length(flow_partitions)
+        for B ∈ P
+            # Update search_start_index
+            while last(flow_partitions[search_start_index]) < first(B)
+                search_start_index += 1
+                if search_start_index > num_flow_partitions
+                    break
+                end
+            end
+            if search_start_index > num_flow_partitions
+                break
+            end
+            last_B = last(B)
+            for j = search_start_index:num_flow_partitions
+                B_flow = flow_partitions[j]
+                d = duration(B, B_flow, rp)
+                if d != 0
+                    push!(flow_sum_indices[a, rp, B], (d, f, B_flow))
+                end
+                if first(B_flow) > last_B
+                    break
+                end
+            end
+        end
+    end
+
     flow_sum_indices_incoming_lowest =
         Dict{TupleAssetRPTimeBlock,Vector{TupleDurationFlowTimeBlock}}()
     flow_sum_indices_outgoing_lowest =
@@ -152,48 +181,20 @@ function create_model(graph, representative_periods, constraints_partitions; wri
         for B ∈ Pl[(a, rp)]
             flow_sum_indices_incoming_lowest[a, rp, B] = TupleDurationFlowTimeBlock[]
             flow_sum_indices_outgoing_lowest[a, rp, B] = TupleDurationFlowTimeBlock[]
-            for u ∈ inneighbor_labels(graph, a)
-                add_to_flow_sum_indices!(
-                    flow_sum_indices_incoming_lowest[a, rp, B],
-                    a,
-                    rp,
-                    B,
-                    (u, a),
-                )
-            end
-
-            for v ∈ outneighbor_labels(graph, a)
-                add_to_flow_sum_indices!(
-                    flow_sum_indices_outgoing_lowest[a, rp, B],
-                    a,
-                    rp,
-                    B,
-                    (a, v),
-                )
-            end
         end
         for B ∈ Ph[(a, rp)]
             flow_sum_indices_incoming_highest[a, rp, B] = TupleDurationFlowTimeBlock[]
             flow_sum_indices_outgoing_highest[a, rp, B] = TupleDurationFlowTimeBlock[]
-            for u ∈ inneighbor_labels(graph, a)
-                add_to_flow_sum_indices!(
-                    flow_sum_indices_incoming_highest[a, rp, B],
-                    a,
-                    rp,
-                    B,
-                    (u, a),
-                )
-            end
+        end
 
-            for v ∈ outneighbor_labels(graph, a)
-                add_to_flow_sum_indices!(
-                    flow_sum_indices_outgoing_highest[a, rp, B],
-                    a,
-                    rp,
-                    B,
-                    (a, v),
-                )
-            end
+        for u ∈ inneighbor_labels(graph, a)
+            add_to_flow!(flow_sum_indices_incoming_lowest, a, rp, Pl[(a, rp)], (u, a))
+            add_to_flow!(flow_sum_indices_incoming_highest, a, rp, Ph[(a, rp)], (u, a))
+        end
+
+        for v ∈ outneighbor_labels(graph, a)
+            add_to_flow!(flow_sum_indices_outgoing_lowest, a, rp, Pl[(a, rp)], (a, v))
+            add_to_flow!(flow_sum_indices_outgoing_highest, a, rp, Ph[(a, rp)], (a, v))
         end
     end
 


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

To avoid using conditionals inside of summations in the expressions, we precompute them.
We also compute the duration.
This speed up the code, but maybe is it readable enough?

## List of related issues or pull requests

Related to #294 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
