### PR TITLE
Rename and split some constraints to reflect Miro

### DIFF
--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -245,8 +245,7 @@ function add_capacity_constraints!(model, variables, constraints, graph, sets)
         [
             @constraint(
                 model,
-                outgoing_flow_highest_out_resolution[row.index] ≤
-                assets_profile_times_capacity_out[row.index],
+                outgoing_flow[row.index] ≤ assets_profile_times_capacity_out[row.index],
                 base_name = "max_output_flows_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
             ) for row in eachrow(cons_outgoing.indices)
         ],

--- a/src/constraints/consumer.jl
+++ b/src/constraints/consumer.jl
@@ -12,13 +12,12 @@ add_consumer_constraints!(model,
 Adds the consumer asset constraints to the model.
 """
 
-function add_consumer_constraints!(model, constraints, graph, sets)
-    Ac = sets[:Ac]
-    incoming_flow_highest_in_out_resolution = constraints[:highest_in_out].expressions[:incoming]
-    outgoing_flow_highest_in_out_resolution = constraints[:highest_in_out].expressions[:outgoing]
+function add_consumer_constraints!(model, constraints, graph)
+    cons = constraints[:balance_consumer]
+    incoming_flow_highest_in_out_resolution = cons.expressions[:incoming]
+    outgoing_flow_highest_in_out_resolution = cons.expressions[:outgoing]
 
     # - Balance constraint (using the lowest temporal resolution)
-    df = filter(:asset => ∈(Ac), constraints[:highest_in_out].indices; view = true)
     model[:consumer_balance] = [
         @constraint(
             model,
@@ -35,6 +34,6 @@ function add_consumer_constraints!(model, constraints, graph, sets)
             ) * graph[row.asset].peak_demand[row.year] in
             graph[row.asset].consumer_balance_sense,
             base_name = "consumer_balance[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(df)
+        ) for row in eachrow(cons.indices)
     ]
 end

--- a/src/constraints/conversion.jl
+++ b/src/constraints/conversion.jl
@@ -11,17 +11,16 @@ add_conversion_constraints!(model,
 Adds the conversion asset constraints to the model.
 """
 
-function add_conversion_constraints!(model, constraints, sets)
-    Acv = sets[:Acv]
+function add_conversion_constraints!(model, constraints)
     # - Balance constraint (using the lowest temporal resolution)
-    df = filter(:asset => ∈(Acv), constraints[:lowest].indices; view = true)
-    incoming = constraints[:lowest].expressions[:incoming]
-    outgoing = constraints[:lowest].expressions[:outgoing]
+    cons = constraints[:balance_conversion]
+    incoming = cons.expressions[:incoming]
+    outgoing = cons.expressions[:outgoing]
     model[:conversion_balance] = [
         @constraint(
             model,
             incoming[row.index] == outgoing[row.index],
             base_name = "conversion_balance[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(df)
+        ) for row in eachrow(cons.indices)
     ]
 end

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -6,7 +6,7 @@ function compute_constraints_indices(connection)
 
     constraints = Dict{Symbol,TulipaConstraint}(
         key => TulipaConstraint(connection, "cons_$key") for key in (
-            :lowest,
+            :balance_conversion,
             :highest_in_out,
             :highest_in,
             :highest_out,
@@ -25,7 +25,7 @@ function _create_constraints_tables(connection)
     DuckDB.query(
         connection,
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_lowest AS
+        CREATE OR REPLACE TABLE cons_balance_conversion AS
         SELECT
             nextval('id') AS index,
             asset.asset,
@@ -37,7 +37,7 @@ function _create_constraints_tables(connection)
         LEFT JOIN asset
             ON t_low.asset = asset.asset
         WHERE
-            asset.type in ('conversion', 'producer')
+            asset.type in ('conversion')
         ORDER BY
             asset.asset,
             t_low.year,

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -14,8 +14,8 @@ function compute_constraints_indices(connection)
             :units_on_and_outflows,
             :storage_level_intra_rp,
             :storage_level_inter_rp,
-            :min_energy_inter_rp,
-            :max_energy_inter_rp,
+            :min_energy_over_clustered_year,
+            :max_energy_over_clustered_year,
         )
     )
 
@@ -163,7 +163,7 @@ function _create_constraints_tables(connection)
     DuckDB.query(
         connection,
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_min_energy_inter_rp AS
+        CREATE OR REPLACE TABLE cons_min_energy_over_clustered_year AS
         SELECT
             nextval('id') AS index,
             attr.asset,
@@ -184,7 +184,7 @@ function _create_constraints_tables(connection)
     DuckDB.query(
         connection,
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_max_energy_inter_rp AS
+        CREATE OR REPLACE TABLE cons_max_energy_over_clustered_year AS
         SELECT
             nextval('id') AS index,
             attr.asset,

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -11,7 +11,7 @@ function compute_constraints_indices(connection)
             :balance_hub,
             :capacity_incoming,
             :capacity_outgoing,
-            :units_on_and_outflows,
+            :ramping_with_unit_commitment,
             :ramping_without_unit_commitment,
             :balance_storage_rep_period,
             :balance_storage_over_clustered_year,
@@ -129,7 +129,7 @@ function _create_constraints_tables(connection)
     DuckDB.query(
         connection,
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_units_on_and_outflows AS
+        CREATE OR REPLACE TABLE cons_ramping_with_unit_commitment AS
         SELECT
             nextval('id') AS index,
             t_high.*

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -9,7 +9,7 @@ function compute_constraints_indices(connection)
             :balance_conversion,
             :balance_consumer,
             :balance_hub,
-            :highest_in,
+            :capacity_incoming,
             :highest_out,
             :units_on_and_outflows,
             :balance_storage_rep_period,
@@ -90,7 +90,7 @@ function _create_constraints_tables(connection)
     DuckDB.query(
         connection,
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_highest_in AS
+        CREATE OR REPLACE TABLE cons_capacity_incoming AS
         SELECT
             nextval('id') AS index,
             t_high.*

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -12,8 +12,8 @@ function compute_constraints_indices(connection)
             :highest_in,
             :highest_out,
             :units_on_and_outflows,
-            :storage_level_intra_rp,
-            :storage_level_inter_rp,
+            :balance_storage_rep_period,
+            :balance_storage_over_clustered_year,
             :min_energy_over_clustered_year,
             :max_energy_over_clustered_year,
         )
@@ -148,14 +148,14 @@ function _create_constraints_tables(connection)
 
     DuckDB.query(
         connection,
-        "CREATE OR REPLACE TABLE cons_storage_level_intra_rp AS
+        "CREATE OR REPLACE TABLE cons_balance_storage_rep_period AS
         SELECT * FROM var_storage_level_intra_rp
         ",
     )
 
     DuckDB.query(
         connection,
-        "CREATE OR REPLACE TABLE cons_storage_level_inter_rp AS
+        "CREATE OR REPLACE TABLE cons_balance_storage_over_clustered_year AS
         SELECT * FROM var_storage_level_inter_rp
         ",
     )

--- a/src/constraints/energy.jl
+++ b/src/constraints/energy.jl
@@ -11,10 +11,10 @@ function add_energy_constraints!(model, constraints, graph)
     ## INTER-TEMPORAL CONSTRAINTS (between representative periods)
 
     # - Maximum outgoing energy within each period block
-    model[:max_energy_inter_rp] = [
+    model[:max_energy_over_clustered_year] = [
         @constraint(
             model,
-            constraints[:max_energy_inter_rp].expressions[:outgoing][row.index] ≤
+            constraints[:max_energy_over_clustered_year].expressions[:outgoing][row.index] ≤
             profile_aggregation(
                 sum,
                 graph[row.asset].timeframe_profiles,
@@ -24,15 +24,15 @@ function add_energy_constraints!(model, constraints, graph)
                 row.period_block_start:row.period_block_end,
                 1.0,
             ) * (graph[row.asset].max_energy_timeframe_partition[row.year]),
-            base_name = "max_energy_inter_rp_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
-        ) for row in eachrow(constraints[:max_energy_inter_rp].indices)
+            base_name = "max_energy_over_clustered_year_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
+        ) for row in eachrow(constraints[:max_energy_over_clustered_year].indices)
     ]
 
     # - Minimum outgoing energy within each period block
-    model[:min_energy_inter_rp] = [
+    model[:min_energy_over_clustered_year] = [
         @constraint(
             model,
-            constraints[:min_energy_inter_rp].expressions[:outgoing][row.index] ≥
+            constraints[:min_energy_over_clustered_year].expressions[:outgoing][row.index] ≥
             profile_aggregation(
                 sum,
                 graph[row.asset].timeframe_profiles,
@@ -42,7 +42,7 @@ function add_energy_constraints!(model, constraints, graph)
                 row.period_block_start:row.period_block_end,
                 1.0,
             ) * (graph[row.asset].min_energy_timeframe_partition[row.year]),
-            base_name = "min_energy_inter_rp_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
-        ) for row in eachrow(constraints[:min_energy_inter_rp].indices)
+            base_name = "min_energy_over_clustered_year_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
+        ) for row in eachrow(constraints[:min_energy_over_clustered_year].indices)
     ]
 end

--- a/src/constraints/hub.jl
+++ b/src/constraints/hub.jl
@@ -11,18 +11,18 @@ add_hub_constraints!(model,
 Adds the hub asset constraints to the model.
 """
 
-function add_hub_constraints!(model, constraints, sets)
-    Ah = sets[:Ah]
-    incoming_flow_highest_in_out_resolution = constraints[:highest_in_out].expressions[:incoming]
-    outgoing_flow_highest_in_out_resolution = constraints[:highest_in_out].expressions[:outgoing]
+function add_hub_constraints!(model, constraints)
+    cons = constraints[:balance_hub]
+    incoming_flow_highest_in_out_resolution = cons.expressions[:incoming]
+    outgoing_flow_highest_in_out_resolution = cons.expressions[:outgoing]
+
     # - Balance constraint (using the lowest temporal resolution)
-    df = filter(:asset => ∈(Ah), constraints[:highest_in_out].indices; view = true)
     model[:hub_balance] = [
         @constraint(
             model,
             incoming_flow_highest_in_out_resolution[row.index] ==
             outgoing_flow_highest_in_out_resolution[row.index],
             base_name = "hub_balance[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(df)
+        ) for row in eachrow(cons.indices)
     ]
 end

--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -19,13 +19,13 @@ function add_storage_constraints!(model, variables, constraints, graph)
 
     accumulated_energy_capacity = model[:accumulated_energy_capacity]
     incoming_flow_lowest_storage_resolution_intra_rp =
-        constraints[:storage_level_intra_rp].expressions[:incoming]
+        constraints[:balance_storage_rep_period].expressions[:incoming]
     outgoing_flow_lowest_storage_resolution_intra_rp =
-        constraints[:storage_level_intra_rp].expressions[:outgoing]
+        constraints[:balance_storage_rep_period].expressions[:outgoing]
     incoming_flow_storage_inter_rp_balance =
-        constraints[:storage_level_inter_rp].expressions[:incoming]
+        constraints[:balance_storage_over_clustered_year].expressions[:incoming]
     outgoing_flow_storage_inter_rp_balance =
-        constraints[:storage_level_inter_rp].expressions[:outgoing]
+        constraints[:balance_storage_over_clustered_year].expressions[:outgoing]
 
     # - Balance constraint (using the lowest temporal resolution)
     for ((a, y, rp), sub_df) in pairs(df_storage_intra_rp_balance_grouped)
@@ -146,7 +146,7 @@ function add_storage_constraints!(model, variables, constraints, graph)
                         )
                     end
                 ) +
-                constraints[:storage_level_inter_rp].expressions[:inflows_profile_aggregation][row.index] +
+                constraints[:balance_storage_over_clustered_year].expressions[:inflows_profile_aggregation][row.index] +
                 incoming_flow_storage_inter_rp_balance[row.index] -
                 outgoing_flow_storage_inter_rp_balance[row.index],
                 base_name = "storage_inter_rp_balance[$a,$(row.year),$(row.period_block_start):$(row.period_block_end)]"

--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -68,7 +68,7 @@ function add_storage_constraints!(model, variables, constraints, graph)
     # - Maximum storage level
     attach_constraint!(
         model,
-        constraints[:storage_level_intra_rp],
+        constraints[:balance_storage_rep_period],
         :max_storage_level_intra_rp_limit,
         [
             @constraint(
@@ -91,7 +91,7 @@ function add_storage_constraints!(model, variables, constraints, graph)
     # - Minimum storage level
     attach_constraint!(
         model,
-        constraints[:storage_level_intra_rp],
+        constraints[:balance_storage_rep_period],
         :min_storage_level_intra_rp_limit,
         [
             @constraint(
@@ -157,7 +157,7 @@ function add_storage_constraints!(model, variables, constraints, graph)
     # - Maximum storage level
     attach_constraint!(
         model,
-        constraints[:storage_level_inter_rp],
+        constraints[:balance_storage_over_clustered_year],
         :max_storage_level_inter_rp_limit,
         [
             @constraint(
@@ -180,7 +180,7 @@ function add_storage_constraints!(model, variables, constraints, graph)
     # - Minimum storage level
     attach_constraint!(
         model,
-        constraints[:storage_level_inter_rp],
+        constraints[:balance_storage_over_clustered_year],
         :min_storage_level_inter_rp_limit,
         [
             @constraint(

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -138,7 +138,7 @@ function create_model(
 
     @timeit to "add_hub_constraints!" add_hub_constraints!(model, constraints, sets)
 
-    @timeit to "add_conversion_constraints!" add_conversion_constraints!(model, constraints, sets)
+    @timeit to "add_conversion_constraints!" add_conversion_constraints!(model, constraints)
 
     @timeit to "add_transport_constraints!" add_transport_constraints!(
         model,

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -152,7 +152,7 @@ function create_model(
         )
     end
 
-    if !isempty(constraints[:units_on_and_outflows].indices)
+    if !isempty(constraints[:ramping_with_unit_commitment].indices)
         @timeit to "add_ramping_constraints!" add_ramping_constraints!(
             model,
             variables,

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -122,12 +122,7 @@ function create_model(
 
     @timeit to "add_energy_constraints!" add_energy_constraints!(model, constraints, graph)
 
-    @timeit to "add_consumer_constraints!" add_consumer_constraints!(
-        model,
-        constraints,
-        graph,
-        sets,
-    )
+    @timeit to "add_consumer_constraints!" add_consumer_constraints!(model, constraints, graph)
 
     @timeit to "add_storage_constraints!" add_storage_constraints!(
         model,
@@ -136,7 +131,7 @@ function create_model(
         graph,
     )
 
-    @timeit to "add_hub_constraints!" add_hub_constraints!(model, constraints, sets)
+    @timeit to "add_hub_constraints!" add_hub_constraints!(model, constraints)
 
     @timeit to "add_conversion_constraints!" add_conversion_constraints!(model, constraints)
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -468,14 +468,14 @@ function save_solution_to_file(output_folder, graph, solution)
     #
     # output_file = joinpath(output_folder, "max-energy-inter-rp.csv")
     # output_table =
-    #     DataFrames.select(dataframes[:max_energy_inter_rp], :asset, :periods_block => :period)
-    # output_table.value = solution.max_energy_inter_rp
+    #     DataFrames.select(dataframes[:max_energy_over_clustered_year], :asset, :periods_block => :period)
+    # output_table.value = solution.max_energy_over_clustered_year
     # output_table |> CSV.write(output_file)
     #
     # output_file = joinpath(output_folder, "min-energy-inter-rp.csv")
     # output_table =
-    #     DataFrames.select(dataframes[:min_energy_inter_rp], :asset, :periods_block => :period)
-    # output_table.value = solution.min_energy_inter_rp
+    #     DataFrames.select(dataframes[:min_energy_over_clustered_year], :asset, :periods_block => :period)
+    # output_table.value = solution.min_energy_over_clustered_year
     # output_table |> CSV.write(output_file)
 
     return

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -331,7 +331,7 @@ function add_expressions_to_constraints!(
     # Unpack variables
     # Creating the incoming and outgoing flow expressions
     @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
-        constraints[:lowest],
+        constraints[:balance_conversion],
         variables[:flow],
         expression_workspace,
         representative_periods,

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -348,8 +348,7 @@ function add_expressions_to_constraints!(
         use_highest_resolution = false,
         multiply_by_duration = true,
     )
-    @timeit to "add_expression_terms_intra_rp_constraints!"
-    add_expression_terms_intra_rp_constraints!(
+    @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
         constraints[:balance_consumer],
         variables[:flow],
         expression_workspace,
@@ -396,9 +395,9 @@ function add_expressions_to_constraints!(
         multiply_by_duration = false,
         add_min_outgoing_flow_duration = true,
     )
-    if !isempty(constraints[:units_on_and_outflows].indices)
+    if !isempty(constraints[:ramping_with_unit_commitment].indices)
         @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
-            constraints[:units_on_and_outflows],
+            constraints[:ramping_with_unit_commitment],
             variables[:flow],
             expression_workspace,
             representative_periods,
@@ -440,9 +439,9 @@ function add_expressions_to_constraints!(
         variables[:is_charging],
         expression_workspace,
     )
-    if !isempty(constraints[:units_on_and_outflows].indices)
+    if !isempty(constraints[:ramping_with_unit_commitment].indices)
         @timeit to "add_expression_units_on_terms_intra_rp_constraints!" add_expression_units_on_terms_intra_rp_constraints!(
-            constraints[:units_on_and_outflows],
+            constraints[:ramping_with_unit_commitment],
             variables[:units_on],
             expression_workspace,
         )

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -377,7 +377,17 @@ function add_expressions_to_constraints!(
         multiply_by_duration = false,
     )
     @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
-        constraints[:highest_out],
+        constraints[:capacity_outgoing],
+        variables[:flow],
+        expression_workspace,
+        representative_periods,
+        graph;
+        use_highest_resolution = true,
+        multiply_by_duration = false,
+        add_min_outgoing_flow_duration = true,
+    )
+    @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
+        constraints[:ramping_without_unit_commitment],
         variables[:flow],
         expression_workspace,
         representative_periods,
@@ -426,13 +436,20 @@ function add_expressions_to_constraints!(
         expression_workspace,
     )
     @timeit to "add_expression_is_charging_terms_intra_rp_constraints!" add_expression_is_charging_terms_intra_rp_constraints!(
-        constraints[:highest_out],
+        constraints[:capacity_outgoing],
         variables[:is_charging],
         expression_workspace,
     )
     if !isempty(constraints[:units_on_and_outflows].indices)
         @timeit to "add_expression_units_on_terms_intra_rp_constraints!" add_expression_units_on_terms_intra_rp_constraints!(
             constraints[:units_on_and_outflows],
+            variables[:units_on],
+            expression_workspace,
+        )
+    end
+    if !isempty(constraints[:ramping_without_unit_commitment].indices)
+        @timeit to "add_expression_units_on_terms_intra_rp_constraints!" add_expression_units_on_terms_intra_rp_constraints!(
+            constraints[:ramping_without_unit_commitment],
             variables[:units_on],
             expression_workspace,
         )

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -368,7 +368,7 @@ function add_expressions_to_constraints!(
         multiply_by_duration = false,
     )
     @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
-        constraints[:highest_in],
+        constraints[:capacity_incoming],
         variables[:flow],
         expression_workspace,
         representative_periods,
@@ -421,7 +421,7 @@ function add_expressions_to_constraints!(
         representative_periods,
     )
     @timeit to "add_expression_is_charging_terms_intra_rp_constraints!" add_expression_is_charging_terms_intra_rp_constraints!(
-        constraints[:highest_in],
+        constraints[:capacity_incoming],
         variables[:is_charging],
         expression_workspace,
     )

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -348,8 +348,18 @@ function add_expressions_to_constraints!(
         use_highest_resolution = false,
         multiply_by_duration = true,
     )
+    @timeit to "add_expression_terms_intra_rp_constraints!"
+    add_expression_terms_intra_rp_constraints!(
+        constraints[:balance_consumer],
+        variables[:flow],
+        expression_workspace,
+        representative_periods,
+        graph;
+        use_highest_resolution = true,
+        multiply_by_duration = false,
+    )
     @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
-        constraints[:highest_in_out],
+        constraints[:balance_hub],
         variables[:flow],
         expression_workspace,
         representative_periods,

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -407,14 +407,14 @@ function add_expressions_to_constraints!(
         is_storage_level = true,
     )
     @timeit to "add_expression_terms_inter_rp_constraints!" add_expression_terms_inter_rp_constraints!(
-        constraints[:max_energy_inter_rp],
+        constraints[:max_energy_over_clustered_year],
         variables[:flow],
         timeframe.map_periods_to_rp,
         graph,
         representative_periods,
     )
     @timeit to "add_expression_terms_inter_rp_constraints!" add_expression_terms_inter_rp_constraints!(
-        constraints[:min_energy_inter_rp],
+        constraints[:min_energy_over_clustered_year],
         variables[:flow],
         timeframe.map_periods_to_rp,
         graph,

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -340,7 +340,7 @@ function add_expressions_to_constraints!(
         multiply_by_duration = true,
     )
     @timeit to "add_expression_terms_intra_rp_constraints!" add_expression_terms_intra_rp_constraints!(
-        constraints[:storage_level_intra_rp],
+        constraints[:balance_storage_rep_period],
         variables[:flow],
         expression_workspace,
         representative_periods,
@@ -399,7 +399,7 @@ function add_expressions_to_constraints!(
         )
     end
     @timeit to "add_expression_terms_inter_rp_constraints!" add_expression_terms_inter_rp_constraints!(
-        constraints[:storage_level_inter_rp],
+        constraints[:balance_storage_over_clustered_year],
         variables[:flow],
         timeframe.map_periods_to_rp,
         graph,

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -48,14 +48,14 @@ function solve_model!(
     #     graph[a].storage_level_inter_rp[pb] = value
     # end
     #
-    # for row in eachrow(energy_problem.dataframes[:max_energy_inter_rp])
+    # for row in eachrow(energy_problem.dataframes[:max_energy_over_clustered_year])
     #     a, pb, value = row.asset, row.periods_block, row.solution
-    #     graph[a].max_energy_inter_rp[pb] = value
+    #     graph[a].max_energy_over_clustered_year[pb] = value
     # end
     #
-    # for row in eachrow(energy_problem.dataframes[:min_energy_inter_rp])
+    # for row in eachrow(energy_problem.dataframes[:max_energy_over_clustered_year])
     #     a, pb, value = row.asset, row.periods_block, row.solution
-    #     graph[a].min_energy_inter_rp[pb] = value
+    #     graph[a].max_energy_over_clustered_year[pb] = value
     # end
 
     for ((y, (u, v)), value) in energy_problem.solution.flows_investment
@@ -95,8 +95,8 @@ function solve_model!(model, args...; kwargs...)
     # dataframes[:flow].solution = solution.flow
     # dataframes[:storage_level_intra_rp].solution = solution.storage_level_intra_rp
     # dataframes[:storage_level_inter_rp].solution = solution.storage_level_inter_rp
-    # dataframes[:max_energy_inter_rp].solution = solution.max_energy_inter_rp
-    # dataframes[:min_energy_inter_rp].solution = solution.min_energy_inter_rp
+    # dataframes[:max_energy_over_clustered_year].solution = solution.max_energy_over_clustered_year
+    # dataframes[:min_energy_over_clustered_year].solution = solution.min_energy_over_clustered_year
 
     return solution
 end
@@ -191,8 +191,8 @@ function solve_model(
         Dict(k => JuMP.value(v) for (k, v) in variables[:flows_investment].lookup),
         JuMP.value.(variables[:storage_level_intra_rp].container),
         JuMP.value.(variables[:storage_level_inter_rp].container),
-        JuMP.value.(model[:max_energy_inter_rp]),
-        JuMP.value.(model[:min_energy_inter_rp]),
+        JuMP.value.(model[:max_energy_over_clustered_year]),
+        JuMP.value.(model[:min_energy_over_clustered_year]),
         JuMP.value.(variables[:flow].container),
         JuMP.objective_value(model),
         dual_variables,

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -212,8 +212,8 @@ mutable struct GraphAssetData
     investment_energy::Dict{Int,Float64} # for storage assets with energy method
     storage_level_intra_rp::Dict{Tuple{Int,TimestepsBlock},Float64}
     storage_level_inter_rp::Dict{PeriodsBlock,Float64}
-    max_energy_inter_rp::Dict{PeriodsBlock,Float64}
-    min_energy_inter_rp::Dict{PeriodsBlock,Float64}
+    max_energy_over_clustered_year::Dict{PeriodsBlock,Float64}
+    min_energy_over_clustered_year::Dict{PeriodsBlock,Float64}
 
     # You don't need profiles to create the struct, so initiate it empty
     function GraphAssetData(args...)
@@ -302,8 +302,8 @@ mutable struct Solution
     flows_investment::Any # TODO: Fix this type
     storage_level_intra_rp::Vector{Float64}
     storage_level_inter_rp::Vector{Float64}
-    max_energy_inter_rp::Vector{Float64}
-    min_energy_inter_rp::Vector{Float64}
+    max_energy_over_clustered_year::Vector{Float64}
+    min_energy_over_clustered_year::Vector{Float64}
     flow::Vector{Float64}
     objective_value::Float64
     duals::Union{Nothing,Dict{Symbol,Vector{Float64}}}

--- a/src/tmp.jl
+++ b/src/tmp.jl
@@ -459,6 +459,7 @@ function tmp_example_of_flow_expression_problem()
 
     ref: see $(@__FILE__):$(@__LINE__)
 
+    # TODO: This is outdated
     The desired incoming and outgoing flows are:
     - ep.dataframes[:highest_in_out].incoming_flow
     - ep.dataframes[:highest_in_out].outgoing_flow


### PR DESCRIPTION
Rename some of the constraints from Miro. Many other issues were created in #642 to handle the various edge cases and new tables, but this includes the main changes and, after merged, should allow other issues to be worked on, such as #960. 

- **Rename lowest to balance_conversion and limit to conversion asset type**
- **Split highest_in_out into balance_consumer and balance_hub**
- **Rename m.._energy_inter_rp to ..._over_clustered_year**
- **Rename storage constraints**
- **Rename constraint highest_in to capacity_incoming**
- **Rename constraint highest_out to capacity_outgoing and a copy to ramping_without_unit_commitment**
- **Rename units_on_and_outflows to ramping_with_unit_commitment**

Part of #642 
Closes #958 