### PR TITLE
Limit DuckDB version to 1.0 until duckdb/duckdb#13911 is fixed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ TulipaIO = "7b3808b7-0819-42d4-885c-978ba173db11"
 [compat]
 CSV = "0.10"
 DataFrames = "1"
-DuckDB = "0.10, 1"
+DuckDB = "0.10, ~1.0" # ~1.0 until they fix https://github.com/duckdb/duckdb/issues/13911
 Graphs = "1.8"
 HiGHS = "1"
 JuMP = "1"


### PR DESCRIPTION
DuckDB.jl 1.1 on Windows is broken with an error
'Could not load symbol duckdb_vector_size'
This limits the DuckDB version until that is fixed.

refs:
- duckdb/duckdb#13911
