### PR TITLE
Update schema to be used by TulipaIO and change name to schema_per_table

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -2,6 +2,5 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DuckDB = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
-ProfileView = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 TulipaEnergyModel = "5d7bd171-d18e-45a5-9111-f1f11ac5d04d"
 TulipaIO = "7b3808b7-0819-42d4-885c-978ba173db11"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,7 +17,11 @@ end
 const OUTPUT_FOLDER_BM = mktempdir()
 
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, INPUT_FOLDER_BM)
+TulipaIO.read_csv_folder(
+    connection,
+    INPUT_FOLDER_BM;
+    schemas = TulipaEnergyModel.schema_per_table_name,
+)
 
 SUITE["energy_problem"] = BenchmarkGroup()
 SUITE["energy_problem"]["input_and_constructor"] = @benchmarkable begin

--- a/benchmark/profiling/common.jl
+++ b/benchmark/profiling/common.jl
@@ -7,7 +7,7 @@ dir = norse_dir
 
 function _read_dir_and_return_connection(dir)
     con = DBInterface.connect(DuckDB.DB)
-    TulipaIO.read_csv_folder(con, dir)
+    TulipaIO.read_csv_folder(con, dir; schemas = TulipaEnergyModel.schema_per_table_name)
 
     return con
 end

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -397,7 +397,7 @@ using DuckDB, TulipaIO, TulipaEnergyModel
 input_dir = "../../test/inputs/Storage" # hide
 # input_dir should be the path to the Storage example
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = run_scenario(connection)
 ```
 

--- a/docs/src/how-to-use.md
+++ b/docs/src/how-to-use.md
@@ -167,7 +167,7 @@ Markdown.parse(
         join(
             ["  - `$f: $t`" for (f, t) in schema],
             "\n",
-        ) for (filename, schema) in TulipaEnergyModel.schema_per_file
+        ) for (filename, schema) in TulipaEnergyModel.schema_per_table_name
     ] |> sort, "\n")
 )
 ```

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -27,8 +27,9 @@ using DuckDB, TulipaIO, TulipaEnergyModel
 
 input_dir = "../../test/inputs/Tiny" # hide
 # input_dir should be the path to Tiny as a string (something like "test/inputs/Tiny")
+# TulipaEnergyModel.schema_per_table_name contains the schema with columns and types the file must have
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = run_scenario(connection)
 ```
 
@@ -47,7 +48,7 @@ using DuckDB, TulipaIO, TulipaEnergyModel
 input_dir = "../../test/inputs/Tiny" # hide
 # input_dir should be the path to Tiny as a string (something like "test/inputs/Tiny")
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = EnergyProblem(connection)
 ```
 
@@ -96,7 +97,7 @@ using DuckDB, TulipaIO, TulipaEnergyModel
 input_dir = "../../test/inputs/Tiny" # hide
 # input_dir should be the path to Tiny as a string (something like "test/inputs/Tiny")
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 ```
 
 ```@example manual
@@ -157,7 +158,7 @@ using DuckDB, TulipaIO, TulipaEnergyModel, GLPK
 
 input_dir = "../../test/inputs/Tiny" # hide
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = run_scenario(connection, optimizer = GLPK.Optimizer)
 ```
 
@@ -192,7 +193,7 @@ using DuckDB, TulipaIO, TulipaEnergyModel, GLPK
 input_dir = "../../test/inputs/Tiny" # hide
 parameters = Dict("tm_lim" => 1)
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = run_scenario(connection, optimizer = GLPK.Optimizer, parameters = parameters)
 energy_problem.termination_status
 ```
@@ -286,7 +287,7 @@ using DuckDB, TulipaIO, TulipaEnergyModel
 input_dir = "../../test/inputs/Norse" # hide
 # input_dir should be the path to Norse as a string (something like "test/inputs/Norse")
 connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir)
+read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = EnergyProblem(connection)
 create_model!(energy_problem)
 solution = solve_model!(energy_problem)

--- a/src/input-schemas.jl
+++ b/src/input-schemas.jl
@@ -4,125 +4,125 @@ const schemas = (
     assets = (
         # Schema for the assets-data.csv file.
         data = OrderedDict(
-            :name => String,                                            # Name of Asset (geographical?)
-            :type => String,                                            # Producer/Consumer/Storage/Conversion
-            :active => Bool,                                            # Active or decomissioned
-            :investable => Bool,                                        # Whether able to invest
-            :investment_integer => Bool,                                # Whether investment is integer or continuous
-            :investment_cost => Float64,                                # kEUR/MW/year
-            :investment_limit => Union{Missing,Float64},                # MW (Missing -> no limit)
-            :capacity => Float64,                                       # MW
-            :initial_capacity => Float64,                               # MW
-            :peak_demand => Float64,                                    # MW
-            :consumer_balance_sense => Union{Missing,String},           # Sense of the consumer balance constraint (default ==)
-            :is_seasonal => Bool,                                       # Whether seasonal storage (e.g. hydro) or not (e.g. battery)
-            :storage_inflows => Float64,                                # MWh/year
-            :initial_storage_capacity => Float64,                       # MWh
-            :initial_storage_level => Union{Missing,Float64},           # MWh (Missing -> free initial level)
-            :energy_to_power_ratio => Float64,                          # Hours
-            :storage_method_energy => Bool,                             # Whether storage method is energy or not (i.e., fixed_ratio)
-            :investment_cost_storage_energy => Float64,                 # kEUR/MWh/year
-            :investment_limit_storage_energy => Union{Missing,Float64}, # MWh (Missing -> no limit)
-            :capacity_storage_energy => Float64,                        # MWh
-            :investment_integer_storage_energy => Bool,                 # Whether investment for storage energy is integer or continuous
-            :use_binary_storage_method => Union{String,Missing},        # Whether to use an extra binary variable for the storage assets to avoid charging and discharging simultaneously (missing;binary;relaxed_binary)
-            :max_energy_timeframe_partition => Union{Missing,Float64},  # MWh (Missing -> no limit)
-            :min_energy_timeframe_partition => Union{Missing,Float64},  # MWh (Missing -> no limit)
+            :name => "VARCHAR",                              # Name of Asset (geographical?)
+            :type => "VARCHAR",                              # Producer/Consumer/Storage/Conversion
+            :active => "BOOLEAN",                            # Active or decomissioned
+            :investable => "BOOLEAN",                        # Whether able to invest
+            :investment_integer => "BOOLEAN",                # Whether investment is integer or continuous
+            :investment_cost => "DOUBLE",                    # kEUR/MW/year
+            :investment_limit => "DOUBLE",                   # MW (Missing -> no limit)
+            :capacity => "DOUBLE",                           # MW
+            :initial_capacity => "DOUBLE",                   # MW
+            :peak_demand => "DOUBLE",                        # MW
+            :consumer_balance_sense => "VARCHAR",            # Sense of the consumer balance constraint (default ==)
+            :is_seasonal => "BOOLEAN",                       # Whether seasonal storage (e.g. hydro) or not (e.g. battery)
+            :storage_inflows => "DOUBLE",                    # MWh/year
+            :initial_storage_capacity => "DOUBLE",           # MWh
+            :initial_storage_level => "DOUBLE",              # MWh (Missing -> free initial level)
+            :energy_to_power_ratio => "DOUBLE",              # Hours
+            :storage_method_energy => "BOOLEAN",             # Whether storage method is energy or not (i.e., fixed_ratio)
+            :investment_cost_storage_energy => "DOUBLE",     # kEUR/MWh/year
+            :investment_limit_storage_energy => "DOUBLE",    # MWh (Missing -> no limit)
+            :capacity_storage_energy => "DOUBLE",            # MWh
+            :investment_integer_storage_energy => "BOOLEAN", # Whether investment for storage energy is integer or continuous
+            :use_binary_storage_method => "VARCHAR",         # Whether to use an extra binary variable for the storage assets to avoid charging and discharging simultaneously (missing;binary;relaxed_binary)
+            :max_energy_timeframe_partition => "DOUBLE",     # MWh (Missing -> no limit)
+            :min_energy_timeframe_partition => "DOUBLE",     # MWh (Missing -> no limit)
         ),
 
         # Schema for the assets-profiles.csv file.
         profiles_reference = OrderedDict(
-            :asset => String,               # Asset name
-            :profile_type => String,        # Type of profile, used to determine dataframe with source profile
-            :profile_name => String,        # Name of profile, used to determine data inside the dataframe
+            :asset => "VARCHAR",               # Asset name
+            :profile_type => "VARCHAR",        # Type of profile, used to determine dataframe with source profile
+            :profile_name => "VARCHAR",        # Name of profile, used to determine data inside the dataframe
         ),
 
         # Schema for the assets-timeframe-partitions.csv file.
         timeframe_partition = OrderedDict(
-            :asset => String,
-            :specification => String,
-            :partition => String,
+            :asset => "VARCHAR",
+            :specification => "VARCHAR",
+            :partition => "VARCHAR",
         ),
 
         # Schema for the assets-rep-periods-partitions.csv file.
         rep_periods_partition = OrderedDict(
-            :asset => String,
-            :rep_period => Int,
-            :specification => String,
-            :partition => String,
+            :asset => "VARCHAR",
+            :rep_period => "INTEGER",
+            :specification => "VARCHAR",
+            :partition => "VARCHAR",
         ),
     ),
     flows = (
         # Schema for the flows-data.csv file.
         data = OrderedDict(
-            :carrier => String,                             # (Optional?) Energy carrier
-            :from_asset => String,                          # Name of Asset
-            :to_asset => String,                            # Name of Asset
-            :active => Bool,                                # Active or decomissioned
-            :is_transport => Bool,                          # Whether a transport flow
-            :investable => Bool,                            # Whether able to invest
-            :investment_integer => Bool,                    # Whether investment is integer or continuous
-            :variable_cost => Float64,                      # kEUR/MWh
-            :investment_cost => Float64,                    # kEUR/MW/year
-            :investment_limit => Union{Missing,Float64},    # MW
-            :capacity => Float64,                           # MW
-            :initial_export_capacity => Float64,            # MW
-            :initial_import_capacity => Float64,            # MW
-            :efficiency => Float64,                         # p.u. (per unit)
+            :carrier => "VARCHAR",                  # (Optional?) Energy carrier
+            :from_asset => "VARCHAR",               # Name of Asset
+            :to_asset => "VARCHAR",                 # Name of Asset
+            :active => "BOOLEAN",                   # Active or decomissioned
+            :is_transport => "BOOLEAN",             # Whether a transport flow
+            :investable => "BOOLEAN",               # Whether able to invest
+            :investment_integer => "BOOLEAN",       # Whether investment is integer or continuous
+            :variable_cost => "DOUBLE",             # kEUR/MWh
+            :investment_cost => "DOUBLE",           # kEUR/MW/year
+            :investment_limit => "DOUBLE",          # MW
+            :capacity => "DOUBLE",                  # MW
+            :initial_export_capacity => "DOUBLE",   # MW
+            :initial_import_capacity => "DOUBLE",   # MW
+            :efficiency => "DOUBLE",                # p.u. (per unit)
         ),
 
         # Schema for the flows-profiles file.
         profiles_reference = OrderedDict(
-            :from_asset => String,          # Name of Asset
-            :to_asset => String,            # Name of Asset
-            :profile_type => String,        # Type of profile, used to determine dataframe with source profile
-            :profile_name => String,        # Name of profile, used to determine data inside the dataframe
+            :from_asset => "VARCHAR",          # Name of Asset
+            :to_asset => "VARCHAR",            # Name of Asset
+            :profile_type => "VARCHAR",        # Type of profile, used to determine dataframe with source profile
+            :profile_name => "VARCHAR",        # Name of profile, used to determine data inside the dataframe
         ),
 
         # Schema for the flows-rep-periods-partitions.csv file.
         rep_periods_partition = OrderedDict(
-            :from_asset => String,          # Name of Asset
-            :to_asset => String,            # Name of Asset
-            :rep_period => Int,
-            :specification => String,
-            :partition => String,
+            :from_asset => "VARCHAR",          # Name of Asset
+            :to_asset => "VARCHAR",            # Name of Asset
+            :rep_period => "INTEGER",
+            :specification => "VARCHAR",
+            :partition => "VARCHAR",
         ),
     ),
     timeframe = (
         # Schema for the profiles-timeframe-<type>.csv file.
         profiles_data = OrderedDict(
-            :profile_name => String,        # Profile name
-            :period => Int,                 # Period
-            :value => Float64,              # p.u. (per unit)
+            :profile_name => "VARCHAR",      # Profile name
+            :period => "INTEGER",            # Period
+            :value => "DOUBLE",              # p.u. (per unit)
         ),
     ),
 
     # Schema for the rep-periods-data.csv file.
     rep_periods = (
         data = OrderedDict(
-            :rep_period => Int,             # Representative period number
-            :num_timesteps => Int,          # Numer of timesteps
-            :resolution => Float64,         # Duration of each timestep (hours)
+            :rep_period => "INTEGER",        # Representative period number
+            :num_timesteps => "INTEGER",     # Numer of timesteps
+            :resolution => "DOUBLE",         # Duration of each timestep (hours)
         ),
 
         # Schema for the rep-periods-mapping.csv file.
         mapping = OrderedDict(
-            :period => Int,                 # Period number
-            :rep_period => Int,             # Representative period number
-            :weight => Float64,             # Hours
+            :period => "INTEGER",            # Period number
+            :rep_period => "INTEGER",        # Representative period number
+            :weight => "DOUBLE",             # Hours
         ),
 
         # Schema for the profiles-rep-periods-<type>.csv file.
         profiles_data = OrderedDict(
-            :profile_name => String,        # Profile name
-            :rep_period => Int,             # Representative period number
-            :timestep => Int,               # Timestep number
-            :value => Float64,              # p.u. (per unit)
+            :profile_name => "VARCHAR",  # Profile name
+            :rep_period => "INTEGER",    # Representative period number
+            :timestep => "INTEGER",      # Timestep number
+            :value => "DOUBLE",          # p.u. (per unit)
         ),
     ),
 )
 
-const schema_per_file = OrderedDict(
+const schema_per_table_name = OrderedDict(
     "assets_timeframe_partitions" => schemas.assets.timeframe_partition,
     "assets_data" => schemas.assets.data,
     "assets_timeframe_profiles" => schemas.assets.profiles_reference,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,6 @@ end
 
 @testset "Ensuring data can be read and create dataframes" begin
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, joinpath(@__DIR__, "../benchmark/EU/"))
+    _read_csv_folder(connection, joinpath(@__DIR__, "../benchmark/EU/"))
     create_input_dataframes(connection)
 end

--- a/test/test-aux.jl
+++ b/test/test-aux.jl
@@ -1,0 +1,6 @@
+# file with auxiliary functions for the testing
+
+function _read_csv_folder(connection, input_dir)
+    schemas = TulipaEnergyModel.schema_per_table_name
+    return TulipaIO.read_csv_folder(connection, input_dir; schemas)
+end

--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -9,7 +9,7 @@
     end
     for (optimizer, parameters) in parameters_dict
         connection = DBInterface.connect(DuckDB.DB)
-        read_csv_folder(connection, dir)
+        _read_csv_folder(connection, dir)
         energy_problem = run_scenario(connection; optimizer, parameters)
         @test JuMP.is_solved_and_feasible(energy_problem.model)
     end
@@ -23,7 +23,7 @@ end
     end
     for optimizer in optimizer_list
         connection = DBInterface.connect(DuckDB.DB)
-        read_csv_folder(connection, dir)
+        _read_csv_folder(connection, dir)
         energy_problem = run_scenario(connection; optimizer)
         @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
     end
@@ -32,7 +32,7 @@ end
 @testset "Test run_scenario arguments" begin
     dir = joinpath(INPUT_FOLDER, "Norse")
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, dir)
+    _read_csv_folder(connection, dir)
     energy_problem = run_scenario(
         connection;
         output_folder = OUTPUT_FOLDER,
@@ -44,7 +44,7 @@ end
 @testset "Storage Assets Case Study" begin
     dir = joinpath(INPUT_FOLDER, "Storage")
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, dir)
+    _read_csv_folder(connection, dir)
     energy_problem = run_scenario(connection)
     @test energy_problem.objective_value ≈ 2409.384029 atol = 1e-5
 end
@@ -52,7 +52,7 @@ end
 @testset "Tiny Variable Resolution Case Study" begin
     dir = joinpath(INPUT_FOLDER, "Variable Resolution")
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, dir)
+    _read_csv_folder(connection, dir)
     energy_problem = run_scenario(connection)
     @test energy_problem.objective_value ≈ 28.45872 atol = 1e-5
 end
@@ -60,7 +60,7 @@ end
 @testset "Infeasible Case Study" begin
     dir = joinpath(INPUT_FOLDER, "Tiny")
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, dir)
+    _read_csv_folder(connection, dir)
     energy_problem = EnergyProblem(connection)
     energy_problem.graph["demand"].peak_demand = -1 # make it infeasible
     create_model!(energy_problem)

--- a/test/test-io.jl
+++ b/test/test-io.jl
@@ -5,7 +5,7 @@
 
     @testset "Check missing asset partition if strict" begin
         connection = DBInterface.connect(DuckDB.DB)
-        read_csv_folder(connection, joinpath(INPUT_FOLDER, "Norse"))
+        _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Norse"))
         @test_throws Exception EnergyProblem(connection, strict = true)
     end
 end
@@ -13,7 +13,7 @@ end
 @testset "Output validation" begin
     @testset "Make sure that saving an unsolved energy problem fails" begin
         connection = DBInterface.connect(DuckDB.DB)
-        read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+        _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
         energy_problem = EnergyProblem(connection)
         output_dir = mktempdir()
         @test_throws Exception save_solution_to_file(output_dir, energy_problem)
@@ -27,7 +27,7 @@ end
 @testset "Printing EnergyProblem validation" begin
     @testset "Check the missing cases of printing the EnergyProblem" begin # model infeasible is covered in testset "Infeasible Case Study".
         connection = DBInterface.connect(DuckDB.DB)
-        read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+        _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
         energy_problem = EnergyProblem(connection)
         print(energy_problem)
         create_model!(energy_problem)
@@ -40,7 +40,7 @@ end
 @testset "Graph structure" begin
     @testset "Graph structure is correct" begin
         connection = DBInterface.connect(DuckDB.DB)
-        read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+        _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
         table_tree = create_input_dataframes(connection)
         graph, _, _ = create_internal_structures(table_tree, connection)
 
@@ -138,7 +138,7 @@ end
     missing_asset = split(lines[end], ",")[1] # The asset that was not included
 
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, dir)
+    _read_csv_folder(connection, dir)
     table_tree = create_input_dataframes(connection)
     graph, rps, tf = create_internal_structures(table_tree, connection)
     @test graph[missing_asset].timeframe_partitions == [i:i for i in 1:tf.num_periods]

--- a/test/test-model.jl
+++ b/test/test-model.jl
@@ -1,6 +1,6 @@
 @testset "Test that solve_model! throws if model is not created but works otherwise" begin
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+    _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
     energy_problem = EnergyProblem(connection)
     @test_throws Exception solve_model!(energy_problem)
     @test !energy_problem.solved

--- a/test/test-options.jl
+++ b/test/test-options.jl
@@ -1,6 +1,6 @@
 @testset "Test some HiGHS options" begin
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+    _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
     energy_problem = run_scenario(
         connection;
         output_folder = OUTPUT_FOLDER,
@@ -73,7 +73,7 @@ end
 
 @testset "Test that bad options throw errors" begin
     connection = DBInterface.connect(DuckDB.DB)
-    read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+    _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
     @test_throws MathOptInterface.UnsupportedAttribute energy_problem = run_scenario(
         connection;
         output_folder = OUTPUT_FOLDER,


### PR DESCRIPTION
Change schema_per_file to schema_per_table.
Change the types of the schema to a SQL/DuckDB compliant name.
This also prepares the ground to remove table_tree (#729).

Closes #734
