### PR TITLE
Use DataFrames to linearize indices

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -26,10 +26,15 @@ const OUTPUT_FOLDER_BM = mktempdir()
 # end
 # constraints_partitions = compute_constraints_partitions(graph, representative_periods)
 
-# SUITE["direct_usage"]["create_model"] = @benchmarkable begin
-#     create_model($graph, $representative_periods, $constraints_partitions)
+# SUITE["direct_usage"]["construct_dataframes"] = @benchmarkable begin
+#     construct_dataframes($graph, $representative_periods, $constraints_partitions)
 # end
-# model = create_model(graph, representative_periods, constraints_partitions)
+# dataframes = construct_dataframes(graph, representative_periods, constraints_partitions)
+#
+# SUITE["direct_usage"]["create_model"] = @benchmarkable begin
+#     create_model($graph, $representative_periods, $dataframes)
+# end
+# model = create_model(graph, representative_periods, dataframes)
 
 # SUITE["direct_usage"]["solve_model"] = @benchmarkable begin
 #     solve_model($model)

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -1,7 +1,152 @@
-export create_model!, create_model
+export create_model!, create_model, construct_dataframes
 
 """
-    create_model!(energy_problem)
+    dataframes = construct_dataframes(
+        graph,
+        representative_periods,
+        constraints_partitions,
+    )
+
+Computes the data frames used to linearize the variables and constraints. These are used
+internally in the model only.
+"""
+function construct_dataframes(graph, representative_periods, constraints_partitions)
+    A = labels(graph) |> collect
+    F = edge_labels(graph) |> collect
+    RP = 1:length(representative_periods)
+    Pl = constraints_partitions[:lowest_resolution]
+    Ph = constraints_partitions[:highest_resolution]
+
+    df_flows = DataFrame(
+        (
+            (
+                (from = u, to = v, rp = rp, time_block = B, efficiency = graph[u, v].efficiency) for B ∈ graph[u, v].partitions[rp]
+            ) for (u, v) ∈ F, rp ∈ RP
+        ) |> Iterators.flatten,
+    )
+    df_flows.index = 1:size(df_flows, 1)
+
+    # This construction should ensure the ordering of the time blocks for groups of (a, rp)
+    df_constraints_lowest = DataFrame(
+        (((asset = a, rp = rp, time_block = B) for B ∈ Pl[(a, rp)]) for a ∈ A, rp ∈ RP) |>
+        Iterators.flatten,
+    )
+    df_constraints_lowest.index = 1:size(df_constraints_lowest, 1)
+
+    df_constraints_highest = DataFrame(
+        (((asset = a, rp = rp, time_block = B) for B ∈ Ph[(a, rp)]) for a ∈ A, rp ∈ RP) |>
+        Iterators.flatten,
+    )
+    df_constraints_highest.index = 1:size(df_constraints_highest, 1)
+
+    df_storage_level = rename(
+        filter(row -> graph[row.asset].type == "storage", df_constraints_lowest),
+        :index => :cons_index,
+    )
+    df_storage_level.index = 1:size(df_storage_level, 1)
+
+    return Dict(
+        :flows => df_flows,
+        :cons_lowest => df_constraints_lowest,
+        :cons_highest => df_constraints_highest,
+        :storage_level => df_storage_level,
+    )
+end
+
+"""
+    add_expression_terms!(df_cons, df_flows, workspace, representative_periods; add_efficiency)
+
+Computes the incoming and outgoing expressions per row of df_cons. This function
+is only used internally in the model.
+
+This strategy is based on the replies in this discourse thread:
+
+  - https://discourse.julialang.org/t/help-improving-the-speed-of-a-dataframes-operation/107615/23
+"""
+function add_expression_terms!(
+    df_cons,
+    df_flows,
+    workspace,
+    representative_periods;
+    add_efficiency = true,
+)
+    if add_efficiency
+        df_cons[!, :incoming_w_efficiency_term] .= AffExpr(0.0)
+        df_cons[!, :outgoing_w_efficiency_term] .= AffExpr(0.0)
+    else
+        df_cons[!, :incoming_term] .= AffExpr(0.0)
+        df_cons[!, :outgoing_term] .= AffExpr(0.0)
+    end
+
+    grouped_cons = groupby(df_cons, [:rp, :asset])
+
+    # Incoming flows
+    grouped_flows = groupby(df_flows, [:rp, :to])
+    for ((rp, to), sub_df) in pairs(grouped_cons)
+        if !haskey(grouped_flows, (; rp, to))
+            continue
+        end
+        resolution = representative_periods[rp].resolution
+        for i in eachindex(workspace)
+            workspace[i] = AffExpr(0.0)
+        end
+        # Store the corresponding flow in the workspace
+        for row in eachrow(grouped_flows[(; rp, to)])
+            for t ∈ row.time_block
+                if row.efficiency != 0 || !add_efficiency
+                    add_to_expression!(
+                        workspace[t],
+                        row.flow,
+                        (resolution * (add_efficiency ? row.efficiency : 1.0)),
+                    )
+                end
+            end
+        end
+        # Sum the corresponding flows from the workspace
+        for row in eachrow(sub_df)
+            if add_efficiency
+                row.incoming_w_efficiency_term = sum(@view workspace[row.time_block])
+            else
+                row.incoming_term = sum(@view workspace[row.time_block])
+            end
+        end
+    end
+
+    # Outgoing flows
+    grouped_flows = groupby(df_flows, [:rp, :from])
+    for ((rp, from), sub_df) in pairs(grouped_cons)
+        if !haskey(grouped_flows, (; rp, from))
+            continue
+        end
+        resolution = representative_periods[rp].resolution
+        for i in eachindex(workspace)
+            workspace[i] = AffExpr(0.0)
+        end
+        # Store the corresponding flow in the workspace
+        for row in eachrow(grouped_flows[(; rp, from)])
+            for t ∈ row.time_block
+                if row.efficiency != 0 || !add_efficiency
+                    add_to_expression!(
+                        workspace[t],
+                        row.flow,
+                        (resolution / (add_efficiency ? row.efficiency : 1.0)),
+                    )
+                end
+            end
+        end
+        # Sum the corresponding flows from the workspace
+        for row in eachrow(sub_df)
+            if add_efficiency
+                row.outgoing_w_efficiency_term = sum(@view workspace[row.time_block])
+            else
+                row.outgoing_term = sum(@view workspace[row.time_block])
+            end
+        end
+    end
+end
+
+"""
+    create_model!(energy_problem; verbose = false)
 
 Create the internal model of an [`TulipaEnergyModel.EnergyProblem`](@ref).
 """
@@ -9,26 +154,23 @@ function create_model!(energy_problem; kwargs...)
     graph = energy_problem.graph
     representative_periods = energy_problem.representative_periods
     constraints_partitions = energy_problem.constraints_partitions
+    energy_problem.dataframes =
+        construct_dataframes(graph, representative_periods, constraints_partitions)
     energy_problem.model =
-        create_model(graph, representative_periods, constraints_partitions; kwargs...)
+        create_model(graph, representative_periods, energy_problem.dataframes; kwargs...)
     return energy_problem
 end
 
 """
-    model = create_model(graph, representative_periods, constraints_partitions)
+    model = create_model(graph, representative_periods, dataframes)
 
-Create the energy model given the graph, representative_periods, and constraints_partitions.
+Create the energy model given the graph, representative_periods, and dictionary of dataframes (created by [`construct_dataframes`](@ref)).
 """
-function create_model(graph, representative_periods, constraints_partitions; write_lp_file = false)
+function create_model(graph, representative_periods, dataframes; write_lp_file = false)
 
     ## Helper functions
-    # Computes the duration of the `block` that is within the `period`, and
-    # multiply by the resolution of the representative period `rp`.
-    # It is equivalent to finding the indexes of these values in the matrix.
-    function duration(B1, B2, rp)
-        return length(B1 ∩ B2) * representative_periods[rp].resolution
-    end
-
+    # Computes the duration of the `block` and multiply by the resolution of the
+    # representative period `rp`.
     function duration(B, rp)
         return length(B) * representative_periods[rp].resolution
     end
@@ -53,10 +195,10 @@ function create_model(graph, representative_periods, constraints_partitions; wri
     end
 
     ## Sets unpacking
-    A = labels(graph)
-    F = edge_labels(graph)
-    filter_assets(key, value) = Iterators.filter(a -> getfield(graph[a], key) == value, A)
-    filter_flows(key, value) = Iterators.filter(f -> getfield(graph[f...], key) == value, F)
+    A = labels(graph) |> collect
+    F = edge_labels(graph) |> collect
+    filter_assets(key, value) = filter(a -> getfield(graph[a], key) == value, A)
+    filter_flows(key, value) = filter(f -> getfield(graph[f...], key) == value, F)
 
     Ac = filter_assets(:type, "consumer")
     Ap = filter_assets(:type, "producer")
@@ -66,18 +208,36 @@ function create_model(graph, representative_periods, constraints_partitions; wri
     Acv = filter_assets(:type, "conversion")
     Fi = filter_flows(:investable, true)
     Ft = filter_flows(:is_transport, true)
-    RP = 1:length(representative_periods)
-    Pl = constraints_partitions[:lowest_resolution]
-    Ph = constraints_partitions[:highest_resolution]
+
+    Tmax = maximum(last(rp.time_steps) for rp in representative_periods)
+    expression_workspace = Vector{AffExpr}(undef, Tmax)
+
+    # Unpacking dataframes
+    df_flows = dataframes[:flows]
+    df_constraints_lowest = dataframes[:cons_lowest]
+    df_constraints_highest = dataframes[:cons_highest]
+    df_storage_level = dataframes[:storage_level]
+
+    df_storage_level_grouped = groupby(df_storage_level, [:asset, :rp])
 
     ## Model
     model = Model()
 
     ## Variables
-    @variable(model, flow[(u, v) ∈ F, rp ∈ RP, graph[u, v].partitions[rp]])
-    @variable(model, 0 ≤ assets_investment[Ai])
+    flow =
+        model[:flow] =
+            df_flows.flow = [
+                @variable(
+                    model,
+                    base_name = "flow[($(row.from), $(row.to)), $(row.rp), $(row.time_block)]"
+                ) for row in eachrow(df_flows)
+            ]
+    @variable(model, 0 ≤ assets_investment[Ai])  #number of installed asset units [N]
     @variable(model, 0 ≤ flows_investment[Fi])
-    @variable(model, 0 ≤ storage_level[a ∈ As, rp ∈ RP, Pl[(a, rp)]])
+    storage_level =
+        model[:storage_level] = [
+            @variable(model, base_name = "storage_level[$(row.asset),$(row.rp),$(row.time_block)]") for row in eachrow(df_storage_level)
+        ]
 
     ### Integer Investment Variables
     for a ∈ Ai
@@ -93,6 +253,49 @@ function create_model(graph, representative_periods, constraints_partitions; wri
     end
 
     # TODO: Fix storage_level[As, RP, 0] = 0
+
+    # Creating the incoming and outgoing flow expressions
+    add_expression_terms!(
+        df_constraints_lowest,
+        df_flows,
+        expression_workspace,
+        representative_periods;
+        add_efficiency = false,
+    )
+    add_expression_terms!(
+        df_constraints_lowest,
+        df_flows,
+        expression_workspace,
+        representative_periods;
+        add_efficiency = true,
+    )
+    add_expression_terms!(
+        df_constraints_highest,
+        df_flows,
+        expression_workspace,
+        representative_periods;
+        add_efficiency = false,
+    )
+    incoming_flow_lowest_resolution =
+        model[:incoming_flow_lowest_resolution] = df_constraints_lowest.incoming_term
+    outgoing_flow_lowest_resolution =
+        model[:outgoing_flow_lowest_resolution] = df_constraints_lowest.outgoing_term
+    incoming_flow_lowest_resolution_w_efficiency =
+        model[:incoming_flow_lowest_resolution_w_efficiency] =
+            df_constraints_lowest.incoming_w_efficiency_term
+    outgoing_flow_lowest_resolution_w_efficiency =
+        model[:outgoing_flow_lowest_resolution_w_efficiency] =
+            df_constraints_lowest.outgoing_w_efficiency_term
+    incoming_flow_highest_resolution =
+        model[:incoming_flow_highest_resolution] = df_constraints_highest.incoming_term
+    outgoing_flow_highest_resolution =
+        model[:outgoing_flow_highest_resolution] = df_constraints_highest.outgoing_term
+    drop_zeros!.(incoming_flow_lowest_resolution)
+    drop_zeros!.(outgoing_flow_lowest_resolution)
+    drop_zeros!.(incoming_flow_lowest_resolution_w_efficiency)
+    drop_zeros!.(outgoing_flow_lowest_resolution_w_efficiency)
+    drop_zeros!.(incoming_flow_highest_resolution)
+    drop_zeros!.(outgoing_flow_highest_resolution)
 
     ## Expressions for the objective function
     assets_investment_cost = @expression(
@@ -111,56 +314,15 @@ function create_model(graph, representative_periods, constraints_partitions; wri
     flows_variable_cost = @expression(
         model,
         sum(
-            representative_periods[rp].weight *
-            duration(B_flow, rp) *
-            graph[u, v].variable_cost *
-            flow[(u, v), rp, B_flow] for (u, v) ∈ F, rp ∈ RP,
-            B_flow ∈ graph[u, v].partitions[rp]
+            representative_periods[row.rp].weight *
+            duration(row.time_block, row.rp) *
+            graph[row.from, row.to].variable_cost *
+            row.flow for row in eachrow(df_flows)
         )
     )
 
     ## Objective function
     @objective(model, Min, assets_investment_cost + flows_investment_cost + flows_variable_cost)
-
-    ## Expressions for balance constraints
-    @expression(
-        model,
-        incoming_flow_lowest_resolution[a ∈ A, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        sum(
-            duration(B, B_flow, rp) * flow[(u, a), rp, B_flow] for
-            u in inneighbor_labels(graph, a), B_flow ∈ graph[u, a].partitions[rp] if
-            B_flow[end] ≥ B[1] && B[end] ≥ B_flow[1]
-        )
-    )
-
-    @expression(
-        model,
-        outgoing_flow_lowest_resolution[a ∈ A, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        sum(
-            duration(B, B_flow, rp) * flow[(a, v), rp, B_flow] for
-            v in outneighbor_labels(graph, a), B_flow ∈ graph[a, v].partitions[rp] if
-            B_flow[end] ≥ B[1] && B[end] ≥ B_flow[1]
-        )
-    )
-
-    @expression(
-        model,
-        incoming_flow_lowest_resolution_w_efficiency[a ∈ A, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        sum(
-            duration(B, B_flow, rp) * flow[(u, a), rp, B_flow] * graph[u, a].efficiency for
-            u in inneighbor_labels(graph, a), B_flow ∈ graph[u, a].partitions[rp] if
-            B_flow[end] ≥ B[1] && B[end] ≥ B_flow[1]
-        )
-    )
-    @expression(
-        model,
-        outgoing_flow_lowest_resolution_w_efficiency[a ∈ A, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        sum(
-            duration(B, B_flow, rp) * flow[(a, v), rp, B_flow] / graph[a, v].efficiency for
-            v in outneighbor_labels(graph, a), B_flow ∈ graph[a, v].partitions[rp] if
-            B_flow[end] ≥ B[1] && B[end] ≥ B_flow[1]
-        )
-    )
 
     @expression(
         model,
@@ -168,155 +330,199 @@ function create_model(graph, representative_periods, constraints_partitions; wri
         graph[a].energy_to_power_ratio * graph[a].capacity * assets_investment[a]
     )
 
-    @expression(
-        model,
-        storage_inflows[a ∈ As, rp ∈ RP, T ∈ Pl[(a, rp)]],
-        assets_profile_sum(a, rp, T, 0.0) *
-        (graph[a].initial_storage_capacity + (a ∈ Ai ? energy_limit[a] : 0.0))
-    )
-
     ## Balance constraints (using the lowest resolution)
     # - consumer balance equation
-    @constraint(
-        model,
-        consumer_balance[a ∈ Ac, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        incoming_flow_lowest_resolution[(a, rp, B)] - outgoing_flow_lowest_resolution[(a, rp, B)] ==
-        assets_profile_sum(a, rp, B, 1.0) * graph[a].peak_demand
-    )
+    df = filter(row -> row.asset ∈ Ac, df_constraints_lowest; view = true)
+    model[:consumer_balance] = [
+        @constraint(
+            model,
+            incoming_flow_lowest_resolution[row.index] -
+            outgoing_flow_lowest_resolution[row.index] ==
+            assets_profile_sum(row.asset, row.rp, row.time_block, 1.0) *
+            graph[row.asset].peak_demand,
+            base_name = "consumer_balance[$(row.asset),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df)
+    ]
 
     # - storage balance equation
-    @constraint(
-        model,
-        storage_balance[a ∈ As, rp ∈ RP, (k, B) ∈ enumerate(Pl[(a, rp)])],
-        storage_level[a, rp, B] ==
-        (
-            if k > 1
-                storage_level[a, rp, Pl[(a, rp)][k-1]]
-            else
+    for ((a, rp), sub_df) ∈ pairs(df_storage_level_grouped)
+        # This assumes an ordering of the time blocks, that is guaranteed inside
+        # construct_dataframes
+        # The storage_inflows have been moved here
+        model[Symbol("storage_balance_$(a)_$(rp)")] = [
+            @constraint(
+                model,
+                storage_level[row.index] ==
                 (
-                    if ismissing(graph[a].initial_storage_level)
-                        storage_level[a, rp, Pl[(a, rp)][end]]
+                    if k > 1
+                        storage_level[row.index-1]
                     else
-                        graph[a].initial_storage_level
+                        (
+                            if ismissing(graph[a].initial_storage_level)
+                                storage_level[last(sub_df.index)]
+                            else
+                                graph[a].initial_storage_level
+                            end
+                        )
                     end
-                )
-            end
-        ) +
-        storage_inflows[a, rp, B] +
-        incoming_flow_lowest_resolution_w_efficiency[(a, rp, B)] -
-        outgoing_flow_lowest_resolution_w_efficiency[(a, rp, B)]
-    )
+                ) +
+                assets_profile_sum(a, rp, row.time_block, 0.0) * (
+                    graph[a].initial_storage_capacity +
+                    (row.asset ∈ Ai ? energy_limit[row.asset] : 0.0)
+                ) +
+                incoming_flow_lowest_resolution_w_efficiency[row.cons_index] -
+                outgoing_flow_lowest_resolution_w_efficiency[row.cons_index],
+                base_name = "storage_balance[$a,$rp,$(row.time_block)]"
+            ) for (k, row) ∈ enumerate(eachrow(sub_df))
+        ]
+    end
 
     # - hub balance equation
-    @constraint(
-        model,
-        hub_balance[a ∈ Ah, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        incoming_flow_lowest_resolution[(a, rp, B)] == outgoing_flow_lowest_resolution[(a, rp, B)]
-    )
+    df = filter(row -> row.asset ∈ Ah, df_constraints_lowest; view = true)
+    model[:hub_balance] = [
+        @constraint(
+            model,
+            incoming_flow_lowest_resolution[row.index] ==
+            outgoing_flow_lowest_resolution[row.index],
+            base_name = "hub_balance[$(row.asset),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df)
+    ]
 
     # - conversion balance equation
-    @constraint(
-        model,
-        conversion_balance[a ∈ Acv, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        incoming_flow_lowest_resolution_w_efficiency[(a, rp, B)] ==
-        outgoing_flow_lowest_resolution_w_efficiency[(a, rp, B)]
-    )
+    df = filter(row -> row.asset ∈ Acv, df_constraints_lowest; view = true)
+    model[:conversion_balance] = [
+        @constraint(
+            model,
+            incoming_flow_lowest_resolution_w_efficiency[row.index] ==
+            outgoing_flow_lowest_resolution_w_efficiency[row.index],
+            base_name = "conversion_balance[$(row.asset),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df)
+    ]
 
-    ## Expression for capacity limit constraints
-    @expression(
-        model,
-        incoming_flow_highest_resolution[a ∈ A, rp ∈ RP, B ∈ Ph[(a, rp)]],
-        sum(
-            duration(B, B_flow, rp) * flow[(u, a), rp, B_flow] for
-            u in inneighbor_labels(graph, a), B_flow ∈ graph[u, a].partitions[rp] if
-            B_flow[end] ≥ B[1] && B[end] ≥ B_flow[1]
-        )
-    )
-
-    @expression(
-        model,
-        outgoing_flow_highest_resolution[a ∈ A, rp ∈ RP, B ∈ Ph[(a, rp)]],
-        sum(
-            duration(B, B_flow, rp) * flow[(a, v), rp, B_flow] for
-            v in outneighbor_labels(graph, a), B_flow ∈ graph[a, v].partitions[rp] if
-            B_flow[end] ≥ B[1] && B[end] ≥ B_flow[1]
-        )
-    )
-
-    @expression(
-        model,
-        assets_profile_times_capacity[a ∈ A, rp ∈ RP, B ∈ Ph[(a, rp)]],
-        assets_profile_sum(a, rp, B, 1.0) *
-        (graph[a].initial_capacity + (a ∈ Ai ? (graph[a].capacity * assets_investment[a]) : 0.0))
-    )
+    assets_profile_times_capacity =
+        model[:assets_profile_times_capacity] = [
+            if row.asset ∈ Ai
+                @expression(
+                    model,
+                    assets_profile_sum(row.asset, row.rp, row.time_block, 1.0) * (
+                        graph[row.asset].initial_capacity +
+                        graph[row.asset].capacity * assets_investment[row.asset]
+                    )
+                )
+            else
+                @expression(
+                    model,
+                    assets_profile_sum(row.asset, row.rp, row.time_block, 1.0) *
+                    graph[row.asset].initial_capacity
+                )
+            end for row in eachrow(df_constraints_highest)
+        ]
 
     ## Capacity limit constraints (using the highest resolution)
     # - maximum output flows limit
-    @constraint(
-        model,
-        max_output_flows_limit[a ∈ Acv∪As∪Ap, rp ∈ RP, B ∈ Ph[(a, rp)]],
-        outgoing_flow_highest_resolution[(a, rp, B)] ≤ assets_profile_times_capacity[a, rp, B]
+    df = filter(
+        row -> row.asset ∈ Acv || row.asset ∈ As || row.asset ∈ Ap,
+        df_constraints_highest;
+        view = true,
     )
+    model[:max_output_flows_limit] = [
+        @constraint(
+            model,
+            outgoing_flow_highest_resolution[row.index] ≤ assets_profile_times_capacity[row.index],
+            base_name = "max_output_flows_limit[$(row.asset),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df) if outgoing_flow_highest_resolution[row.index] != 0
+    ]
 
     # - maximum input flows limit
-    @constraint(
-        model,
-        max_input_flows_limit[a ∈ As, rp ∈ RP, B ∈ Ph[(a, rp)]],
-        incoming_flow_highest_resolution[(a, rp, B)] ≤ assets_profile_times_capacity[a, rp, B]
-    )
+    df = filter(row -> row.asset ∈ As, df_constraints_highest; view = true)
+    model[:max_input_flows_limit] = [
+        @constraint(
+            model,
+            incoming_flow_highest_resolution[row.index] ≤ assets_profile_times_capacity[row.index],
+            base_name = "max_input_flows_limit[$(row.asset),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df)
+    ]
 
     # - define lower bounds for flows that are not transport assets
-    for f ∈ F, rp ∈ RP, B_flow ∈ graph[f...].partitions[rp]
-        if f ∉ Ft
-            set_lower_bound(flow[f, rp, B_flow], 0.0)
+    for row in eachrow(df_flows)
+        if !graph[row.from, row.to].is_transport
+            set_lower_bound(flow[row.index], 0.0)
         end
     end
 
     ## Expressions for transport flow constraints
-    @expression(
-        model,
-        upper_bound_transport_flow[(u, v) ∈ F, rp ∈ RP, B_flow ∈ graph[u, v].partitions[rp]],
-        flows_profile_sum(u, v, rp, B_flow, 1.0) * (
-            graph[u, v].initial_export_capacity +
-            (graph[u, v].investable ? graph[u, v].capacity * flows_investment[(u, v)] : 0.0)
-        )
-    )
+    upper_bound_transport_flow = [
+        if graph[row.from, row.to].investable
+            @expression(
+                model,
+                flows_profile_sum(row.from, row.to, row.rp, row.time_block, 1.0) * (
+                    graph[row.from, row.to].initial_export_capacity +
+                    graph[row.from, row.to].capacity * flows_investment[(row.from, row.to)]
+                )
+            )
+        else
+            @expression(
+                model,
+                flows_profile_sum(row.from, row.to, row.rp, row.time_block, 1.0) *
+                graph[row.from, row.to].initial_export_capacity
+            )
+        end for row in eachrow(df_flows)
+    ]
 
-    @expression(
-        model,
-        lower_bound_transport_flow[(u, v) ∈ F, rp ∈ RP, B_flow ∈ graph[u, v].partitions[rp]],
-        flows_profile_sum(u, v, rp, B_flow, 1.0) * (
-            graph[u, v].initial_import_capacity +
-            (graph[u, v].investable ? graph[u, v].capacity * flows_investment[(u, v)] : 0.0)
-        )
-    )
+    lower_bound_transport_flow = [
+        if graph[row.from, row.to].investable
+            @expression(
+                model,
+                flows_profile_sum(row.from, row.to, row.rp, row.time_block, 1.0) * (
+                    graph[row.from, row.to].initial_import_capacity +
+                    graph[row.from, row.to].capacity * flows_investment[(row.from, row.to)]
+                )
+            )
+        else
+            @expression(
+                model,
+                flows_profile_sum(row.from, row.to, row.rp, row.time_block, 1.0) *
+                graph[row.from, row.to].initial_import_capacity
+            )
+        end for row in eachrow(df_flows)
+    ]
 
     ## Constraints that define bounds for a transport flow Ft
-    @constraint(
-        model,
-        max_transport_flow_limit[f ∈ Ft, rp ∈ RP, B_flow ∈ graph[f...].partitions[rp]],
-        duration(B_flow, rp) * flow[f, rp, B_flow] ≤ upper_bound_transport_flow[f, rp, B_flow]
-    )
+    df = filter(row -> (row.from, row.to) ∈ Ft, df_flows)
+    model[:max_transport_flow_limit] = [
+        @constraint(
+            model,
+            duration(row.time_block, row.rp) * flow[row.index] ≤
+            upper_bound_transport_flow[row.index],
+            base_name = "max_transport_flow_limit[($(row.from),$(row.to)),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df)
+    ]
 
-    @constraint(
-        model,
-        min_transport_flow_limit[f ∈ Ft, rp ∈ RP, B_flow ∈ graph[f...].partitions[rp]],
-        duration(B_flow, rp) * flow[f, rp, B_flow] ≥ -lower_bound_transport_flow[f, rp, B_flow]
-    )
+    model[:min_transport_flow_limit] = [
+        @constraint(
+            model,
+            duration(row.time_block, row.rp) * flow[row.index] ≥
+            -lower_bound_transport_flow[row.index],
+            base_name = "min_transport_flow_limit[($(row.from),$(row.to)),$(row.rp),$(row.time_block)]"
+        ) for row in eachrow(df)
+    ]
 
     ## Extra constraints for storage assets
     # - maximum storage level limit
-    @constraint(
-        model,
-        max_storage_level_limit[a ∈ As, rp ∈ RP, B ∈ Pl[(a, rp)]],
-        storage_level[a, rp, B] ≤
-        graph[a].initial_storage_capacity + (a ∈ Ai ? energy_limit[a] : 0.0)
-    )
+    model[:max_storage_level_limit] = [
+        @constraint(
+            model,
+            storage_level[row.index] ≤
+            graph[row.asset].initial_storage_capacity +
+            (row.asset ∈ Ai ? energy_limit[row.asset] : 0.0)
+        ) for row ∈ eachrow(df_storage_level)
+    ]
 
     # - cycling condition for storage level
-    for a ∈ As, rp ∈ RP
+    for ((a, _), sub_df) ∈ pairs(df_storage_level_grouped)
+        # Again, ordering is assume
         if !ismissing(graph[a].initial_storage_level)
-            set_lower_bound(storage_level[a, rp, Pl[(a, rp)][end]], graph[a].initial_storage_level)
+            set_lower_bound(storage_level[last(sub_df.index)], graph[a].initial_storage_level)
         end
     end
 

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -134,6 +134,7 @@ mutable struct EnergyProblem
     }
     representative_periods::Vector{RepresentativePeriod}
     constraints_partitions::Dict{Symbol,Dict{Tuple{String,Int},Vector{TimeBlock}}}
+    dataframes::Dict{Symbol,DataFrame}
     model::Union{JuMP.Model,Nothing}
     solved::Bool
     objective_value::Float64
@@ -153,6 +154,7 @@ mutable struct EnergyProblem
             graph,
             representative_periods,
             constraints_partitions,
+            Dict(),
             nothing,
             false,
             NaN,

--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -2,9 +2,9 @@
     dir = joinpath(INPUT_FOLDER, "Norse")
     optimizer_list = [HiGHS.Optimizer, Cbc.Optimizer, GLPK.Optimizer]
     parameters_dict = Dict(
-        HiGHS.Optimizer => Dict("mip_rel_gap" => 0.0),
-        Cbc.Optimizer   => Dict("ratioGap" => 0.0),
-        GLPK.Optimizer  => Dict("mip_gap" => 0.0),
+        HiGHS.Optimizer => Dict("mip_rel_gap" => 0.0, "output_flag" => false),
+        Cbc.Optimizer => Dict("ratioGap" => 0.0, "logLevel" => 0),
+        GLPK.Optimizer => Dict("mip_gap" => 0.0, "msg_lev" => 0),
     )
     for optimizer in optimizer_list
         energy_problem =
@@ -14,7 +14,7 @@
             plot_graph(energy_problem)
             plot_assets_capacity(energy_problem)
         end
-        @test energy_problem.objective_value ≈ 1.7913342401746374e8 atol = 1e-5
+        @test energy_problem.objective_value ≈ 1.7913342401e8 rtol = 1e-8
     end
 end
 
@@ -22,15 +22,14 @@ end
     dir = joinpath(INPUT_FOLDER, "Tiny")
     optimizer_list = [HiGHS.Optimizer, Cbc.Optimizer, GLPK.Optimizer]
     for optimizer in optimizer_list
-        energy_problem = run_scenario(
-            dir,
-            OUTPUT_FOLDER;
-            optimizer = optimizer,
-            write_lp_file = true,
-            log_file = "model.log",
-        )
+        energy_problem = run_scenario(dir; optimizer = optimizer)
         @test energy_problem.objective_value ≈ 269238.43825 atol = 1e-5
     end
+end
+
+@testset "Test run_scenario arguments" begin
+    dir = joinpath(INPUT_FOLDER, "Tiny")
+    energy_problem = run_scenario(dir, OUTPUT_FOLDER; write_lp_file = true, log_file = "model.log")
 end
 
 @testset "Tiny Variable Resolution Case Study" begin


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Store the indices of the multi-index variables, constraints and expressions in DataFrames. This allows the definition of these structures with a linear index, which makes it more efficient.

## List of related issues or pull requests

Closes #294
at least for now...

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
