### PR TITLE
Remove graph from src/constraints/ramping-and-unit-commitment.jl

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -162,10 +162,11 @@ function create_model(
 
     if !isempty(constraints[:ramping_with_unit_commitment].indices)
         @timeit to "add_ramping_constraints!" add_ramping_constraints!(
+            connection,
             model,
             variables,
             constraints,
-            graph,
+            profiles,
             sets,
         )
     end


### PR DESCRIPTION
Blocked by #978 and #979 

- Create a field coefficients in TulipaConstraint to allow attaching numeric columns to constraints without modifying the DuckDB table.
- Remove graph from src/constraints/ramping-and-unit-commitment.jl

Part of #942 