### PR TITLE
Add run_scenario(connection)

### DIFF
--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -66,31 +66,42 @@ function run_scenario(
     log_file = "",
     show_log = true,
 )
-    energy_problem =
-        @timeit to "create_energy_problem_from_csv_folder" create_energy_problem_from_csv_folder(
-            input_folder,
-        )
+    connection = create_connection_and_import_from_csv_folder(input_folder)
 
-    @timeit to "create_model!" create_model!(energy_problem; write_lp_file = write_lp_file)
-
-    @timeit to "solve and store solution" solve_model!(
-        energy_problem,
-        optimizer;
+    run_scenario(
+        connection;
+        optimizer = HiGHS.Optimizer,
         parameters = parameters,
+        write_lp_file = write_lp_file,
+        log_file = log_file,
+        show_log = show_log,
     )
 
-    if output_folder != ""
-        @timeit to "save_solution_to_file" save_solution_to_file(output_folder, energy_problem)
-    end
+    # energy_problem =
+    #     @timeit to "create_energy_problem_from_csv_folder" create_energy_problem_from_csv_folder(
+    #         input_folder,
+    #     )
 
-    show_log && show(to)
-    println()
+    # @timeit to "create_model!" create_model!(energy_problem; write_lp_file = write_lp_file)
 
-    if log_file != ""
-        open(log_file, "w") do io
-            show(io, to)
-        end
-    end
+    # @timeit to "solve and store solution" solve_model!(
+    #     energy_problem,
+    #     optimizer;
+    #     parameters = parameters,
+    # )
 
-    return energy_problem
+    # if output_folder != ""
+    #     @timeit to "save_solution_to_file" save_solution_to_file(output_folder, energy_problem)
+    # end
+
+    # show_log && show(to)
+    # println()
+
+    # if log_file != ""
+    #     open(log_file, "w") do io
+    #         show(io, to)
+    #     end
+    # end
+
+    # return energy_problem
 end

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -21,15 +21,11 @@ function run_scenario(
     log_file = "",
     show_log = true,
 )
-    energy_problem = @timeit to "create_energy_problem_from_csv_folder" EnergyProblem(connection)
+    energy_problem = @timeit to "create EnergyProblem from connection" EnergyProblem(connection)
 
-    @timeit to "create_model!" create_model!(energy_problem; write_lp_file = write_lp_file)
+    @timeit to "create_model!" create_model!(energy_problem; write_lp_file)
 
-    @timeit to "solve and store solution" solve_model!(
-        energy_problem,
-        optimizer;
-        parameters = parameters,
-    )
+    @timeit to "solve and store solution" solve_model!(energy_problem, optimizer; parameters)
 
     if output_folder != ""
         @timeit to "save_solution_to_file" save_solution_to_file(output_folder, energy_problem)

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -1,14 +1,62 @@
 export run_scenario
 
 """
-    energy_problem = run_scenario(input_folder[, output_folder; optimizer, parameters])
+    energy_problem = run_scenario(connection; optimizer, parameters, write_lp_file, log_file, show_log)
+
+Run the scenario in the given `connection` and return the energy problem.
+
+The `optimizer` and `parameters` keyword arguments can be used to change the optimizer
+(the default is HiGHS) and its parameters. The variables are passed to the [`solve_model`](@ref) function.
+
+Set `write_lp_file = true` to export the problem that is sent to the solver to a file for viewing.
+Set `show_log = false` to silence printing the log while running.
+Specify a `log_file` name to export the log to a file.
+"""
+function run_scenario(
+    connection;
+    optimizer = HiGHS.Optimizer,
+    parameters = default_parameters(optimizer),
+    write_lp_file = false,
+    log_file = "",
+    show_log = true,
+)
+    energy_problem = @timeit to "create_energy_problem_from_csv_folder" EnergyProblem(connection)
+
+    @timeit to "create_model!" create_model!(energy_problem; write_lp_file = write_lp_file)
+
+    @timeit to "solve and store solution" solve_model!(
+        energy_problem,
+        optimizer;
+        parameters = parameters,
+    )
+
+    show_log && show(to)
+    println()
+
+    if log_file != ""
+        open(log_file, "w") do io
+            show(io, to)
+        end
+    end
+
+    return energy_problem
+end
+
+"""
+    energy_problem = run_scenario(input_folder[, output_folder; optimizer, parameters, write_lp_file, log_file, show_log])
 
 Run the scenario in the given `input_folder` and return the energy problem.
 The `output_folder` is optional. If it is specified, save the sets, parameters, and solution to the `output_folder`.
 
 The `optimizer` and `parameters` keyword arguments can be used to change the optimizer
 (the default is HiGHS) and its parameters. The variables are passed to the [`solve_model`](@ref) function.
+
+Set `write_lp_file = true` to export the problem that is sent to the solver to a file for viewing.
+Set `show_log = false` to silence printing the log while running.
+Specify a `log_file` name to export the log to a file.
+
 """
+
 function run_scenario(
     input_folder::AbstractString,
     output_folder::String = "";

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -14,6 +14,7 @@ Specify a `log_file` name to export the log to a file.
 """
 function run_scenario(
     connection;
+    output_folder = "",
     optimizer = HiGHS.Optimizer,
     parameters = default_parameters(optimizer),
     write_lp_file = false,
@@ -29,6 +30,10 @@ function run_scenario(
         optimizer;
         parameters = parameters,
     )
+
+    if output_folder != ""
+        @timeit to "save_solution_to_file" save_solution_to_file(output_folder, energy_problem)
+    end
 
     show_log && show(to)
     println()
@@ -68,40 +73,13 @@ function run_scenario(
 )
     connection = create_connection_and_import_from_csv_folder(input_folder)
 
-    run_scenario(
+    return run_scenario(
         connection;
-        optimizer = HiGHS.Optimizer,
-        parameters = parameters,
-        write_lp_file = write_lp_file,
-        log_file = log_file,
-        show_log = show_log,
+        output_folder,
+        optimizer,
+        parameters,
+        write_lp_file,
+        log_file,
+        show_log,
     )
-
-    # energy_problem =
-    #     @timeit to "create_energy_problem_from_csv_folder" create_energy_problem_from_csv_folder(
-    #         input_folder,
-    #     )
-
-    # @timeit to "create_model!" create_model!(energy_problem; write_lp_file = write_lp_file)
-
-    # @timeit to "solve and store solution" solve_model!(
-    #     energy_problem,
-    #     optimizer;
-    #     parameters = parameters,
-    # )
-
-    # if output_folder != ""
-    #     @timeit to "save_solution_to_file" save_solution_to_file(output_folder, energy_problem)
-    # end
-
-    # show_log && show(to)
-    # println()
-
-    # if log_file != ""
-    #     open(log_file, "w") do io
-    #         show(io, to)
-    #     end
-    # end
-
-    # return energy_problem
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Added a version of run_scenario function that uses a connection rather than input folder.
Still needs proper testing, although it appeared to work using the pipeline workflow. (Not sure how to test it.)

Do we want to remove run_scenario that uses input and output folders?

## List of related issues or pull requests

Closes #665

## Collaboration confirmation

As a contributor I confirm

-   [X] I read and followed the instructions in README.dev.md
-   [X] The documentation is up to date with the changes introduced in this Pull Request (or NA)
-   [x] Tests are passing
-   [x] Lint is passing
