### PR TITLE
Refactor energy constraints to use sum instead of mean

### DIFF
--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -125,19 +125,21 @@ Due to the flexible resolution, we must explicitly state how the constraints are
 
 Below is the table outlining the details for each type of constraint. Note _min_ means highest resolution, and _max_ means lowest resolution.
 
-| Name                                          | Variables involved             | Parameters involved | Constraint type | Resolution of the constraints                                               | Parameter aggregation |
-| --------------------------------------------- | ------------------------------ | ------------------- | --------------- | --------------------------------------------------------------------------- | --------------------- |
-| Consumer Balance                              | inputs, outputs                | demand              | power           | min(incoming flows, outgoing flows)                                         | mean                  |
-| Storage Balance                               | inputs, outputs, storage level | inflows             | energy          | max(asset, min(incoming flows, outgoing flows))                             | sum                   |
-| Hub Balance                                   | inputs, outputs                | -                   | power           | min(incoming flows, outgoing flows)                                         | -                     |
-| Conversion Balance                            | inputs, outputs                | -                   | energy          | max(incoming flows, outgoing flows)                                         | -                     |
-| Producers Capacity Constraints                | outputs                        | production          | power           | min(outgoing flows)                                                         | mean                  |
-| Storage Capacity Constraints (outgoing)       | outputs                        | -                   | power           | min(outgoing flows)                                                         | -                     |
-| Conversion Capacity Constraints (outgoing)    | outputs                        | -                   | power           | min(outgoing flows)                                                         | -                     |
-| Conversion Capacity Constraints (incoming)    | inputs                         | -                   | power           | min(incoming flows)                                                         | -                     |
-| Storage Capacity Constraints (incoming)       | inputs                         | -                   | power           | min(incoming flows)                                                         | -                     |
-| Transport Capacity Constraints (upper bounds) | flow                           | capacity            | power           | if it connects two hubs or demands then max(hub a,hub b), otherwise its own | mean                  |
-| Transport Capacity Constraints (lower bounds) | flow                           | capacity            | power           | if it connects two hubs or demands then max(hub a,hub b), otherwise its own | mean                  |
+| Name                                          | Variables involved             | Profile involved | Constraint type | Resolution of the constraints                                                            | Profile aggregation |
+| --------------------------------------------- | ------------------------------ | ---------------- | --------------- | ---------------------------------------------------------------------------------------- | ------------------- |
+| Consumer Balance                              | inputs, outputs                | demand           | power           | min(incoming flows, outgoing flows)                                                      | mean                |
+| Storage Balance                               | inputs, outputs, storage level | inflows          | energy          | max(asset, min(incoming flows, outgoing flows))                                          | sum                 |
+| Hub Balance                                   | inputs, outputs                | -                | power           | min(incoming flows, outgoing flows)                                                      | -                   |
+| Conversion Balance                            | inputs, outputs                | -                | energy          | max(incoming flows, outgoing flows)                                                      | -                   |
+| Producers Capacity Constraints                | outputs                        | availability     | power           | min(outgoing flows)                                                                      | mean                |
+| Storage Capacity Constraints (outgoing)       | outputs                        | -                | power           | min(outgoing flows)                                                                      | -                   |
+| Conversion Capacity Constraints (outgoing)    | outputs                        | -                | power           | min(outgoing flows)                                                                      | -                   |
+| Conversion Capacity Constraints (incoming)    | inputs                         | -                | power           | min(incoming flows)                                                                      | -                   |
+| Storage Capacity Constraints (incoming)       | inputs                         | -                | power           | min(incoming flows)                                                                      | -                   |
+| Transport Capacity Constraints (upper bounds) | flow                           | availability     | power           | if it connects two hubs or demands then max(hub a,hub b), otherwise its own              | mean                |
+| Transport Capacity Constraints (lower bounds) | flow                           | availability     | power           | if it connects two hubs or demands then max(hub a,hub b), otherwise its own              | mean                |
+| Maximum Energy Limits (outgoing)              | outputs                        | max_energy       | energy          | Determine by timeframe partitions. The default value is for each period in the timeframe | sum                 |
+| Minumum Energy Limits (outgoing)              | outputs                        | min_energy       | energy          | Determine by timeframe partitions. The default value is for each period in the timeframe | sum                 |
 
 For this basic example, we can describe the balance and capacity constraints in the model. For the sake of simplicity, we consider only the intra-temporal constraints, the representative period index is dropped from the equations, and there are no investment variables in the equations.
 

--- a/src/constraints/energy.jl
+++ b/src/constraints/energy.jl
@@ -1,4 +1,4 @@
-export add_storage_constraints!
+export add_energy_constraints!
 
 """
 function add_energy_constraints!(model, graph, dataframes)

--- a/src/constraints/energy.jl
+++ b/src/constraints/energy.jl
@@ -16,7 +16,7 @@ function add_energy_constraints!(model, graph, dataframes)
             model,
             dataframes[:max_energy_inter_rp].outgoing_flow[row.index] ≤
             profile_aggregation(
-                Statistics.mean,
+                sum,
                 graph[row.asset].timeframe_profiles,
                 :max_energy,
                 row.periods_block,
@@ -32,7 +32,7 @@ function add_energy_constraints!(model, graph, dataframes)
             model,
             dataframes[:min_energy_inter_rp].outgoing_flow[row.index] ≥
             profile_aggregation(
-                Statistics.mean,
+                sum,
                 graph[row.asset].timeframe_profiles,
                 :min_energy,
                 row.periods_block,

--- a/test/inputs/Norse/assets-data.csv
+++ b/test/inputs/Norse/assets-data.csv
@@ -5,10 +5,10 @@ Asgard_Solar,producer,true,true,true,350,50000,100,0,0,,false,0,0,0,0,false,0,,0
 Asgard_E_demand,consumer,true,false,false,0,0,0,0,65787.17792,,false,0,0,0,0,false,0,,0,false,,,
 Asgard_CCGT,conversion,true,true,true,650,,500,0,0,,false,0,0,0,0,false,0,,0,false,,,
 G_imports,producer,true,false,false,0,0,0,75000,0,,false,0,0,0,0,false,0,,0,false,,,
-Midgard_Wind,producer,true,true,true,1300,80000,3,0,0,,true,0,0,0,0,false,0,,0,false,,1e9,
+Midgard_Wind,producer,true,true,true,1300,80000,3,0,0,,true,0,0,0,0,false,0,,0,false,,4.5e6,
 Midgard_Hydro,storage,true,false,false,1600,0,0,250,0,,true,10000,50000,25000,0,false,0,,0,false,relaxed_binary,,
 Midgard_PHS,storage,true,true,true,800,5000,200,350,0,,false,0,0,,1,true,500,1000,100,false,,,
-Midgard_Nuclear_SMR,producer,true,true,false,6000,,150,1000,0,,true,0,0,0,0,false,0,,0,false,,,1e6
+Midgard_Nuclear_SMR,producer,true,true,false,6000,,150,1000,0,,true,0,0,0,0,false,0,,0,false,,,4.5e3
 Midgard_E_imports,producer,true,false,false,0,0,0,500,0,,false,0,0,0,0,false,0,,0,false,,,
 Midgard_CCGT,conversion,true,true,true,650,,500,0,0,,false,0,0,0,0,false,0,,0,false,,,
 Midgard_E_demand,consumer,true,false,false,0,0,0,0,19604.76443,,false,0,0,0,0,false,0,,0,false,,,


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

The aggregation function in the function `add_energy_constraints!` must be `sum`, not `Statistics.mean` 

## List of related issues or pull requests

Closes #692 

## Collaboration confirmation

As a contributor I confirm

-   [x] I read and followed the instructions in README.dev.md
-   [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
-   [x] Tests are passing
-   [x] Lint is passing
