### PR TITLE
Use DuckDB to create the RepresentativePeriod structure

### DIFF
--- a/docs/src/how-to-use.md
+++ b/docs/src/how-to-use.md
@@ -273,10 +273,9 @@ The timeframe is the total period we want to analyze with the model. Usually thi
 
 The [timeframe](@ref timeframe) (e.g., a full year) is described by a selection of representative periods, for instance, days or weeks, that nicely summarize other similar periods. For example, we could model the year into 3 days, by clustering all days of the year into 3 representative days. Each one of these days is called a representative period. _TulipaEnergyModel.jl_ has the flexibility to consider representative periods of different lengths for the same timeframe (e.g., a year can be represented by a set of 4 days and 2 weeks). To obtain the representative periods, we recommend using [TulipaClustering](https://github.com/TulipaEnergy/TulipaClustering.jl).
 
-A representative period has four fields:
+A representative period has three fields:
 
--   `mapping`: Indicates the periods of the [timeframe](@ref timeframe) that map into a representative period and the weight of the representative period in them.
--   `weight`: Indicates how many representative periods are contained in the [timeframe](@ref timeframe); this is inferred automatically from `mapping`.
+-   `weight`: Indicates how many representative periods are contained in the [timeframe](@ref timeframe); this is inferred automatically from `map_periods_to_rp` in the [timeframe](@ref timeframe).
 -   `timesteps`: The number of timesteps blocks in the representative period.
 -   `resolution`: The duration in time of each timestep.
 

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -106,7 +106,7 @@ table_tree = create_input_dataframes(connection)
 The `table_tree` contains all tables in the folder, which are then processed into the internal structures below:
 
 ```@example manual
-graph, representative_periods, timeframe = create_internal_structures(table_tree)
+graph, representative_periods, timeframe = create_internal_structures(table_tree, connection)
 ```
 
 We also need a time partition for the constraints to create the model.

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -54,14 +54,12 @@ end
 Structure to hold the data of one representative period.
 """
 struct RepresentativePeriod
-    mapping::Union{Nothing,Dict{Int,Float64}}  # which periods in the full problem formulation does this rep_period stand for
     weight::Float64
     timesteps::TimestepsBlock
     resolution::Float64
 
-    function RepresentativePeriod(mapping, num_timesteps, resolution)
-        weight = sum(values(mapping))
-        return new(mapping, weight, 1:num_timesteps, resolution)
+    function RepresentativePeriod(weight, num_timesteps, resolution)
+        return new(weight, 1:num_timesteps, resolution)
     end
 end
 
@@ -299,7 +297,8 @@ mutable struct EnergyProblem
             table_tree = create_input_dataframes(connection; strict = strict)
         end
         elapsed_time_internal = @elapsed begin
-            graph, representative_periods, timeframe = create_internal_structures(table_tree)
+            graph, representative_periods, timeframe =
+                create_internal_structures(table_tree, connection)
         end
         elapsed_time_cons = @elapsed begin
             constraints_partitions = compute_constraints_partitions(graph, representative_periods)

--- a/test/test-io.jl
+++ b/test/test-io.jl
@@ -42,7 +42,7 @@ end
         connection = DBInterface.connect(DuckDB.DB)
         read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
         table_tree = create_input_dataframes(connection)
-        graph, _, _ = create_internal_structures(table_tree)
+        graph, _, _ = create_internal_structures(table_tree, connection)
 
         @test Graphs.nv(graph) == 6
         @test Graphs.ne(graph) == 5
@@ -53,10 +53,8 @@ end
 
 @testset "Test parsing of partitions" begin
     @testset "compute assets partitions" begin
-        representative_periods = [
-            RepresentativePeriod(Dict(1 => 1.0), 12, 1.0),
-            RepresentativePeriod(Dict(2 => 1.0), 24, 1.0),
-        ]
+        representative_periods =
+            [RepresentativePeriod(1.0, 12, 1.0), RepresentativePeriod(1.0, 24, 1.0)]
         df = DataFrame(
             :asset => [1, 2, 2, 3],
             :rep_period => [1, 1, 2, 2],
@@ -82,10 +80,8 @@ end
     end
 
     @testset "compute flows partitions" begin
-        representative_periods = [
-            RepresentativePeriod(Dict(1 => 1.0), 12, 1.0),
-            RepresentativePeriod(Dict(2 => 1.0), 24, 1.0),
-        ]
+        representative_periods =
+            [RepresentativePeriod(1.0, 12, 1.0), RepresentativePeriod(1.0, 24, 1.0)]
         df = DataFrame(
             :from_asset => [1, 2, 2, 3],
             :to_asset => [2, 3, 3, 4],
@@ -144,6 +140,6 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     read_csv_folder(connection, dir)
     table_tree = create_input_dataframes(connection)
-    graph, rps, tf = create_internal_structures(table_tree)
+    graph, rps, tf = create_internal_structures(table_tree, connection)
     @test graph[missing_asset].timeframe_partitions == [i:i for i in 1:tf.num_periods]
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Atomic commit to refactor the RepresentativePeriod structure to be created using DuckDB instead of table_tree

## List of related issues or pull requests

Closes #707 
Closes #495 

## Collaboration confirmation

As a contributor I confirm

-   [x] I read and followed the instructions in README.dev.md
-   [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
-   [x] Tests are passing
-   [x] Lint is passing
