### PR TITLE
Add memory table to the benchmark report and test fork benchmark

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
     benchmark:
         # Only runs if the PR originates from the repo itself and if the label 'benchmark' is assigned
-        if: contains(github.event.pull_request.labels.*.name, 'benchmark') && github.event.pull_request.head.repo.full_name == github.repository
+        if: contains(github.event.pull_request.labels.*.name, 'benchmark')
         runs-on: ubuntu-latest
         env:
             BASE: ${{ github.event.pull_request.base.sha }}
@@ -87,6 +87,7 @@ jobs:
               run: |
                   benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} \
                     --rev="$BASE,$HEAD" \
+                    --mode=time,memory \
                     --input-dir=results/ --ratio > table.md
                   echo '### Benchmark Results' > body.md
                   echo '' >> body.md


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Add memory table to the benchmark report, based on AirspeedVelicity.jl release 0.5.0.
Test fork benchmark. This might work and surprise me, or I will have to close this and open a new PR.

## List of related issues or pull requests

Closes #502

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
