### PR TITLE
Add an expression that covers both simple and compact methods

### DIFF
--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -28,6 +28,7 @@ function add_capacity_constraints!(
     decommissionable_assets_using_simple_method,
     decommissionable_assets_using_compact_method,
     V_all,
+    accumulated_set_using_compact_method_lookup,
     Asb,
     assets_investment,
     accumulate_capacity_simple_method,
@@ -36,9 +37,6 @@ function add_capacity_constraints!(
     outgoing_flow_highest_out_resolution,
     incoming_flow_highest_in_resolution,
 )
-    compact_set_lookup = Dict(
-        (a, y, v) => idx for (idx, (a, y, v)) in enumerate(accumulated_set_using_compact_method)
-    )
 
     ## Expressions used by capacity constraints
     # - Create capacity limit for outgoing flows
@@ -72,7 +70,8 @@ function add_capacity_constraints!(
                             ("availability", row.rep_period),
                             row.timesteps_block,
                             1.0,
-                        ) * accumulate_capacity_compact_method[compact_set_lookup[(
+                        ) *
+                        accumulate_capacity_compact_method[accumulated_set_using_compact_method_lookup[(
                             row.asset,
                             row.year,
                             v,

--- a/test/inputs/Multi-year Investments/graph-assets-data.csv
+++ b/test/inputs/Multi-year Investments/graph-assets-data.csv
@@ -1,8 +1,8 @@
 ,{producer;consumer},{group name},{none;simple;compact},MW,year,
 name,type,group,investment_method,capacity,technical_lifetime,discount_rate
-ocgt,producer,,compact,100,15,0.05
-ccgt,producer,,compact,400,25,0.05
+ocgt,producer,,simple,100,15,0.05
+ccgt,producer,,simple,400,25,0.05
 wind,producer,,compact,50,30,0.05
-solar,producer,,compact,10,15,0.05
+solar,producer,,simple,10,15,0.05
 ens,producer,,none,1115,15,0.05
 demand,consumer,,none,0,15,0.05


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

- Add new expression that is either `accumulate_capacity_simple_method` or `accumulate_capacity_compact_method` depending on the asset. For the latter, sum over all v, following the method using for the capacity constraint.
- Sum all vintage years to get the total initial units for simple method

## List of related issues or pull requests

Closes #798 

## Collaboration confirmation

As a contributor I confirm

-   [ ] I read and followed the instructions in README.dev.md
-   [ ] The documentation is up to date with the changes introduced in this Pull Request (or NA)
-   [ ] Tests are passing
-   [ ] Lint is passing
