### PR TITLE
Add an extra condition to only include files ending with .jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,11 +13,9 @@ using TulipaEnergyModel
 const INPUT_FOLDER = joinpath(@__DIR__, "inputs")
 const OUTPUT_FOLDER = joinpath(@__DIR__, "outputs")
 
-# Run all files in test folder starting with `test-`
-for file in readdir(@__DIR__)
-    if !startswith("test-")(file)
-        continue
-    end
+# Run all files in test folder starting with `test-` and ending with `.jl`
+test_files = filter(file -> startswith("test-")(file) && endswith(".jl")(file), readdir(@__DIR__))
+for file in test_files
     include(file)
 end
 


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

We now include all files starting with `test-` and ending with `.jl`

## List of related issues or pull requests

Closes #409 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
