### PR TITLE
Add storage level between (intra) representative periods to the outputs

### DIFF
--- a/docs/src/how-to-use.md
+++ b/docs/src/how-to-use.md
@@ -290,6 +290,7 @@ The solution object is a NamedTuple with the following fields:
 - `flows_investment[u, v]`: The investment for each flow, indexed on the investable flow `(u, v)`.
 - `flow[(u, v), rp, B]`: The flow value for a given flow `(u, v)` at a given representative period `rp`, and time block `B`. The list of time blocks is defined by `graph[(u, v)].partitions[rp]`.
 - `storage_level_intra_rp[a, rp, B]`: The storage level for the storage asset `a` within (intra) a representative period `rp` and a time block `B`. The list of time blocks is defined by `constraints_partitions`, which was used to create the model.
+- `storage_level_inter_rp[a, bp]`: The storage level for the storage asset `a` between (inter) representative periods in the base periods `bp`.
 
 For tips on manipulating the solution, check the [tutorial](@ref solution-tutorial).
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -114,7 +114,7 @@ Finally, we can compute the solution.
 solution = solve_model(model)
 ```
 
-or, if we want to store the `flow` and `storage_level_intra_rp` optimal value in the dataframes:
+or, if we want to store the `flow`, `storage_level_intra_rp`, `storage_level_inter_rp` optimal value in the dataframes:
 
 ```@example manual
 solution = solve_model!(dataframes, model)
@@ -280,7 +280,7 @@ To create a traditional array in the order given by the investable flows, one ca
 [solution.flows_investment[(u, v)] for (u, v) in edge_labels(graph) if graph[u, v].investable]
 ```
 
-The `solution.flow` and `solution.storage_level_intra_rp` values are linearized according to the dataframes in the dictionary `energy_problem.dataframes` with keys `:flows` and `:lowest_storage_level_intra_rp`, respectively.
+The `solution.flow`, `solution.storage_level_intra_rp`, and `solution.storage_level_inter_rp` values are linearized according to the dataframes in the dictionary `energy_problem.dataframes` with keys `:flows`, `:lowest_storage_level_intra_rp`, and `:storage_level_inter_rp`, respectively.
 You need to query the data from these dataframes and then use the column `index` to select the appropriate value.
 
 To create a vector with all values of `flow` for a given `(u, v)` and `rp`, one can run
@@ -307,6 +307,18 @@ df = filter(
     view = true,
 )
 [solution.storage_level_intra_rp[row.index] for row in eachrow(df)]
+```
+
+To create a vector with the all values of `storage_level_inter_rp` for a given `a`, one can run
+
+```@example solution
+a = energy_problem.dataframes[:storage_level_inter_rp].asset[1]
+df = filter(
+    row -> row.asset == a,
+    energy_problem.dataframes[:storage_level_inter_rp],
+    view = true,
+)
+[solution.storage_level_inter_rp[row.index] for row in eachrow(df)]
 ```
 
 ### The solution inside the graph
@@ -347,9 +359,21 @@ df = filter(
 [energy_problem.graph[a].storage_level_intra_rp[(rp, row.time_block)] for row in eachrow(df)]
 ```
 
+To create a vector with the all values of `storage_level_inter_rp` for a given `a`, one can run
+
+```@example solution
+a = energy_problem.dataframes[:storage_level_inter_rp].asset[1]
+df = filter(
+    row -> row.asset == a,
+    energy_problem.dataframes[:storage_level_inter_rp],
+    view = true,
+)
+[energy_problem.graph[a].storage_level_inter_rp[row.base_period_block] for row in eachrow(df)]
+```
+
 ### The solution inside the dataframes object
 
-In addition to being stored in the `solution` object, and in the `graph` object, the solution for the `flow` and the `storage_level_intra_rp` is also stored inside the corresponding DataFrame objects if `solve_model!` is called.
+In addition to being stored in the `solution` object, and in the `graph` object, the solution for the `flow`, `storage_level_intra_rp`, and `storage_level_inter_rp` is also stored inside the corresponding DataFrame objects if `solve_model!` is called.
 
 The code below will do the same as in the two previous examples:
 
@@ -370,6 +394,16 @@ rp = 1
 df = filter(
     row -> row.asset == a && row.rp == rp,
     energy_problem.dataframes[:lowest_storage_level_intra_rp],
+    view = true,
+)
+df.solution
+```
+
+```@example solution
+a = energy_problem.dataframes[:storage_level_inter_rp].asset[1]
+df = filter(
+    row -> row.asset == a,
+    energy_problem.dataframes[:storage_level_inter_rp],
     view = true,
 )
 df.solution

--- a/src/io.jl
+++ b/src/io.jl
@@ -310,6 +310,22 @@ function save_solution_to_file(output_folder, graph, dataframes, solution)
     )
     output_table |> CSV.write(output_file)
 
+    output_file = joinpath(output_folder, "storage-level-inter-rp.csv")
+    output_table = select(dataframes[:storage_level_inter_rp], :asset, :base_period_block => :time_step)
+    output_table.value = solution.storage_level_inter_rp
+    output_table = flatten(
+        transform(
+            output_table,
+            [:time_step, :value] =>
+                ByRow((base_period_block, value) -> begin
+                        n = length(base_period_block)
+                        (base_period_block, Iterators.repeated(value / n, n))
+                    end) => [:time_step, :value],
+        ),
+        [:time_step, :value],
+    )
+    output_table |> CSV.write(output_file)
+
     return
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -311,16 +311,19 @@ function save_solution_to_file(output_folder, graph, dataframes, solution)
     output_table |> CSV.write(output_file)
 
     output_file = joinpath(output_folder, "storage-level-inter-rp.csv")
-    output_table = select(dataframes[:storage_level_inter_rp], :asset, :base_period_block => :time_step)
+    output_table =
+        select(dataframes[:storage_level_inter_rp], :asset, :base_period_block => :time_step)
     output_table.value = solution.storage_level_inter_rp
     output_table = flatten(
         transform(
             output_table,
             [:time_step, :value] =>
-                ByRow((base_period_block, value) -> begin
+                ByRow(
+                    (base_period_block, value) -> begin
                         n = length(base_period_block)
                         (base_period_block, Iterators.repeated(value / n, n))
-                    end) => [:time_step, :value],
+                    end,
+                ) => [:time_step, :value],
         ),
         [:time_step, :value],
     )

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -134,7 +134,7 @@ The `solution` object is a NamedTuple with the following fields:
     ```
 - `storage_level_inter_rp[a, bp]`: The storage level for the storage asset `a` for a base period `bp`.
     To create a vector with the all values of `storage_level_inter_rp` for a given `a`, one can run
-    
+
     ```
     [solution.storage_level_inter_rp[a, bp] for bp in 1:base_periods]
     ```

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -43,6 +43,11 @@ function solve_model!(
         graph[a].storage_level_intra_rp[(rp, time_block)] = value
     end
 
+    for row in eachrow(energy_problem.dataframes[:storage_level_inter_rp])
+        a, bp, value = row.asset, row.base_period_block, row.solution
+        graph[a].storage_level_inter_rp[bp] = value
+    end
+
     for (u, v) in edge_labels(graph)
         if graph[u, v].investable
             if graph[u, v].investment_integer
@@ -70,6 +75,7 @@ The modifications made to `dataframes` are:
 
 - `df_flows.solution = solution.flow`
 - `df_storage_level_intra_rp.solution = solution.storage_level_intra_rp`
+- `df_storage_level_inter_rp.solution = solution.storage_level_inter_rp`
 """
 function solve_model!(dataframes, model, args...; kwargs...)
     solution = solve_model(model, args...; kwargs...)
@@ -79,6 +85,7 @@ function solve_model!(dataframes, model, args...; kwargs...)
 
     dataframes[:flows].solution = solution.flow
     dataframes[:lowest_storage_level_intra_rp].solution = solution.storage_level_intra_rp
+    dataframes[:storage_level_inter_rp].solution = solution.storage_level_inter_rp
 
     return solution
 end
@@ -125,6 +132,12 @@ The `solution` object is a NamedTuple with the following fields:
     ```
     [solution.storage_level_intra_rp[a, rp, B] for B in constraints_partitions[:lowest_resolution][(a, rp)]]
     ```
+- `storage_level_inter_rp[a, bp]`: The storage level for the storage asset `a` for a base period `bp`.
+    To create a vector with the all values of `storage_level_inter_rp` for a given `a`, one can run
+    
+    ```
+    [solution.storage_level_inter_rp[a, bp] for bp in 1:base_periods]
+    ```
 
 ## Examples
 
@@ -156,6 +169,7 @@ function solve_model(
         Dict(a => value(model[:assets_investment][a]) for a in model[:assets_investment].axes[1]),
         Dict(uv => value(model[:flows_investment][uv]) for uv in model[:flows_investment].axes[1]),
         value.(model[:storage_level_intra_rp]),
+        value.(model[:storage_level_inter_rp]),
         value.(model[:flow]),
         objective_value(model),
         compute_dual_variables(model),

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -48,6 +48,7 @@ mutable struct GraphAssetData
     # Solution
     investment::Float64
     storage_level_intra_rp::Dict{Tuple{Int,TimeBlock},Float64}
+    storage_level_inter_rp::Dict{TimeBlock,Float64}
 
     # You don't need profiles to create the struct, so initiate it empty
     function GraphAssetData(
@@ -87,6 +88,7 @@ mutable struct GraphAssetData
             partitions,
             -1,
             Dict{Tuple{Int,TimeBlock},Float64}(),
+            Dict{TimeBlock,Float64}(),
         )
     end
 end
@@ -139,6 +141,7 @@ mutable struct Solution
     assets_investment::Dict{String,Float64}
     flows_investment::Dict{Tuple{String,String},Float64}
     storage_level_intra_rp::Vector{Float64}
+    storage_level_inter_rp::Vector{Float64}
     flow::Vector{Float64}
     objective_value::Float64
     duals::Union{Nothing,Dict{Symbol,Vector{Float64}}}


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Add the new variable `storage_level_intra_rp` to the solution and outputs of the model.

## List of related issues or pull requests

Closes #509 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
