### PR TITLE
Fix 91-developer.md

### DIFF
--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -446,25 +446,25 @@ When publishing a new version of the model to the Julia Registry, follow this pr
 
 1. Click on the `Project.toml` file on GitHub.
 
-2. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch<br>
+1. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch<br>
    ![Screenshot of editing Project.toml on GitHub](./images/UpdateVersion.png)
 
-4. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.<br>
+1. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.<br>
    ![Screenshot of PR with commit message "Release 0.6.1"](./images/CommitMessage.png)
 
-5. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.<br>
+1. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.<br>
    ![Screenshot of full PR template on GitHub](./images/PullRequest.png)
 
-7. Go to the main page of repo and click in the commit.<br>
+1. Go to the main page of repo and click in the commit.<br>
    ![Screenshot of how to access commit on GitHub](./images/AccessCommit.png)
 
-8. Add the following comment to the commit: `@JuliaRegistrator register`<br>
+1. Add the following comment to the commit: `@JuliaRegistrator register`<br>
    ![Screenshot of calling JuliaRegistrator in commit comments](./images/JuliaRegistrator.png)
 
-9. The bot should start the registration process.<br>
+1. The bot should start the registration process.<br>
    ![Screenshot of JuliaRegistrator bot message](./images/BotProcess.png)
 
-11. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.<br>
+1. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.<br>
    ![Screenshot of new version on registry](./images/NewRelease.png)
 
    Thank you for helping make frequent releases!

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -441,37 +441,30 @@ See the file <benchmark/profiling.jl> for an example of profiling code.
 When publishing a new version of the model to the Julia Registry, follow this procedure:
 
 > **Note:**
-> To be able to register, you need to be a member of the organisation TulipaEnergy and have your visibility set to public:
+> To be able to register, you need to be a member of the organisation TulipaEnergy and have your visibility set to public:<br>
 > ![Screenshot of public members of TulipaEnergy on GitHub](./images/PublicMember.png)
 
 1. Click on the `Project.toml` file on GitHub.
 
-2. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch
-   
+2. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch<br>
    ![Screenshot of editing Project.toml on GitHub](./images/UpdateVersion.png)
 
-4. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.
-   
+4. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.<br>
    ![Screenshot of PR with commit message "Release 0.6.1"](./images/CommitMessage.png)
 
-5. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.
-   
+5. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.<br>
    ![Screenshot of full PR template on GitHub](./images/PullRequest.png)
 
-7. Go to the main page of repo and click in the commit.
-   
+7. Go to the main page of repo and click in the commit.<br>
    ![Screenshot of how to access commit on GitHub](./images/AccessCommit.png)
 
-8. Add the following comment to the commit: `@JuliaRegistrator register`
-   
+8. Add the following comment to the commit: `@JuliaRegistrator register`<br>
    ![Screenshot of calling JuliaRegistrator in commit comments](./images/JuliaRegistrator.png)
 
-9. The bot should start the registration process.
-    
+9. The bot should start the registration process.<br>
    ![Screenshot of JuliaRegistrator bot message](./images/BotProcess.png)
 
-11. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.
-    
+11. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.<br>
    ![Screenshot of new version on registry](./images/NewRelease.png)
 
    Thank you for helping make frequent releases!

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -447,24 +447,31 @@ When publishing a new version of the model to the Julia Registry, follow this pr
 1. Click on the `Project.toml` file on GitHub.
 
 2. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch
+   
    ![Screenshot of editing Project.toml on GitHub](./images/UpdateVersion.png)
 
-3. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.
+4. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.
+   
    ![Screenshot of PR with commit message "Release 0.6.1"](./images/CommitMessage.png)
 
-4. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.
+5. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.
+   
    ![Screenshot of full PR template on GitHub](./images/PullRequest.png)
 
-5. Go to the main page of repo and click in the commit.
+7. Go to the main page of repo and click in the commit.
+   
    ![Screenshot of how to access commit on GitHub](./images/AccessCommit.png)
 
-6. Add the following comment to the commit: `@JuliaRegistrator register`
+8. Add the following comment to the commit: `@JuliaRegistrator register`
+   
    ![Screenshot of calling JuliaRegistrator in commit comments](./images/JuliaRegistrator.png)
 
-7. The bot should start the registration process.
+9. The bot should start the registration process.
+    
    ![Screenshot of JuliaRegistrator bot message](./images/BotProcess.png)
 
-8. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.
+11. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.
+    
    ![Screenshot of new version on registry](./images/NewRelease.png)
 
    Thank you for helping make frequent releases!

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -446,32 +446,25 @@ When publishing a new version of the model to the Julia Registry, follow this pr
 
 1. Click on the `Project.toml` file on GitHub.
 
-1. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch
-   
+1. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch<br>
    ![Screenshot of editing Project.toml on GitHub](./images/UpdateVersion.png)
 
-1. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.
-   
+1. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.<br>
    ![Screenshot of PR with commit message "Release 0.6.1"](./images/CommitMessage.png)
 
-1. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.
-   
+1. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.<br>
    ![Screenshot of full PR template on GitHub](./images/PullRequest.png)
 
-1. Go to the main page of repo and click in the commit.
-   
+1. Go to the main page of repo and click in the commit.<br>
    ![Screenshot of how to access commit on GitHub](./images/AccessCommit.png)
 
-1. Add the following comment to the commit: `@JuliaRegistrator register`
-   
+1. Add the following comment to the commit: `@JuliaRegistrator register`<br>
    ![Screenshot of calling JuliaRegistrator in commit comments](./images/JuliaRegistrator.png)
 
-1. The bot should start the registration process.
-   
+1. The bot should start the registration process.<br>
    ![Screenshot of JuliaRegistrator bot message](./images/BotProcess.png)
 
-1. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.
-   
+1. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.<br>
    ![Screenshot of new version on registry](./images/NewRelease.png)
 
    Thank you for helping make frequent releases!

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -446,25 +446,32 @@ When publishing a new version of the model to the Julia Registry, follow this pr
 
 1. Click on the `Project.toml` file on GitHub.
 
-1. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch<br>
+1. Edit the file and change the version number according to [semantic versioning](https://semver.org/): Major.Minor.Patch
+   
    ![Screenshot of editing Project.toml on GitHub](./images/UpdateVersion.png)
 
-1. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.<br>
+1. Commit the changes in a new branch and open a pull request. Change the commit message according to the version number.
+   
    ![Screenshot of PR with commit message "Release 0.6.1"](./images/CommitMessage.png)
 
-1. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.<br>
+1. Create the pull request and squash & merge it after the review and testing process. Delete the branch after the squash and merge.
+   
    ![Screenshot of full PR template on GitHub](./images/PullRequest.png)
 
-1. Go to the main page of repo and click in the commit.<br>
+1. Go to the main page of repo and click in the commit.
+   
    ![Screenshot of how to access commit on GitHub](./images/AccessCommit.png)
 
-1. Add the following comment to the commit: `@JuliaRegistrator register`<br>
+1. Add the following comment to the commit: `@JuliaRegistrator register`
+   
    ![Screenshot of calling JuliaRegistrator in commit comments](./images/JuliaRegistrator.png)
 
-1. The bot should start the registration process.<br>
+1. The bot should start the registration process.
+   
    ![Screenshot of JuliaRegistrator bot message](./images/BotProcess.png)
 
-1. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.<br>
+1. After approval, the bot will take care of the PR at the Julia Registry and automatically create the release for the new version.
+   
    ![Screenshot of new version on registry](./images/NewRelease.png)
 
    Thank you for helping make frequent releases!


### PR DESCRIPTION
Text was in line with image - added carriage returns

Problem:
![image](https://github.com/user-attachments/assets/76597599-2318-4d32-8eab-478968fe4286)


<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [X] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)

- [X] Tests are passing
- [X] Lint workflow is passing
- [X] Docs were updated and workflow is passing
