### PR TITLE
Remove need for representative_periods and graph in add_expression_terms_rep_period_constraints

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -72,6 +72,7 @@ function create_model(
     ## Add expressions to dataframes
     # TODO: What will improve this? Variables (#884)?, Constraints?
     @timeit to "add_expressions_to_constraints!" add_expressions_to_constraints!(
+        connection,
         variables,
         constraints,
         model,

--- a/src/io.jl
+++ b/src/io.jl
@@ -32,7 +32,7 @@ function create_internal_structures(connection)
         "profiles_timeframe"
     ]
     for table in tables_allowed_to_be_missing
-        _check_if_table_exist(connection, table)
+        _create_empty_unless_exists(connection, table)
     end
 
     # Get the years struct ordered by year
@@ -305,18 +305,14 @@ function get_schema(tablename)
     end
 end
 
-function _check_if_table_exist(connection, table_name)
+function _create_empty_unless_exists(connection, table_name)
     schema = get_schema(table_name)
 
-    existence_query = DBInterface.execute(
-        connection,
-        "SELECT table_name FROM information_schema.tables WHERE table_name = '$table_name'",
-    )
-    if length(collect(existence_query)) == 0
+    if !_check_if_table_exists(connection, table_name)
         columns_in_table = join(("$col $col_type" for (col, col_type) in schema), ",")
-        create_table_query =
-            DuckDB.query(connection, "CREATE TABLE $table_name ($columns_in_table)")
+        DuckDB.query(connection, "CREATE TABLE $table_name ($columns_in_table)")
     end
+
     return
 end
 

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -85,9 +85,9 @@ function add_expression_terms_rep_period_constraints!(
                 cons.asset,
                 cons.year,
                 cons.rep_period,
-                ARRAY_AGG(cons.index) AS index,
-                ARRAY_AGG(cons.time_block_start) AS time_block_start,
-                ARRAY_AGG(cons.time_block_end) AS time_block_end,
+                ARRAY_AGG(cons.index ORDER BY cons.index) AS index,
+                ARRAY_AGG(cons.time_block_start ORDER BY cons.index) AS time_block_start,
+                ARRAY_AGG(cons.time_block_end ORDER BY cons.index) AS time_block_end,
             FROM $(cons.table_name) AS cons
             GROUP BY cons.asset, cons.year, cons.rep_period
             ",
@@ -121,10 +121,10 @@ function add_expression_terms_rep_period_constraints!(
                     var.$(case.asset_match) AS asset,
                     var.year,
                     var.rep_period,
-                    ARRAY_AGG(var.index) AS index,
-                    ARRAY_AGG(var.time_block_start) AS time_block_start,
-                    ARRAY_AGG(var.time_block_end) AS time_block_end,
-                    ARRAY_AGG(var.efficiency) AS efficiency,
+                    ARRAY_AGG(var.index ORDER BY var.index) AS index,
+                    ARRAY_AGG(var.time_block_start ORDER BY var.index) AS time_block_start,
+                    ARRAY_AGG(var.time_block_end ORDER BY var.index) AS time_block_end,
+                    ARRAY_AGG(var.efficiency ORDER BY var.index) AS efficiency,
                 FROM $(flow.table_name) AS var
                 GROUP BY var.$(case.asset_match), var.year, var.rep_period
                 ",

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,13 @@
 # Auxiliary functions to create the model
 
+function _check_if_table_exists(connection, table_name)
+    existence_query = DBInterface.execute(
+        connection,
+        "SELECT table_name FROM information_schema.tables WHERE table_name = '$table_name'",
+    )
+    return length(collect(existence_query)) > 0
+end
+
 # FIXME: Ugly hack applied
 """
     is_active(graph, a, y)


### PR DESCRIPTION
Remove graph and representative_periods from add_expression_terms_rep_period_constraints.
Refactor the function to use the DuckDB tables instead of the DataFrames. 

This now uses DuckDB to compute the groups and the intersection. The type instability made the code a bit slower so to improve, we have to manually specify the types of some outputs with `::Type`. This made the code faster than it was before!

## Related issues

Part of #942

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- ~~Docs were updated and workflow is passing~~
