### PR TITLE
Change Inf to 86400 in the benchmarks.jl script and benchmark on the HEAD script

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -69,7 +69,7 @@ jobs:
                   benchpkg ${{ steps.extract-package-name.outputs.package_name }} \
                     --rev="$BASE,$HEAD" \
                     --url=${{ github.event.repository.clone_url }} \
-                    --bench-on="$BASE" \
+                    --bench-on="$HEAD" \
                     --output-dir=results/
             - name: Create plots from benchmarks
               run: |

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -48,12 +48,12 @@ const OUTPUT_FOLDER_BM = mktempdir()
 SUITE["energy_problem"] = BenchmarkGroup()
 SUITE["energy_problem"]["input_and_constructor"] = @benchmarkable begin
     create_energy_problem_from_csv_folder($INPUT_FOLDER_BM)
-end samples = 3 evals = 1 seconds = Inf
+end samples = 3 evals = 1 seconds = 86400
 energy_problem = create_energy_problem_from_csv_folder(INPUT_FOLDER_BM)
 
 SUITE["energy_problem"]["create_model"] = @benchmarkable begin
     create_model!($energy_problem)
-end samples = 3 evals = 1 seconds = Inf
+end samples = 3 evals = 1 seconds = 86400
 create_model!(energy_problem)
 
 # SUITE["energy_problem"]["solve_model"] = @benchmarkable begin


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

`Inf` is not allowed in the JSON file used internally by AirspeedVelocity.jl. The BenchmarkTools package seems to handle it properly when saving, but AirspeedVelocity bypass that and uses JSON directly.
We explicitly use `Inf` in the benchmarks.jl script, to the simplest tentative solution is to change that to another value.

This PR changes `Inf` to `86400`, which should be enough for any reasonable benchmark that we do.
This PR also changes the `bench-on` parameter to `$HEAD` to indicate that we run the script given in the PR (otherwise we can't test this change before merging).

## List of related issues or pull requests

Closes #588 

## Collaboration confirmation

As a contributor I confirm

-   [ ] I read and followed the instructions in README.dev.md
-   [ ] The documentation is up to date with the changes introduced in this Pull Request (or NA)
-   [ ] Tests are passing
-   [ ] Lint is passing
