### PR TITLE
Make the number of samples explicit in the benchmark

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -70,8 +70,7 @@ jobs:
                     --rev="$BASE,$HEAD" \
                     --url=${{ github.event.repository.clone_url }} \
                     --bench-on="$BASE" \
-                    --output-dir=results/ \
-                    --tune
+                    --output-dir=results/
             - name: Create plots from benchmarks
               run: |
                   mkdir -p plots

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -48,12 +48,12 @@ const OUTPUT_FOLDER_BM = mktempdir()
 SUITE["energy_problem"] = BenchmarkGroup()
 SUITE["energy_problem"]["input_and_constructor"] = @benchmarkable begin
     create_energy_problem_from_csv_folder($INPUT_FOLDER_BM)
-end
+end samples = 3 evals = 1 seconds = Inf
 energy_problem = create_energy_problem_from_csv_folder(INPUT_FOLDER_BM)
 
 SUITE["energy_problem"]["create_model"] = @benchmarkable begin
     create_model!($energy_problem)
-end
+end samples = 3 evals = 1 seconds = Inf
 create_model!(energy_problem)
 
 # SUITE["energy_problem"]["solve_model"] = @benchmarkable begin


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Use `samples = 3 evals =1 seconds = Inf` in the benchmarks, and don't tune.
<!-- include screenshots if that helps the review -->

## List of related issues or pull requests

Closes #534 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
