### PR TITLE
Update TulipaConstraint to allow attaching more constraints to the same indices table

### DIFF
--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -244,26 +244,34 @@ function add_capacity_constraints!(model, variables, constraints, graph, sets)
 
     ## Capacity limit constraints (using the highest resolution)
     # - Maximum output flows limit
-    model[:max_output_flows_limit] = [
-        @constraint(
-            model,
-            outgoing_flow_highest_out_resolution[row.index] ≤
-            assets_profile_times_capacity_out[row.index],
-            base_name = "max_output_flows_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(constraints[:highest_out].indices) if
-        outgoing_flow_highest_out_resolution[row.index] != 0
-    ]
+    attach_constraint!(
+        model,
+        constraints[:highest_out],
+        :max_output_flows_limit,
+        [
+            @constraint(
+                model,
+                outgoing_flow_highest_out_resolution[row.index] ≤
+                assets_profile_times_capacity_out[row.index],
+                base_name = "max_output_flows_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+            ) for row in eachrow(constraints[:highest_out].indices)
+        ],
+    )
 
     # - Maximum input flows limit
-    model[:max_input_flows_limit] = [
-        @constraint(
-            model,
-            incoming_flow_highest_in_resolution[row.index] ≤
-            assets_profile_times_capacity_in[row.index],
-            base_name = "max_input_flows_limit[$(row.asset),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(constraints[:highest_in].indices) if
-        incoming_flow_highest_in_resolution[row.index] != 0
-    ]
+    attach_constraint!(
+        model,
+        constraints[:highest_in],
+        :max_input_flows_limit,
+        [
+            @constraint(
+                model,
+                incoming_flow_highest_in_resolution[row.index] ≤
+                assets_profile_times_capacity_in[row.index],
+                base_name = "max_input_flows_limit[$(row.asset),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+            ) for row in eachrow(constraints[:highest_in].indices)
+        ],
+    )
 
     ## Capacity limit constraints (using the highest resolution) for storage assets using binary to avoid charging and discharging at the same time
     # - Maximum output flows limit with is_charging binary for storage assets

--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -66,40 +66,50 @@ function add_storage_constraints!(model, variables, constraints, graph)
     end
 
     # - Maximum storage level
-    model[:max_storage_level_intra_rp_limit] = [
-        @constraint(
-            model,
-            storage_level_intra_rp.container[row.index] ≤
-            profile_aggregation(
-                Statistics.mean,
-                graph[row.asset].rep_periods_profiles,
-                row.year,
-                row.year,
-                ("max-storage-level", row.rep_period),
-                row.time_block_start:row.time_block_end,
-                1.0,
-            ) * accumulated_energy_capacity[row.year, row.asset],
-            base_name = "max_storage_level_intra_rp_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(storage_level_intra_rp.indices)
-    ]
+    attach_constraint!(
+        model,
+        constraints[:storage_level_intra_rp],
+        :max_storage_level_intra_rp_limit,
+        [
+            @constraint(
+                model,
+                storage_level_intra_rp.container[row.index] ≤
+                profile_aggregation(
+                    Statistics.mean,
+                    graph[row.asset].rep_periods_profiles,
+                    row.year,
+                    row.year,
+                    ("max-storage-level", row.rep_period),
+                    row.time_block_start:row.time_block_end,
+                    1.0,
+                ) * accumulated_energy_capacity[row.year, row.asset],
+                base_name = "max_storage_level_intra_rp_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+            ) for row in eachrow(storage_level_intra_rp.indices)
+        ],
+    )
 
     # - Minimum storage level
-    model[:min_storage_level_intra_rp_limit] = [
-        @constraint(
-            model,
-            storage_level_intra_rp.container[row.index] ≥
-            profile_aggregation(
-                Statistics.mean,
-                graph[row.asset].rep_periods_profiles,
-                row.year,
-                row.year,
-                ("min_storage_level", row.rep_period),
-                row.time_block_start:row.time_block_end,
-                0.0,
-            ) * accumulated_energy_capacity[row.year, row.asset],
-            base_name = "min_storage_level_intra_rp_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-        ) for row in eachrow(storage_level_intra_rp.indices)
-    ]
+    attach_constraint!(
+        model,
+        constraints[:storage_level_intra_rp],
+        :min_storage_level_intra_rp_limit,
+        [
+            @constraint(
+                model,
+                storage_level_intra_rp.container[row.index] ≥
+                profile_aggregation(
+                    Statistics.mean,
+                    graph[row.asset].rep_periods_profiles,
+                    row.year,
+                    row.year,
+                    ("min_storage_level", row.rep_period),
+                    row.time_block_start:row.time_block_end,
+                    0.0,
+                ) * accumulated_energy_capacity[row.year, row.asset],
+                base_name = "min_storage_level_intra_rp_limit[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+            ) for row in eachrow(storage_level_intra_rp.indices)
+        ],
+    )
 
     # - Cycling condition
     for ((a, y, _), sub_df) in pairs(df_storage_intra_rp_balance_grouped)
@@ -145,40 +155,50 @@ function add_storage_constraints!(model, variables, constraints, graph)
     end
 
     # - Maximum storage level
-    model[:max_storage_level_inter_rp_limit] = [
-        @constraint(
-            model,
-            storage_level_inter_rp.container[row.index] ≤
-            profile_aggregation(
-                Statistics.mean,
-                graph[row.asset].timeframe_profiles,
-                row.year,
-                row.year,
-                "max_storage_level",
-                row.period_block_start:row.period_block_end,
-                1.0,
-            ) * accumulated_energy_capacity[row.year, row.asset],
-            base_name = "max_storage_level_inter_rp_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
-        ) for row in eachrow(storage_level_inter_rp.indices)
-    ]
+    attach_constraint!(
+        model,
+        constraints[:storage_level_inter_rp],
+        :max_storage_level_inter_rp_limit,
+        [
+            @constraint(
+                model,
+                storage_level_inter_rp.container[row.index] ≤
+                profile_aggregation(
+                    Statistics.mean,
+                    graph[row.asset].timeframe_profiles,
+                    row.year,
+                    row.year,
+                    "max_storage_level",
+                    row.period_block_start:row.period_block_end,
+                    1.0,
+                ) * accumulated_energy_capacity[row.year, row.asset],
+                base_name = "max_storage_level_inter_rp_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
+            ) for row in eachrow(storage_level_inter_rp.indices)
+        ],
+    )
 
     # - Minimum storage level
-    model[:min_storage_level_inter_rp_limit] = [
-        @constraint(
-            model,
-            storage_level_inter_rp.container[row.index] ≥
-            profile_aggregation(
-                Statistics.mean,
-                graph[row.asset].timeframe_profiles,
-                row.year,
-                row.year,
-                "min_storage_level",
-                row.period_block_start:row.period_block_end,
-                0.0,
-            ) * accumulated_energy_capacity[row.year, row.asset],
-            base_name = "min_storage_level_inter_rp_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
-        ) for row in eachrow(storage_level_inter_rp.indices)
-    ]
+    attach_constraint!(
+        model,
+        constraints[:storage_level_inter_rp],
+        :min_storage_level_inter_rp_limit,
+        [
+            @constraint(
+                model,
+                storage_level_inter_rp.container[row.index] ≥
+                profile_aggregation(
+                    Statistics.mean,
+                    graph[row.asset].timeframe_profiles,
+                    row.year,
+                    row.year,
+                    "min_storage_level",
+                    row.period_block_start:row.period_block_end,
+                    0.0,
+                ) * accumulated_energy_capacity[row.year, row.asset],
+                base_name = "min_storage_level_inter_rp_limit[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
+            ) for row in eachrow(storage_level_inter_rp.indices)
+        ],
+    )
 
     # - Cycling condition
     for ((a, y), sub_df) in pairs(df_storage_inter_rp_balance_grouped)

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -49,7 +49,7 @@ function add_expression_terms_intra_rp_constraints!(
     num_rows = size(cons.indices, 1)
 
     for case in cases
-        cons.expressions[case.expr_key] = Vector{JuMP.AffExpr}(undef, num_rows)
+        attach_expression!(cons, case.expr_key, Vector{JuMP.AffExpr}(undef, num_rows))
         cons.expressions[case.expr_key] .= JuMP.AffExpr(0.0)
         conditions_to_add_min_outgoing_flow_duration =
             add_min_outgoing_flow_duration && case.expr_key == :outgoing

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -94,7 +94,9 @@ function attach_constraint!(
 end
 
 function attach_constraint!(model::JuMP.Model, cons::TulipaConstraint, name::Symbol, container)
-    # This should be the empty case container = Any[]
+    # This should be the empty case container = Any[] that happens when the
+    # indices table in empty in [@constraint(...) for row in eachrow(indices)].
+    # It resolves to [] so the element type cannot be inferred
     @assert length(container) == 0
     @assert cons.num_rows == 0
     empty_container = JuMP.ConstraintRef{JuMP.Model,Missing,JuMP.ScalarShape}[]

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -100,7 +100,9 @@ function attach_constraint!(model::JuMP.Model, cons::TulipaConstraint, name::Sym
     # indices table in empty in [@constraint(...) for row in eachrow(indices)].
     # It resolves to [] so the element type cannot be inferred
     if length(container) > 0
-        error("This variant is supposed to capture empty containers. This container is not empty for $name")
+        error(
+            "This variant is supposed to capture empty containers. This container is not empty for $name",
+        )
     end
     if cons.num_rows > 0
         error("The number of rows in indices table should be 0 for $name")

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -100,7 +100,7 @@ function attach_constraint!(model::JuMP.Model, cons::TulipaConstraint, name::Sym
     # indices table in empty in [@constraint(...) for row in eachrow(indices)].
     # It resolves to [] so the element type cannot be inferred
     if length(container) > 0
-        error("This variant is supposed to capture empty containers. This container is not empty")
+        error("This variant is supposed to capture empty containers. This container is not empty for $name")
     end
     if cons.num_rows > 0
         error("The number of rows in indices table should be 0")

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -119,7 +119,7 @@ This checks that the `container` length matches the stored `indices` number of r
 """
 function attach_expression!(cons::TulipaConstraint, name::Symbol, container::Vector{JuMP.AffExpr})
     if length(container) != cons.num_rows
-        error("The number of expressions does not match the number of rows in the indices")
+        error("The number of expressions does not match the number of rows in the indices of $name")
     end
     cons.expressions[name] = container
     return nothing

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -103,7 +103,7 @@ function attach_constraint!(model::JuMP.Model, cons::TulipaConstraint, name::Sym
         error("This variant is supposed to capture empty containers. This container is not empty for $name")
     end
     if cons.num_rows > 0
-        error("The number of rows in indices table should be 0")
+        error("The number of rows in indices table should be 0 for $name")
     end
     empty_container = JuMP.ConstraintRef{JuMP.Model,Missing,JuMP.ScalarShape}[]
     model[name] = empty_container

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -88,7 +88,7 @@ function attach_constraint!(
     container::Vector{<:JuMP.ConstraintRef},
 )
     if length(container) != cons.num_rows
-        error("The number of constraints does not match the number of rows in the indices")
+        error("The number of constraints does not match the number of rows in the indices of $name")
     end
     push!(cons.constraint_names, name)
     model[name] = container

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -110,21 +110,22 @@ Attach a expression named `name` stored in `container`, and optionally set `mode
 This checks that the `container` length matches the stored `indices` number of rows.
 """
 function attach_expression!(cons::TulipaConstraint, name::Symbol, container::Vector{JuMP.AffExpr})
-    @assert length(container) = cons.num_rows
+    @assert length(container) == cons.num_rows
     cons.expressions[name] = container
     return nothing
 end
 
-function attach_expression!(
-    cons::TulipaConstraint,
-    name::Symbol,
-    container::Vector{JuMP.AffExpr},
-    model::JuMP.Model,
-)
-    attach_expression!(cons, name, container)
-    model[name] = container
-    return nothing
-end
+# Not used at the moment, but might be useful by the end of #642
+# function attach_expression!(
+#     model::JuMP.Model,
+#     cons::TulipaConstraint,
+#     name::Symbol,
+#     container::Vector{JuMP.AffExpr},
+# )
+#     attach_expression!(cons, name, container)
+#     model[name] = container
+#     return nothing
+# end
 
 """
 Structure to hold the data of one representative period.

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -87,7 +87,9 @@ function attach_constraint!(
     name::Symbol,
     container::Vector{<:JuMP.ConstraintRef},
 )
-    @assert length(container) == cons.num_rows
+    if length(container) != cons.num_rows
+        error("The number of constraints does not match the number of rows in the indices")
+    end
     push!(cons.constraint_names, name)
     model[name] = container
     return nothing
@@ -97,8 +99,12 @@ function attach_constraint!(model::JuMP.Model, cons::TulipaConstraint, name::Sym
     # This should be the empty case container = Any[] that happens when the
     # indices table in empty in [@constraint(...) for row in eachrow(indices)].
     # It resolves to [] so the element type cannot be inferred
-    @assert length(container) == 0
-    @assert cons.num_rows == 0
+    if length(container) > 0
+        error("This variant is supposed to capture empty containers. This container is not empty")
+    end
+    if cons.num_rows > 0
+        error("The number of rows in indices table should be 0")
+    end
     empty_container = JuMP.ConstraintRef{JuMP.Model,Missing,JuMP.ScalarShape}[]
     model[name] = empty_container
     return nothing

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -85,8 +85,8 @@ function attach_constraint!(
     model::JuMP.Model,
     cons::TulipaConstraint,
     name::Symbol,
-    container::Vector{JuMP.ConstraintRef{JuMP.Model,T1,T2}},
-) where {T1,T2}
+    container::Vector{<:JuMP.ConstraintRef},
+)
     @assert length(container) == cons.num_rows
     push!(cons.constraint_names, name)
     model[name] = container

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -118,7 +118,9 @@ Attach a expression named `name` stored in `container`, and optionally set `mode
 This checks that the `container` length matches the stored `indices` number of rows.
 """
 function attach_expression!(cons::TulipaConstraint, name::Symbol, container::Vector{JuMP.AffExpr})
-    @assert length(container) == cons.num_rows
+    if length(container) != cons.num_rows
+        error("The number of expressions does not match the number of rows in the indices")
+    end
     cons.expressions[name] = container
     return nothing
 end


### PR DESCRIPTION
With the idea of allowing multiple constraints per indices table, this links the indices to the constraints. It also creates a function `attach_constraint!` to help keep things in check.

It fails the [avoid fields with abstract types](https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-fields-with-abstract-type) recommendation (`ConstraintRef` has three parametric types), so it might be unnecessarily slow.
I see two solutions:

1. Don't store the container at all, just the names. This is probably sufficient and cleaner.
2. Store the multiple types that ConstraintRef can have, either with multiple fields, dict of dicts, or more complicated structures. I don't like this idea because it makes the code more complex and involves more JuMP specific things. However, if the container for the containers is required, this is necessary (but so I far I don't see it being required).

EDIT: I added a commit with option 1 implemented.

@datejada, what do you think?

Closes #957