### PR TITLE
Remove most of graph from src/constraints/capacity.jl

### DIFF
--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -32,7 +32,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
     ## Expressions used by capacity constraints
     # - Create capacity limit for outgoing flows
     let table_name = :capacity_outgoing, cons = constraints[table_name]
-        indices = _append_data_to_indices(connection, table_name)
+        indices = _append_capacity_data_to_indices(connection, table_name)
         attach_expression!(
             cons,
             :profile_times_capacity,
@@ -81,7 +81,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
     let table_name = :capacity_outgoing_non_investable_storage_with_binary,
         cons = constraints[table_name]
 
-        indices = _append_data_to_indices(connection, table_name)
+        indices = _append_capacity_data_to_indices(connection, table_name)
 
         attach_expression!(
             cons,
@@ -110,7 +110,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
     let table_name = :capacity_outgoing_investable_storage_with_binary,
         cons = constraints[table_name]
 
-        indices = _append_data_to_indices(connection, table_name)
+        indices = _append_capacity_data_to_indices(connection, table_name)
 
         attach_expression!(
             cons,
@@ -165,7 +165,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
 
     # - Create capacity limit for incoming flows
     let table_name = :capacity_incoming, cons = constraints[table_name]
-        indices = _append_data_to_indices(connection, table_name)
+        indices = _append_capacity_data_to_indices(connection, table_name)
         attach_expression!(
             cons,
             :profile_times_capacity,
@@ -193,7 +193,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
     let table_name = :capacity_incoming_non_investable_storage_with_binary,
         cons = constraints[table_name]
 
-        indices = _append_data_to_indices(connection, table_name)
+        indices = _append_capacity_data_to_indices(connection, table_name)
 
         attach_expression!(
             cons,
@@ -222,7 +222,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
     let table_name = :capacity_incoming_investable_storage_with_binary,
         cons = constraints[table_name]
 
-        indices = _append_data_to_indices(connection, table_name)
+        indices = _append_capacity_data_to_indices(connection, table_name)
 
         attach_expression!(
             cons,
@@ -372,7 +372,7 @@ function add_capacity_constraints!(connection, model, variables, constraints, pr
     end
 end
 
-function _append_data_to_indices(connection, table_name)
+function _append_capacity_data_to_indices(connection, table_name)
     return DuckDB.query(
         connection,
         "SELECT

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -107,9 +107,11 @@ function create_model(
     # TODO: Pass sets instead of the explicit values
     ## Constraints
     @timeit to "add_capacity_constraints!" add_capacity_constraints!(
+        connection,
         model,
         variables,
         constraints,
+        profiles,
         graph,
         sets,
     )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,7 +117,7 @@ function profile_aggregation(agg, profiles, year, commission_year, key, block, d
 end
 
 function _profile_aggregate(profiles, tuple_key, time_block, agg_function, default_value)
-    if !haskey(profiles, tuple_key)
+    if any(ismissing, tuple_key) || !haskey(profiles, tuple_key)
         return agg_function(Iterators.repeated(default_value, length(time_block)))
     end
     profile_value = profiles[tuple_key]


### PR DESCRIPTION
- **Move part of capacity.jl to new profile**
- **Avoid using graph in src/constraints/capacity.jl**

Almost closes #947 - we have to remove `graph` from the profile used in the compact expression, which is not trivial, so best left for next year.