### PR TITLE
Create timing dict for EnergyProblem and time constructor

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -368,7 +368,7 @@ function create_model!(energy_problem; kwargs...)
         energy_problem.objective_value = NaN
     end
 
-    energy_problem.time_create_model = elapsed_time_create_model
+    energy_problem.timings["creating the model"] = elapsed_time_create_model
 
     return energy_problem
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -16,12 +16,8 @@ the `EnergyProblem` structure.
 Set `strict = true` to error if assets are missing from partition data.
 """
 function create_energy_problem_from_csv_folder(input_folder::AbstractString; strict = false)
-    elapsed_time_read_data = @elapsed begin
-        connection = create_connection_and_import_from_csv_folder(input_folder)
-        energy_problem = EnergyProblem(connection; strict = strict)
-    end
-    energy_problem.time_read_data = elapsed_time_read_data
-    return energy_problem
+    connection = create_connection_and_import_from_csv_folder(input_folder)
+    return EnergyProblem(connection; strict = strict)
 end
 
 """

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -87,7 +87,7 @@ function solve_model!(
         end
     end
 
-    energy_problem.time_solve_model = elapsed_time_solve_model
+    energy_problem.timings["solving the model"] = elapsed_time_solve_model
 
     return energy_problem.solution
 end


### PR DESCRIPTION
To avoid changing the EnergyProblem structure too much because of timing, we create a timings dictionary.
We time the constructor of EnergyProblem instead of the function that reads the CSV folder. This way we time the functions inside the constructor, which are the expensive functions in the input.
This also allows EnergyProblem constructed directly to have times.

Closes #680 