### PR TITLE
Remove duplicate "Code format & guidelines" section

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -359,22 +359,6 @@ main branch using "Squash and Merge".
 You can also delete the branch that originated the pull request by clicking the button that appears after the merge.
 For branches that were pushed to the main repo, it is recommended that you do so.
 
-## Code format and guidelines
-
-This section will list the guidelines for code formatting **not enforced** by [JuliaFormatter](.JuliaFormatter.toml).
-We will try to follow these during development and reviews.
-
--   Naming
-    -   `CamelCase` for classes and modules,
-    -   `snake_case` for functions and variables, and
-    -   `kebab-case` for file names.
--   Use `using` instead of `import`, in the following way:
-
-    -   Don't use pure `using Package`, always list all necessary objects with `using Package: A, B, C`.
-    -   List obvious objects, e.g., `using JuMP: @variable`, since `@variable` is obviously from JuMP in this context, or `using Graph: SimpleDiGraph`, because it's a constructor with an obvious name.
-    -   For other objects inside `Package`, use `using Package: Package` and explicitly call `Package.A` to use it, e.g., `DataFrames.groupby`.
-    -   List all `using` in <src/TulipaEnergyModel.jl>.
-
 ## Building the Documentation Locally
 
 To build and view the documentation locally, first, navigate to the `docs` folder


### PR DESCRIPTION
# Pull request details
The Code format & guidelines section appeared twice in the document (probably a mistake from rearranging the structure of the sections a while back) so I removed the extra.

## List of related issues or pull requests

No issue - quick fix

## Collaboration confirmation

As a contributor I confirm

-   [X] I read and followed the instructions in README.dev.md
-   [X] The documentation is up to date with the changes introduced in this Pull Request (or NA)
-   [X] Tests are passing
-   [X] Lint is passing
