### PR TITLE
Option to disable name creation

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -39,7 +39,7 @@ function create_model!(energy_problem; kwargs...)
 end
 
 """
-    model = create_model(graph, representative_periods, dataframes, timeframe, groups; write_lp_file = false)
+    model = create_model(graph, representative_periods, dataframes, timeframe, groups; write_lp_file = false, enable_names = true)
 
 Create the energy model given the `graph`, `representative_periods`, dictionary of `dataframes` (created by [`construct_dataframes`](@ref)), timeframe, and groups.
 """
@@ -54,6 +54,7 @@ function create_model(
     groups,
     model_parameters;
     write_lp_file = false,
+    enable_names = true,
 )
     # Maximum timestep
     Tmax = maximum(last(rp.timesteps) for year in sets.Y for rp in representative_periods[year])
@@ -73,6 +74,8 @@ function create_model(
 
     ## Model
     model = JuMP.Model()
+
+    JuMP.set_string_names_on_creation(model, enable_names)
 
     ## Variables
     @timeit to "add_flow_variables!" add_flow_variables!(model, variables)


### PR DESCRIPTION
This option is very useful if model building becomes a bottleneck.

I tested with the case: https://github.com/jump-dev/open-energy-modeling-benchmarks/tree/main/TulipaEnergyModel/cases/1_EU_investment_simple

And considered a 744-hour window.

After running:
```julia
@time for i in 1:5
    @time TEM.create_model!(energy_problem, enable_names = true)
end
@time for i in 1:5
    @time TEM.create_model!(energy_problem, enable_names = false)
end
```

```
  6.068038 seconds (51.89 M allocations: 2.070 GiB, 14.97% gc time)
  6.543459 seconds (51.89 M allocations: 2.070 GiB, 15.97% gc time)
  6.146185 seconds (51.89 M allocations: 2.070 GiB, 31.12% gc time)
  4.789449 seconds (51.89 M allocations: 2.070 GiB, 21.78% gc time)
  5.377641 seconds (51.89 M allocations: 2.070 GiB, 28.66% gc time)
 28.927705 seconds (259.45 M allocations: 10.349 GiB, 22.30% gc time)
  3.624356 seconds (41.80 M allocations: 1.707 GiB, 22.72% gc time)
  4.070576 seconds (41.80 M allocations: 1.707 GiB, 28.73% gc time)
  3.930987 seconds (41.80 M allocations: 1.707 GiB, 21.55% gc time)
  4.170375 seconds (41.80 M allocations: 1.707 GiB, 27.58% gc time)
  3.802902 seconds (41.80 M allocations: 1.707 GiB, 21.91% gc time)
 19.601341 seconds (208.98 M allocations: 8.534 GiB, 24.61% gc time)
```

Which is a 30% speedup.

I can imagine some names are important for model interaction.
The more complicated version with names would be to generate names after the build, and only on the need basis.
A simpler version would be to only enable names of specific variables and constraints that are more frequently used.
The latter can be done by calling the JuMP function right before and right after each group of constraints / variables.