### PR TITLE
Fix repeated value calculation in save_solution_to_file function for storage level

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -404,7 +404,7 @@ function save_solution_to_file(output_folder, graph, dataframes, solution)
                 DataFrames.ByRow(
                     (time_block, value) -> begin
                         n = length(time_block)
-                        (time_block, Iterators.repeated(value / n, n))
+                        (time_block, Iterators.repeated(value, n))
                     end,
                 ) => [:time_step, :value],
         ),
@@ -426,7 +426,7 @@ function save_solution_to_file(output_folder, graph, dataframes, solution)
                 DataFrames.ByRow(
                     (base_period_block, value) -> begin
                         n = length(base_period_block)
-                        (base_period_block, Iterators.repeated(value / n, n))
+                        (base_period_block, Iterators.repeated(value, n))
                     end,
                 ) => [:time_step, :value],
         ),


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

We now export the storage level repeated as it is within the block instead of dividing by the duration.

## List of related issues or pull requests

Closes #548 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [NA] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
