### PR TITLE
Fix case where the there are no time blocks to determine in a constraint

### DIFF
--- a/src/tmp.jl
+++ b/src/tmp.jl
@@ -213,7 +213,7 @@ function tmp_create_constraints_indices(connection)
             main.asset,
             main.year,
             main.rep_period,
-            sub.time_block_start,
+            COALESCE(sub.time_block_start, 1) AS time_block_start,
             lead(sub.time_block_start - 1, 1, main.num_timesteps)
                 OVER (PARTITION BY main.asset, main.year, main.rep_period ORDER BY time_block_start)
                 AS time_block_end,
@@ -250,7 +250,7 @@ function tmp_create_constraints_indices(connection)
             main.asset,
             main.year,
             main.rep_period,
-            sub.time_block_start,
+            COALESCE(sub.time_block_start, 1) AS time_block_start,
             lead(sub.time_block_start - 1, 1, main.num_timesteps)
                 OVER (PARTITION BY main.asset, main.year, main.rep_period ORDER BY time_block_start)
                 AS time_block_end,


### PR DESCRIPTION
For FI_Hydro_Reservoir in the EU case, there are no matches in the incoming
flows, so there is nothing constraining the time block. In this case, it uses
1 as time_block_start and num_timesteps and tmie_block_end of the single
block.
