### PR TITLE
[docs]: prepare documentation for release 0.11.0

### DIFF
--- a/docs/src/10-how-to-use.md
+++ b/docs/src/10-how-to-use.md
@@ -64,6 +64,9 @@ You can also check the [`test/inputs` folder](https://github.com/TulipaEnergy/Tu
 
 ### [CSV Files](@id csv-files)
 
+!!! danger
+    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
+
 Below, we have a description of the files.
 At the end, in [Schemas](@ref schemas), we have the expected columns in these CSVs.
 
@@ -205,6 +208,9 @@ Markdown.parse(
 
 ## [Structures](@id structures)
 
+!!! danger
+    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
+
 The list of relevant structures used in this package are listed below:
 
 ### EnergyProblem
@@ -214,7 +220,7 @@ It hides the complexity behind the energy problem, making the usage more friendl
 
 #### Fields
 
-- `graph`: The [Graph](@ref) object that defines the geometry of the energy problem.
+- `graph`: The Graph object that defines the geometry of the energy problem.
 - `representative_periods`: A vector of [Representative Periods](@ref representative-periods).
 - `constraints_partitions`: Dictionaries that connect pairs of asset and representative periods to [time partitions](@ref Partition) (vectors of time blocks).
 - `timeframe`: The number of periods in the `representative_periods`.
@@ -237,30 +243,16 @@ The `EnergyProblem` can also be constructed using the minimal constructor below.
 
 See the [basic example tutorial](@ref basic-example) to see how these can be used.
 
-### Graph
-
-The energy problem is defined using a graph.
-Each vertex is an asset, and each edge is a flow.
-
-We use [MetaGraphsNext.jl](https://github.com/JuliaGraphs/MetaGraphsNext.jl) to define the graph and its objects.
-Using MetaGraphsNext we can define a graph with metadata, i.e., associate data with each asset and flow.
-Furthermore, we can define the labels of each asset as keys to access the elements of the graph.
-The assets in the graph are of type [GraphAssetData](@ref), and the flows are of type [GraphFlowData](@ref).
-
-The graph can be created using the [`create_internal_structures`](@ref) function, or it can be accessed from an [EnergyProblem](@ref).
-
-See how to use the graph in the [graph tutorial](@ref graph-tutorial).
-
 ### GraphAssetData
 
 This structure holds all the information of a given asset.
-These are stored inside the [Graph](@ref).
+These are stored inside the Graph.
 Given a graph `graph`, an asset `a` can be accessed through `graph[a]`.
 
 ### GraphFlowData
 
 This structure holds all the information of a given flow.
-These are stored inside the [Graph](@ref).
+These are stored inside the Graph.
 Given a graph `graph`, a flow from asset `u` to asset `v` can be accessed through `graph[u, v]`.
 
 ### Partition
@@ -294,20 +286,6 @@ A representative period has three fields:
 
 The number of timesteps and resolution work together to define the coarseness of the period.
 Nothing is defined outside of these timesteps; for instance, if the representative period represents a day and you want to specify a variable or constraint with a coarseness of 30 minutes. You need to define the number of timesteps to 48 and the resolution to `0.5`.
-
-### Solution
-
-The solution object `energy_problem.solution` is a mutable struct with the following fields:
-
-- `assets_investment[a]`: The investment for each asset, indexed on the investable asset `a`.
-- `flows_investment[u, v]`: The investment for each flow, indexed on the investable flow `(u, v)`.
-- `storage_level_rep_period[a, rp, timesteps_block]`: The storage level for the storage asset `a` within (intra) a representative period `rp` and a time block `timesteps_block`. The list of time blocks is defined by `constraints_partitions`, which was used to create the model.
-- `storage_level_over_clustered_year[a, periods_block]`: The storage level for the storage asset `a` between (inter) representative periods in the periods block `periods_block`.
-- `flow[(u, v), rp, timesteps_block]`: The flow value for a given flow `(u, v)` at a given representative period `rp`, and time block `timesteps_block`. The list of time blocks is defined by `graph[(u, v)].partitions[rp]`.
-- `objective_value`: A Float64 with the objective value at the solution.
-- `duals`: A Dictionary containing the dual variables of selected constraints.
-
-Check the [tutorial](@ref solution-tutorial) for tips on manipulating the solution.
 
 ### [Time Blocks](@id time-blocks)
 
@@ -479,9 +457,9 @@ In the given data, there are two groups: `renewables` and `ccgt`. Both groups ha
 Let's now explore which assets are in each group. To do so, we can take a look at the graph-assets-data.csv file:
 
 ```@example display-group-setup
-input_asset_file = "../../test/inputs/Norse/graph-assets-data.csv" # hide
-assets = CSV.read(input_asset_file, DataFrame, header = 1) # hide
-assets = assets[.!ismissing.(assets.group), [:name, :type, :group]] # hide
+input_asset_file = "../../test/inputs/Norse/asset.csv" # hide
+assets = CSV.read(input_asset_file, DataFrame) # hide
+assets = assets[.!ismissing.(assets.group), [:asset, :type, :group]] # hide
 ```
 
 Here we can see that the assets `Asgard_Solar` and `Midgard_Wind` belong to the `renewables` group, while the assets `Asgard_CCGT` and `Midgard_CCGT` belong to the `ccgt` group.
@@ -490,6 +468,9 @@ Here we can see that the assets `Asgard_Solar` and `Midgard_Wind` belong to the 
 > If the group has a `min_investment_limit`, then assets in the group have to allow investment (`investable = true`) for the model to be feasible. If the assets are not `investable` then they cannot satisfy the minimum constraint.
 
 ## [Setting up multi-year investments](@id multi-year-setup)
+
+!!! danger
+    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
 
 It is possible to simutaneously model different years, which is especially relevant for modeling multi-year investments. Multi-year investments refer to making investment decisions at different points in time, such that a pathway of investments can be modeled. This is particularly useful when long-term scenarios are modeled, but modeling each year is not practical. Or in a business case, investment decisions are supposed to be made in different years which has an impact on the cash flow.
 
@@ -537,9 +518,9 @@ In order to set up a model with year information, the following steps are necess
     ```@example multi-year-setup
     using DataFrames # hide
     using CSV # hide
-    input_asset_file = "../../test/inputs/Multi-year Investments/assets-data.csv" # hide
-    assets_data = CSV.read(input_asset_file, DataFrame, header = 1) # hide
-    assets_data = assets_data[1:10, [:name, :year, :commission_year, :investable, :initial_units]] # hide
+    input_asset_file = "../../test/inputs/Multi-year Investments/asset-both.csv" # hide
+    assets_data = CSV.read(input_asset_file, DataFrame) # hide
+    assets_data = assets_data[1:10, [:asset, :milestone_year, :commission_year, :initial_units]] # hide
     ```
 
     We allow investments of `ocgt`, `ccgt`, `battery`, `wind`, and `solar` in 2030.

--- a/docs/src/10-how-to-use.md
+++ b/docs/src/10-how-to-use.md
@@ -36,7 +36,7 @@ julia> using TulipaEnergyModel
 
 ### (Optional) Running automatic tests
 
-It is nice to check that tests are passing to make sure your environment is working. (This takes a minute or two.)
+It is nice to check that tests are passing to make sure your environment is working, this takes a minute or two.
 
 - Enter package mode (press "]")
 
@@ -45,6 +45,9 @@ pkg> test TulipaEnergyModel
 ```
 
 All tests should pass.
+
+!!! warning "Admin rights in your local machine"
+    Ensure you have admin rights on the folder where the package is installed; otherwise, an error will appear during the tests.
 
 ## Running a Scenario
 
@@ -57,256 +60,22 @@ The `connection` should have been created and the data loaded into it using [Tul
 See the [tutorials](@ref tutorials) for a complete guide on how to achieve this.
 The `output_folder` is optional if the user wants to export the output.
 
-## [Input](@id input)
+### [Input](@id input)
 
-Currently, we only accept input from [CSV files](@ref csv-files) that follow the [Schemas](@ref schemas).
-You can also check the [`test/inputs` folder](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/tree/main/test/inputs) for examples.
+Currently, we only accept input from CSV files that follow the [Schemas](@ref schemas).
 
-### [CSV Files](@id csv-files)
+You can also check the [`test/inputs` folder](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/tree/main/test/inputs) for examples of different predefined energy systems and features. Moreover, Tulipa's Offshore Bidding Zone Case Study can be found in <https://github.com/TulipaEnergy/Tulipa-OBZ-CaseStudy>. It shows how to start from user-friendly files and transform the data into the input files in the [Schemas](@ref schemas) through different functions.
 
-!!! danger
-    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
+### Writing the output to CSV
 
-Below, we have a description of the files.
-At the end, in [Schemas](@ref schemas), we have the expected columns in these CSVs.
-
-> **Tip:**
-> If you modify CSV files and want to see your modifications, the normal `git diff` command will not be informative.
-> Instead, you can use
->
-> ```bash
-> git diff --word-diff-regex="[^[:space:],]+"
-> ```
->
-> to make `git` treat the `,` as word separators.
-> You can also compare two CSV files with
->
-> ```bash
-> git diff --no-index --word-diff-regex="[^[:space:],]+" file1 file2
-> ```
-
-#### [`graph-assets-data.csv`](@id graph-assets-data)
-
-This file contains the list of assets and the static data associated with each of them.
-
-The meaning of `Missing` data depends on the parameter, for instance:
-
-- `group`: No group assigned to the asset.
-
-#### [`graph-flows-data.csv`](@id graph-flows-data)
-
-The same as [`graph-assets-data.csv`](@ref graph-assets-data), but for flows. Each flow is defined as a pair of assets.
-
-#### [`assets-data.csv`](@id assets-data)
-
-This file contains the yearly data of each asset.
-
-The investment parameters are as follows:
-
-- The `investable` parameter determines whether there is an investment decision for the asset or flow.
-- The `investment_integer` parameter determines if the investment decision is integer or continuous.
-- The `investment_cost` parameter represents the cost in the defined [timeframe](@ref timeframe). Thus, if the timeframe is a year, the investment cost is the annualized cost of the asset.
-- The `investment_limit` parameter limits the total investment capacity of the asset or flow. This limit represents the potential of that particular asset or flow. Without data in this parameter, the model assumes no investment limit.
-
-The meaning of `Missing` data depends on the parameter, for instance:
-
-- `investment_limit`: There is no investment limit.
-- `initial_storage_level`: The initial storage level is free (between the storage level limits), meaning that the optimization problem decides the best starting point for the storage asset. In addition, the first and last time blocks in a representative period are linked to create continuity in the storage level.
-
-#### [`flows-data.csv`](@id flows-data)
-
-The same as [`assets-data.csv`](@ref assets-data), but for flows. Each flow is defined as a pair of assets.
-
-The meaning of `Missing` data depends on the parameter, for instance:
-
-- `investment_limit`: There is no investment limit.
-
-#### [`assets-profiles.csv`] (@id assets-profiles-definition)
-
-These files contain information about assets and their associated profiles. Each row lists an asset, the type of profile (e.g., availability, demand, maximum or minimum storage level), and the profile's name.
-These profiles are used in the [intra-temporal constraints](@ref concepts-summary).
-
-#### [`flows-profiles.csv`](@id flows-profiles-definition)
-
-This file contains information about flows and their representative period profiles for intra-temporal constraints. Each flow is defined as a pair of assets.
-
-#### [`rep-periods-data.csv`](@id rep-periods-data)
-
-Describes the [representative periods](@ref representative-periods) by their unique ID, the number of timesteps per representative period, and the resolution per timestep. Note that in the test files the resolution units are given as hours for understandability, but the resolution is technically unitless.
-
-#### [`rep-periods-mapping.csv`](@id rep-periods-mapping)
-
-Describes the periods of the [timeframe](@ref timeframe) that map into a [representative period](@ref representative-periods) and the weight of the representative periods that construct a period. Note that each weight is a decimal between 0 and 1, and that the sum of weights for a given period must also be between 0 and 1 (but do not have to sum to 1).
-
-#### `profiles-rep-periods.csv`
-
-Define all the profiles for the `rep-periods`.
-The `profile_name` is a unique identifier, the `period` and `value` define the profile, and the `rep_period` field informs the representative period.
-
-The profiles are linked to assets and flows in the files [`assets-profiles`](@ref assets-profiles-definition), [`assets-timeframe-profiles`](@ref assets-profiles-definition), and [`flows-profiles`](@ref flows-profiles-definition).
-
-#### `assets-timeframe-profiles.csv`
-
-Like the [`assets-profiles.csv`](@ref assets-profiles-definition), but for the [inter-temporal constraints](@ref concepts-summary).
-
-#### `group-asset.csv` (optional)
-
-This file contains the list of groups and the methods that apply to each group, along with their respective parameters.
-
-#### `profiles-timeframe.csv` (optional)
-
-Define all the profiles for the `timeframe`.
-This is similar to the [`profiles-rep-periods.csv`](@ref) except that it doesn't have a `rep-period` field and if this is not passed, default values are used in the timeframe constraints.
-
-#### [`assets-rep-periods-partitions.csv` (optional)](@id assets-rep-periods-partitions-definition)
-
-Contains a description of the [partition](@ref Partition) for each asset with respect to representative periods.
-If not specified, each asset will have the same time resolution as the representative period, which is hourly by default.
-
-There are currently three ways to specify the desired resolution, indicated in the column `specification`.
-The column `partition` serves to define the partitions in the specified style.
-
-- `specification = uniform`: Set the resolution to a uniform amount, i.e., a time block is made of `X` timesteps. The number `X` is defined in the column `partition`. The number of timesteps in the representative period must be divisible by `X`.
-- `specification = explicit`: Set the resolution according to a list of numbers separated by `;` on the `partition`. Each number in the list is the number of timesteps for that time block. For instance, `2;3;4` means that there are three time blocks, the first has 2 timesteps, the second has 3 timesteps, and the last has 4 timesteps. The sum of the list must be equal to the total number of timesteps in that representative period, as specified in `num_timesteps` of [`rep-periods-data.csv`](@ref rep-periods-data).
-- `specification = math`: Similar to explicit, but using `+` and `x` for simplification. The value of `partition` is a sequence of elements of the form `NxT` separated by `+`, indicating `N` time blocks of length `T`. For instance, `2x3+3x6` is 2 time blocks of 3 timesteps, followed by 3 time blocks of 6 timesteps, for a total of 24 timesteps in the representative period.
-
-The table below shows various results for different formats for a representative period with 12 timesteps.
-
-| Time Block            | :uniform | :explicit               | :math       |
-| :-------------------- | :------- | :---------------------- | :---------- |
-| 1:3, 4:6, 7:9, 10:12  | 3        | 3;3;3;3                 | 4x3         |
-| 1:4, 5:8, 9:12        | 4        | 4;4;4                   | 3x4         |
-| 1:1, 2:2, …, 12:12    | 1        | 1;1;1;1;1;1;1;1;1;1;1;1 | 12x1        |
-| 1:3, 4:6, 7:10, 11:12 | NA       | 3;3;4;2                 | 2x3+1x4+1x2 |
-
-Note: If an asset is not specified in this file, the balance equation will be written in the lowest resolution of both the incoming and outgoing flows to the asset.
-
-#### [`flows-rep-periods-partitions.csv` (optional)](@id flow-rep-periods-partitions-definition)
-
-The same as [`assets-rep-periods-partitions.csv`](@ref assets-rep-periods-partitions-definition), but for flows.
-
-If a flow is not specified in this file, the flow time resolution will be for each timestep by default (e.g., hourly).
-
-#### [`assets-timeframe-partitions.csv` (optional)](@id assets-timeframe-partitions)
-
-The same as their [`assets-rep-periods-partitions.csv`](@ref assets-rep-periods-partitions-definition) counterpart, but for the periods in the [timeframe](@ref timeframe) of the model.
-
-### [Schemas](@id schemas)
-
-```@eval
-using Markdown, TulipaEnergyModel
-
-Markdown.parse(
-    join(["- **`$filename`**\n" *
-        join(
-            ["  - `$f: $t`" for (f, t) in schema],
-            "\n",
-        ) for (filename, schema) in TulipaEnergyModel.schema_per_table_name
-    ] |> sort, "\n")
-)
-```
-
-## [Structures](@id structures)
-
-!!! danger
-    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
-
-The list of relevant structures used in this package are listed below:
-
-### EnergyProblem
-
-The `EnergyProblem` structure is a wrapper around various other relevant structures.
-It hides the complexity behind the energy problem, making the usage more friendly, although more verbose.
-
-#### Fields
-
-- `graph`: The Graph object that defines the geometry of the energy problem.
-- `representative_periods`: A vector of [Representative Periods](@ref representative-periods).
-- `constraints_partitions`: Dictionaries that connect pairs of asset and representative periods to [time partitions](@ref Partition) (vectors of time blocks).
-- `timeframe`: The number of periods in the `representative_periods`.
-- `dataframes`: A Dictionary of dataframes used to linearize the variables and constraints. These are used internally in the model only.
-- `groups`: A vector of [Groups](@ref group).
-- `model`: A JuMP.Model object representing the optimization model.
-- `solution`: A structure of the variable values (investments, flows, etc) in the solution.
-- `solved`: A boolean indicating whether the `model` has been solved or not.
-- `objective_value`: The objective value of the solved problem (Float64).
-- `termination_status`: The termination status of the optimization model.
-- `time_read_data`: Time taken (in seconds) for reading the data (Float64).
-- `time_create_model`: Time taken (in seconds) for creating the model (Float64).
-- `time_solve_model`: Time taken (in seconds) for solving the model (Float64).
-
-#### Constructor
-
-The `EnergyProblem` can also be constructed using the minimal constructor below.
-
-- `EnergyProblem(connection)`: Constructs a new `EnergyProblem` object with the given `connection` that has been created and the data loaded into it using [TulipaIO](https://github.com/TulipaEnergy/TulipaIO.jl). The `graph`, `representative_periods`, and `timeframe` are computed using `create_internal_structures`. The `constraints_partitions` field is computed from the `representative_periods`, and the other fields are initialized with default values.
-
-See the [basic example tutorial](@ref basic-example) to see how these can be used.
-
-### GraphAssetData
-
-This structure holds all the information of a given asset.
-These are stored inside the Graph.
-Given a graph `graph`, an asset `a` can be accessed through `graph[a]`.
-
-### GraphFlowData
-
-This structure holds all the information of a given flow.
-These are stored inside the Graph.
-Given a graph `graph`, a flow from asset `u` to asset `v` can be accessed through `graph[u, v]`.
-
-### Partition
-
-A [representative period](@ref representative-periods) will be defined with a number of timesteps.
-A partition is a division of these timesteps into [time blocks](@ref time-blocks) such that the time blocks are disjunct (not overlapping) and that all timesteps belong to some time block.
-Some variables and constraints are defined over every time block in a partition.
-
-For instance, for a representative period with 12 timesteps, all sets below are partitions:
-
-- $\{\{1, 2, 3\}, \{4, 5, 6\}, \{7, 8, 9\}, \{10, 11, 12\}\}$
-- $\{\{1, 2, 3, 4\}, \{5, 6, 7, 8\}, \{9, 10, 11, 12\}\}$
-- $\{\{1\}, \{2, 3\}, \{4\}, \{5, 6, 7, 8\}, \{9, 10, 11, 12\}\}$
-
-### [Timeframe](@id timeframe)
-
-The timeframe is the total period we want to analyze with the model. Usually this is a year, but it can be any length of time. A timeframe has two fields:
-
-- `num_periods`: The timeframe is defined by a certain number of periods. For instance, a year can be defined by 365 periods, each describing a day.
-- `map_periods_to_rp`: Indicates the periods of the timeframe that map into a [representative period](@ref representative-periods) and the weight of the representative period to construct that period.
-
-### [Representative Periods](@id representative-periods)
-
-The [timeframe](@ref timeframe) (e.g., a full year) is described by a selection of representative periods, for instance, days or weeks, that nicely summarize other similar periods. For example, we could model the year into 3 days, by clustering all days of the year into 3 representative days. Each one of these days is called a representative period. _TulipaEnergyModel.jl_ has the flexibility to consider representative periods of different lengths for the same timeframe (e.g., a year can be represented by a set of 4 days and 2 weeks). To obtain the representative periods, we recommend using [TulipaClustering](https://github.com/TulipaEnergy/TulipaClustering.jl).
-
-A representative period has three fields:
-
-- `weight`: Indicates how many representative periods are contained in the [timeframe](@ref timeframe); this is inferred automatically from `map_periods_to_rp` in the [timeframe](@ref timeframe).
-- `timesteps`: The number of timesteps blocks in the representative period.
-- `resolution`: The duration in time of each timestep.
-
-The number of timesteps and resolution work together to define the coarseness of the period.
-Nothing is defined outside of these timesteps; for instance, if the representative period represents a day and you want to specify a variable or constraint with a coarseness of 30 minutes. You need to define the number of timesteps to 48 and the resolution to `0.5`.
-
-### [Time Blocks](@id time-blocks)
-
-A time block is a range for which a variable or constraint is defined.
-It is a range of numbers, i.e., all integer numbers inside an interval.
-Time blocks are used for the periods in the [timeframe](@ref timeframe) and the timesteps in the [representative period](@ref representative-periods). Time blocks are disjunct (not overlapping), but do not have to be sequential.
-
-### [Group](@id group)
-
-This structure holds all the information of a given group with the following fields:
-
-- `name`: The name of the group.
-- `invest_method`: Boolean value to indicate whether or not the group has an investment method.
-- `min_investment_limit`: A minimum investment limit in MW is imposed on the total investments of the assets belonging to the group.
-- `max_investment_limit`: A maximum investment limit in MW is imposed on the total investments of the assets belonging to the group.
+To save the solution to CSV files, you can use [`export_solution_to_csv_files`](@ref). See the [tutorials](@ref tutorials) for an example showcasing this function.
 
 ## [Exploring infeasibility](@id infeasible)
 
 If your model is infeasible, you can try exploring the infeasibility with [JuMP.compute_conflict!](https://jump.dev/JuMP.jl/stable/api/JuMP/#JuMP.compute_conflict!) and [JuMP.copy_conflict](https://jump.dev/JuMP.jl/stable/api/JuMP/#JuMP.copy_conflict).
 
-> **Note:** Not all solvers support this functionality.
+!!! warning "Check your solver options!"
+    Not all solvers support this functionality; please check depending on each case.
 
 Use `energy_problem.model` for the model argument. For instance:
 
@@ -332,21 +101,26 @@ create_model!(energy_problem; enable_names = false)
 
 For more information, see the [JuMP documentation](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/performance_tips/#Disable-string-names).
 
+## Finding an input parameter
+
+!!! tip "Are you looking for a input parameter?"
+    Please visit the [Model Parameters](@ref schemas) section for a description and location of the input parameters mentioned in this section.
+
 ## Storage specific setups
 
 ### [Seasonal and non-seasonal storage](@id seasonal-setup)
 
 Section [Storage Modeling](@ref storage-modeling) explains the main concepts for modeling seasonal and non-seasonal storage in _TulipaEnergyModel.jl_. To define if an asset is one type or the other then consider the following:
 
-- _Seasonal storage_: When the storage capacity of an asset is greater than the total length of representative periods, we recommend using the inter-temporal constraints. To apply these constraints, you must set the input parameter `is_seasonal` to `true` in the [`assets-data.csv`](@ref schemas).
-- _Non-seasonal storage_: When the storage capacity of an asset is lower than the total length of representative periods, we recommend using the intra-temporal constraints. To apply these constraints, you must set the input parameter `is_seasonal` to `false` in the [`assets-data.csv`](@ref schemas).
+- _Seasonal storage_: When the storage capacity of an asset is greater than the total length of representative periods, we recommend using the inter-temporal constraints. To apply these constraints, you must set the input parameter `is_seasonal` to `true`.
+- _Non-seasonal storage_: When the storage capacity of an asset is lower than the total length of representative periods, we recommend using the intra-temporal constraints. To apply these constraints, you must set the input parameter `is_seasonal` to `false`.
 
-> **Note:**
-> If the input data covers only one representative period for the entire year, for example, with 8760-hour timesteps, and you have a monthly hydropower plant, then you should set the `is_seasonal` parameter for that asset to `false`. This is because the length of the representative period is greater than the storage capacity of the storage asset.
+!!! info
+    If the input data covers only one representative period for the entire year, for example, with 8760-hour timesteps, and you have a monthly hydropower plant, then you should set the `is_seasonal` parameter for that asset to `false`. This is because the length of the representative period is greater than the storage capacity of the storage asset.
 
 ### [The energy storage investment method](@id storage-investment-setup)
 
-Energy storage assets have a unique characteristic wherein the investment is based not solely on the capacity to charge and discharge, but also on the energy capacity. Some storage asset types have a fixed duration for a given capacity, which means that there is a predefined ratio between energy and power. For instance, a battery of 10MW/unit and 4h duration implies that the energy capacity is 40MWh. Conversely, other storage asset types don't have a fixed ratio between the investment of capacity and storage capacity. Therefore, the energy capacity can be optimized independently of the capacity investment, such as hydrogen storage in salt caverns. To define if an energy asset is one type or the other then consider the following parameter setting in the file [`assets-data.csv`](@ref schemas):
+Energy storage assets have a unique characteristic wherein the investment is based not solely on the capacity to charge and discharge, but also on the energy capacity. Some storage asset types have a fixed duration for a given capacity, which means that there is a predefined ratio between energy and power. For instance, a battery of 10MW/unit and 4h duration implies that the energy capacity is 40MWh. Conversely, other storage asset types don't have a fixed ratio between the investment of capacity and storage capacity. Therefore, the energy capacity can be optimized independently of the capacity investment, such as hydrogen storage in salt caverns. To define if an energy asset is one type or the other then consider the following parameters:
 
 - _Investment energy method_: To use this method, set the parameter `storage_method_energy` to `true`. In addition, it is necessary to define:
 
@@ -357,13 +131,13 @@ Energy storage assets have a unique characteristic wherein the investment is bas
 
 - _Fixed energy-to-power ratio method_: To use this method, set the parameter `storage_method_energy` to `false`. In addition, it is necessary to define the parameter `energy_to_power_ratio` to establish the predefined duration of the storage asset or ratio between energy and power. Note that all the investment costs should be allocated in the parameter `investment_cost`.
 
-In addition, the parameter `capacity_storage_energy` in the [`graph-assets-data.csv`](@ref schemas) defines the energy per unit of storage capacity invested in (e.g., MWh/unit).
+In addition, the parameter `capacity_storage_energy` defines the energy per unit of storage capacity invested in (e.g., MWh/unit).
 
 For more details on the constraints that apply when selecting one method or the other, please visit the [`mathematical formulation`](@ref formulation) section.
 
 ### [Control simultaneous charging and discharging](@id storage-binary-method-setup)
 
-Depending on the configuration of the energy storage assets, it may or may not be possible to charge and discharge them simultaneously. For instance, a single battery cannot charge and discharge at the same time, but some pumped hydro storage technologies have separate components for charging (pump) and discharging (turbine) that can function independently, allowing them to charge and discharge simultaneously. To account for these differences, the model provides users with three options for the `use_binary_storage_method` parameter in the [`assets-data.csv`](@ref schemas) file:
+Depending on the configuration of the energy storage assets, it may or may not be possible to charge and discharge them simultaneously. For instance, a single battery cannot charge and discharge at the same time, but some pumped hydro storage technologies have separate components for charging (pump) and discharging (turbine) that can function independently, allowing them to charge and discharge simultaneously. To account for these differences, the model provides users with three options for the `use_binary_storage_method` parameter:
 
 - `binary`: the model adds a binary variable to prevent charging and discharging simultaneously.
 - `relaxed_binary`: the model adds a binary variable that allows values between 0 and 1, reducing the likelihood of charging and discharging simultaneously. This option uses a tighter set of constraints close to the convex hull of the full formulation, resulting in fewer instances of simultaneous charging and discharging in the results.
@@ -373,7 +147,7 @@ For more details on the constraints that apply when selecting this method, pleas
 
 ## [Setting up unit commitment constraints](@id unit-commitment-setup)
 
-The unit commitment constraints are only applied to producer and conversion assets. The `unit_commitment` parameter must be set to `true` to include the constraints in the [`assets-data.csv`](@ref schemas). Additionally, the following parameters should be set in that same file:
+The unit commitment constraints are only applied to producer and conversion assets. The `unit_commitment` parameter must be set to `true` to include the constraints. Additionally, the following parameters should be set in that same file:
 
 - `unit_commitment_method`: It determines which unit commitment method to use. The current version of the code only includes the basic version. Future versions will add more detailed constraints as additional options.
 - `units_on_cost`: Objective function coefficient on `units_on` variable. (e.g., no-load cost or idling cost in kEUR/h/unit)
@@ -384,7 +158,7 @@ For more details on the constraints that apply when selecting this method, pleas
 
 ## [Setting up ramping constraints](@id ramping-setup)
 
-The ramping constraints are only applied to producer and conversion assets. The `ramping` parameter must be set to `true` to include the constraints in the [`assets-data.csv`](@ref schemas). Additionally, the following parameters should be set in that same file:
+The ramping constraints are only applied to producer and conversion assets. The `ramping` parameter must be set to `true` to include the constraints. Additionally, the following parameters should be set in that same file:
 
 - `max_ramp_up`: Maximum ramping up rate as a portion of the capacity of asset (p.u./h)
 - `max_ramp_down:`Maximum ramping down rate as a portion of the capacity of asset (p.u./h)
@@ -395,15 +169,17 @@ For more details on the constraints that apply when selecting this method, pleas
 
 For the model to add constraints for a [maximum or minimum energy limit](@ref inter-temporal-energy-constraints) for an asset throughout the model's timeframe (e.g., a year), we need to establish a couple of parameters:
 
-- `is_seasonal = true` in the [`assets-data.csv`](@ref schemas). This parameter enables the model to use the inter-temporal constraints.
-- `max_energy_timeframe_partition` $\neq$ `missing` or `min_energy_timeframe_partition` $\neq$ `missing` in the [`assets-data.csv`](@ref schemas). This value represents the peak energy that will be then multiplied by the profile for each period in the timeframe.
-  > **Note:**
-  > These parameters are defined per period, and the default values for profiles are 1.0 p.u. per period. If the periods are determined daily, the energy limit for the whole year will be 365 times `max`or `min_energy_timeframe_partition`.
-- (optional) `profile_type` and `profile_name` in the [`assets-timeframe-profiles.csv`](@ref schemas) and the profile values in the [`profiles-timeframe.csv`](@ref schemas). If there is no profile defined, then by default it is 1.0 p.u. for all periods in the timeframe.
-- (optional) define a period partition in [`assets-timeframe-partitions.csv`](@ref schemas). If there is no partition defined, then by default the constraint is created for each period in the timeframe, otherwise, it will consider the partition definition in the file.
+- `is_seasonal = true`. This parameter enables the model to use the inter-temporal constraints.
+- `max_energy_timeframe_partition` $\neq$ `missing` or `min_energy_timeframe_partition` $\neq$ `missing`. This value represents the peak energy that will be then multiplied by the profile for each period in the timeframe.
 
-> **Tip:**
-> If you want to set a limit on the maximum or minimum outgoing energy for a year with representative days, you can use the partition definition to create a single partition for the entire year to combine the profile.
+!!! info
+    These parameters are defined per period, and the default values for profiles are 1.0 p.u. per period. If the periods are determined daily, the energy limit for the whole year will be 365 times `max`or `min_energy_timeframe_partition`.
+
+- (optional) `profile_type` and `profile_name` in the timeframe files. If there is no profile defined, then by default it is 1.0 p.u. for all periods in the timeframe.
+- (optional) define a period partition in timeframe partition files. If there is no partition defined, then by default the constraint is created for each period in the timeframe, otherwise, it will consider the partition definition in the file.
+
+!!! tip "Tip"
+    If you want to set a limit on the maximum or minimum outgoing energy for a year with representative days, you can use the partition definition to create a single partition for the entire year to combine the profile.
 
 ### Example: Setting Energy Limits
 
@@ -412,8 +188,8 @@ Let's assume we have a year divided into 365 days because we are using days as p
 | Profile | Period Partitions | Example                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | None    | None              | The default profile is 1.p.u. for each period and since there are no period partitions, the constraints will be for each period (i.e., daily). So the outgoing energy of the asset for each day must be less than or equal to 10MWh.                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Defined | None              | The profile definition and value will be in the [`assets-timeframe-profiles.csv`](@ref schemas) and [`profiles-timeframe.csv`](@ref schemas) files. For example, we define a profile that has the following first four values: 0.6 p.u., 1.0 p.u., 0.8 p.u., and 0.4 p.u. There are no period partitions, so constraints will be for each period (i.e., daily). Therefore the outgoing energy of the asset for the first four days must be less than or equal to 6MWh, 10MWh, 8MWh, and 4MWh.                                                                                                                                           |
-| Defined | Defined           | Using the same profile as above, we now define a period partition in the [`assets-timeframe-partitions.csv`](@ref schemas) file as `uniform` with a value of 2. This value means that we will aggregate every two periods (i.e., every two days). So, instead of having 365 constraints, we will have 183 constraints (182 every two days and one last constraint of 1 day). Then the profile is aggregated with the sum of the values inside the periods within the partition. Thus, the outgoing energy of the asset for the first two partitions (i.e., every two days) must be less than or equal to 16MWh and 12MWh, respectively. |
+| Defined | None              | The profile definition and value will be in the  timeframe profiles files. For example, we define a profile that has the following first four values: 0.6 p.u., 1.0 p.u., 0.8 p.u., and 0.4 p.u. There are no period partitions, so constraints will be for each period (i.e., daily). Therefore the outgoing energy of the asset for the first four days must be less than or equal to 6MWh, 10MWh, 8MWh, and 4MWh.                                                                                                                                           |
+| Defined | Defined           | Using the same profile as above, we now define a period partition in the timeframe partitions file as `uniform` with a value of 2. This value means that we will aggregate every two periods (i.e., every two days). So, instead of having 365 constraints, we will have 183 constraints (182 every two days and one last constraint of 1 day). Then the profile is aggregated with the sum of the values inside the periods within the partition. Thus, the outgoing energy of the asset for the first two partitions (i.e., every two days) must be less than or equal to 16MWh and 12MWh, respectively. |
 
 ## [Defining a group of assets](@id group-setup)
 
@@ -421,29 +197,28 @@ A group of assets refers to a set of assets that share certain constraints. For 
 
 In order to define the groups in the model, the following steps are necessary:
 
-1. Create a group in the [`group-asset.csv`](@ref schemas) file by defining the `name` property and its parameters.
-2. In the file [`graph-assets-data.csv`](@ref schemas), assign assets to the group by setting the `name` in the `group` parameter/column.
+1. Create a group file by defining the `name` property and its parameters in the `group_asset` table (or CSV file).
+2. Assign assets to the group by setting the `name` in the `group` parameter/column of the asset file.
 
-   > **Note:**
-   > A missing value in the parameter `group` in the [`graph-assets-data.csv`](@ref schemas) means that the asset does not belong to any group.
+!!! info
+    A missing value in the parameter `group` means that the asset does not belong to any group.
 
 Groups are useful to represent several common constraints, the following group constraints are available.
 
 ### [Setting up a maximum or minimum investment limit for a group](@id investment-group-setup)
 
-The mathematical formulation of the maximum and minimum investment limit for group constraints is available [here](@ref investment-group-constraints). The parameters to set up these constraints in the model are in the [`group-asset.csv`](@ref schemas) file.
+The mathematical formulation of the maximum and minimum investment limit for group constraints is available [here](@ref investment-group-constraints).
 
 - `invest_method = true`. This parameter enables the model to use the investment group constraints.
 - `min_investment_limit` $\neq$ `missing` or `max_investment_limit` $\neq$ `missing`. This value represents the limits that will be imposed on the investment that belongs to the group.
 
-  > **Notes:**
-  >
-  > 1. A missing value in the parameters `min_investment_limit` and `max_investment_limit` means that there is no investment limit.
-  > 2. These constraints are applied to the investments each year. The model does not yet have investment limits to a group's accumulated invested capacity.
+!!! info
+    1. A missing value in the parameters `min_investment_limit` and `max_investment_limit` means that there is no investment limit.
+    2. These constraints are applied to the investments each year. The model does not yet have investment limits to a group's accumulated invested capacity.
 
 ### Example: Group of Assets
 
-Let's explore how the groups are set up in the test case called [Norse](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/tree/main/test/inputs/Norse). First, let's take a look at the group-asset.csv file:
+Let's explore how the groups are set up in the test case called [Norse](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/tree/main/test/inputs/Norse). First, let's take a look at the `group-asset.csv` file:
 
 ```@example display-group-setup
 using DataFrames # hide
@@ -454,7 +229,7 @@ assets = CSV.read(input_asset_file, DataFrame, header = 1) # hide
 
 In the given data, there are two groups: `renewables` and `ccgt`. Both groups have the `invest_method` parameter set to `true`, indicating that investment group constraints apply to both. For the `renewables` group, the `min_investment_limit` parameter is missing, signifying that there is no minimum limit imposed on the group. However, the `max_investment_limit` parameter is set to 40000 MW, indicating that the total investments of assets in the group must be less than or equal to this value. In contrast, the `ccgt` group has a missing value in the `max_investment_limit` parameter, indicating no maximum limit, while the `min_investment_limit` is set to 10000 MW for the total investments in that group.
 
-Let's now explore which assets are in each group. To do so, we can take a look at the graph-assets-data.csv file:
+Let's now explore which assets are in each group. To do so, we can take a look at the `asset.csv` file:
 
 ```@example display-group-setup
 input_asset_file = "../../test/inputs/Norse/asset.csv" # hide
@@ -464,97 +239,111 @@ assets = assets[.!ismissing.(assets.group), [:asset, :type, :group]] # hide
 
 Here we can see that the assets `Asgard_Solar` and `Midgard_Wind` belong to the `renewables` group, while the assets `Asgard_CCGT` and `Midgard_CCGT` belong to the `ccgt` group.
 
-> **Note:**
-> If the group has a `min_investment_limit`, then assets in the group have to allow investment (`investable = true`) for the model to be feasible. If the assets are not `investable` then they cannot satisfy the minimum constraint.
+!!! info
+    If the group has a `min_investment_limit`, then assets in the group have to allow investment (`investable = true`) for the model to be feasible. If the assets are not `investable` then they cannot satisfy the minimum constraint.
 
 ## [Setting up multi-year investments](@id multi-year-setup)
 
-!!! danger
-    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
+!!! warning "This feature is under a major refactor"
+    This section might have out-of-date information. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
 
 It is possible to simutaneously model different years, which is especially relevant for modeling multi-year investments. Multi-year investments refer to making investment decisions at different points in time, such that a pathway of investments can be modeled. This is particularly useful when long-term scenarios are modeled, but modeling each year is not practical. Or in a business case, investment decisions are supposed to be made in different years which has an impact on the cash flow.
 
+### Filling the input data
+
 In order to set up a model with year information, the following steps are necessary.
 
-- Fill in all the years in [`year-data.csv`](@ref schemas) file by defining the `year` property and its parameters.
+#### Year data
 
-  Differentiate milestone years and non-milestone years.
+Fill in all the years in [`year-data.csv`](@ref schemas) file by defining the `year` property and its parameters. Differentiate milestone years and non-milestone years.
 
-  - Milestone years are the years you would like to model, e.g., if you want to model operation and/or investments (it is possibile to not allow investments) in 2030, 2040, and 2050. These 3 years are then milestone years.
-  - Non-milestone years are the investment years of existing units. For example, you want to consider a existing wind unit that is invested in 2020, then 2020 is a non-milestone year.
-    > **Note:** A year can both be a year that you want to model and that there are existing units invested, then this year is a milestone year.
+- Milestone years are the years you would like to model, e.g., if you want to model operation and/or investments (it is possibile to not allow investments) in 2030, 2040, and 2050. These 3 years are then milestone years.
+- Non-milestone years are the investment years of existing units. For example, you want to consider a existing wind unit that is invested in 2020, then 2020 is a non-milestone year.
 
-- Fill in the parameters in [`vintage-assets-data.csv`](@ref schemas) and [`vintage-flows-data.csv`](@ref schemas). Here you need to fill in parameters that are only related to the investment year (`commission_year` in the data) of the asset, i.e., investment costs and fixed costs.
+!!! info
+    A year can both be a year that you want to model and that there are existing units invested, then this year is a milestone year.
 
-- Fill in the parameters in [`graph-assets-data.csv`](@ref schemas) and [`graph-flows-data.csv`](@ref schemas). These parameters are for the assets across all the years, i.e., not dependent on years. Examples are lifetime (both `technical_lifetime` and `economic_lifetime`) and capacity of a unit.
+#### Commission year data
 
-  You also have to choose a `investment_method` for the asset, between `none`, `simple`, and `compact`. The below tables shows what happens to the activation of the investment and decommission variable for certain investment methods and the `investable` parameter.
+Fill in the parameters related to the investment year (`commission_year` in the data) of the asset, i.e., investment costs and fixed costs.
 
-  Consider you only want to model operation without investments, then you would need to set `investable_method` to `none`. Neither investment variables and decommission variables are activated. And here the `investable_method` overrules `investable`, because the latter does not matter.
+#### Assets investment data
 
-  > **Note:** Although it is called `investment_method`, you can see from the table that, actually, it controls directly the activation of the decommission variable. The investment variable is controlled by `investable`, which is overruled by `investable_method` in case of a conflict (i.e., for the `none` method).
+Fill in the parameters in the asset file. These parameters are for the assets across all the years, i.e., not dependent on years. Examples are lifetime (both `technical_lifetime` and `economic_lifetime`) and capacity of a unit.
 
-  | investment_method | investable | investment variable | decommission variable |
-  | ----------------- | ---------- | ------------------- | --------------------- |
-  | none              | true       | false               | false                 |
-  | none              | false      | false               | false                 |
-  | simple            | true       | true                | true                  |
-  | simple            | false      | false               | true                  |
-  | compact           | true       | true                | true                  |
-  | compact           | false      | false               | true                  |
+You also have to choose a `investment_method` for the asset, between `none`, `simple`, and `compact`. The below tables shows what happens to the activation of the investment and decommission variable for certain investment methods and the `investable` parameter.
 
-  For more details on the constraints that apply when selecting these methods, please visit the [`mathematical formulation`](@ref formulation) section.
+Consider you only want to model operation without investments, then you would need to set `investable_method` to `none`. Neither investment variables and decommission variables are activated. And here the `investable_method` overrules `investable`, because the latter does not matter.
 
-  > **Note:** `compact` method can only be applied to producer assets and conversion assets. Transport assets and storage assets can only use `simple` method.
+!!! info
+    Although it is called `investment_method`, you can see from the table that, actually, it controls directly the activation of the decommission variable. The investment variable is controlled by `investable`, which is overruled by `investable_method` in case of a conflict (i.e., for the `none` method).
 
-  - Fill in the assets and flows information in [`assets-data.csv`](@ref schemas) and [`flows-data.csv`](@ref schemas).
+| investment_method | investable | investment variable | decommission variable |
+| ----------------- | ---------- | ------------------- | --------------------- |
+| none              | true       | false               | false                 |
+| none              | false      | false               | false                 |
+| simple            | true       | true                | true                  |
+| simple            | false      | false               | true                  |
+| compact           | true       | true                | true                  |
+| compact           | false      | false               | true                  |
 
-    - In the `year` column, fill in all the milestone years. In the `commission_year` column, fill in the investment years of the existing assets that are still available in this `year`.
-      - If the `commission_year` is a non-milestone year, then it means the row is for an existing unit. The `investable` has to be set to `false`, and you put the existing units in the column `initial_units`.
-      - If the `commission_year` is a milestone year, then you put the existing units in the column `initial_units`. Depending on whether you want to model investments or not, you put the `investable` to either `true` or `false`.
+For more details on the constraints that apply when selecting these methods, please visit the [`mathematical formulation`](@ref formulation) section.
 
-    Let's explain further using an example. To do so, we can take a look at the assets-data.csv file:
+!!! info
+    The `compact` method can only be applied to producer assets and conversion assets. Transport assets and storage assets can only use `simple` method.
 
-    ```@example multi-year-setup
-    using DataFrames # hide
-    using CSV # hide
-    input_asset_file = "../../test/inputs/Multi-year Investments/asset-both.csv" # hide
-    assets_data = CSV.read(input_asset_file, DataFrame) # hide
-    assets_data = assets_data[1:10, [:asset, :milestone_year, :commission_year, :initial_units]] # hide
-    ```
+#### Assets and flows information
 
-    We allow investments of `ocgt`, `ccgt`, `battery`, `wind`, and `solar` in 2030.
+Fill in the assets and flows information.
 
-    - `ocgt` has no existing units.
-    - `ccgt` has 1 existing units, invested in 2028, and still available in 2030.
-    - `ccgt` has 0.07 existing units, invested in 2020, and still available in 2030. Another 0.02 existing units, invested in 2030.
-    - `wind` has 0.07 existing units, invested in 2020, and still available in 2030. Another 0.02 existing units, invested in 2030.
-    - `solar` has no existing units.
+- In the `year` column, fill in all the milestone years. In the `commission_year` column, fill in the investment years of the existing assets that are still available in this `year`.
+  - If the `commission_year` is a non-milestone year, then it means the row is for an existing unit. The `investable` has to be set to `false`, and you put the existing units in the column `initial_units`.
+  - If the `commission_year` is a milestone year, then you put the existing units in the column `initial_units`. Depending on whether you want to model investments or not, you put the `investable` to either `true` or `false`.
 
-    > **Note:** We only consider the existing units which are still available in the milestone years.
+Let's explain further using an example. To do so, we can take a look at the `asset-both.csv` file:
 
-- Fill in relevant profiles in [`assets-profiles.csv`](@ref schemas), [`flows-profiles.csv`](@ref schemas), and [`profiles-rep-periods.csv`](@ref schemas). Important to know that you can use different profiles for assets that are invested in different years. You fill in the profile names in `assets-profiles.csv` for relevant years. In `profiles-rep-periods.csv`, you relate the profile names with the modeled years.
+```@example multi-year-setup
+using DataFrames # hide
+using CSV # hide
+input_asset_file = "../../test/inputs/Multi-year Investments/asset-both.csv" # hide
+assets_data = CSV.read(input_asset_file, DataFrame) # hide
+assets_data = assets_data[1:10, [:asset, :milestone_year, :commission_year, :initial_units]] # hide
+```
 
-  Let's explain further using an example. To do so, we can take a look at the `assets-profiles.csv` file:
+We allow investments of `ocgt`, `ccgt`, `battery`, `wind`, and `solar` in 2030.
 
-  ```@example multi-year-setup
-  input_asset_file = "../../test/inputs/Multi-year Investments/assets-profiles.csv" # hide
-  assets_profiles = CSV.read(input_asset_file, DataFrame, header = 1) # hide
-  assets_profiles = assets_profiles[1:2, :] # hide
-  ```
+- `ocgt` has no existing units.
+- `ccgt` has 1 existing units, invested in 2028, and still available in 2030.
+- `ccgt` has 0.07 existing units, invested in 2020, and still available in 2030. Another 0.02 existing units, invested in 2030.
+- `wind` has 0.07 existing units, invested in 2020, and still available in 2030. Another 0.02 existing units, invested in 2030.
+- `solar` has no existing units.
 
-  We have two profiles for `wind` invested in 2020 and 2030. Imagine these are two wind turbines with different efficiencies due to the year of manufacture. These are reflected in the profiles for the model year 2030, which are defined in the `profiles-rep-periods.csv` file.
+!!! info
+    We only consider the existing units which are still available in the milestone years.
 
-  ### Economic representation
+#### Profiles information
 
-  For economic representation, the following parameters need to be set up:
+Fill in relevant profiles in the files. Important to know that you can use different profiles for assets that are invested in different years. You fill in the profile names in `assets-profiles.csv` for relevant years. In `profiles-rep-periods.csv`, you relate the profile names with the modeled years.
 
-  - [optional] `discount year` and `discount rate` in the `model-parameters-example.toml` file: model-wide discount year and rate. By default, the model will use a discount rate of 0, and a discount year of the first milestone year. In other words, the costs will be discounted to the cost of the first milestone year.
+Let's explain further using an example. To do so, we can take a look at the `assets-profiles.csv` file:
 
-  - `discount_rate` in [`graph-assets-data.csv`](@ref schemas) and [`graph-flows-data.csv`](@ref schemas): technology-specific discount rates.
+```@example multi-year-setup
+input_asset_file = "../../test/inputs/Multi-year Investments/assets-profiles.csv" # hide
+assets_profiles = CSV.read(input_asset_file, DataFrame, header = 1) # hide
+assets_profiles = assets_profiles[1:2, :] # hide
+```
 
-  - `economic_lifetime` in [`graph-assets-data.csv`](@ref schemas) and [`graph-flows-data.csv`](@ref schemas): used for discounting the costs.
+We have two profiles for `wind` invested in 2020 and 2030. Imagine these are two wind turbines with different efficiencies due to the year of manufacture. These are reflected in the profiles for the model year 2030, which are defined in the `profiles-rep-periods.csv` file.
 
-  > **Note:** Since the model explicitly discounts, all the inputs for costs should be given in the costs of the relevant year. For example, to model investments in 2030 and 2050, the `investment_cost` should be given in 2030 costs and 2050 costs, respectively.
+### Economic representation
 
-  For more details on the formulas for economic representation, please visit the [`mathematical formulation`](@ref formulation) section.
+For economic representation, the following parameters need to be set up:
+
+- [optional] `discount year` and `discount rate` in the `model-parameters-example.toml` file: model-wide discount year and rate. By default, the model will use a discount rate of 0, and a discount year of the first milestone year. In other words, the costs will be discounted to the cost of the first milestone year.
+- `discount_rate`: technology-specific discount rates.
+- `economic_lifetime`: used for discounting the costs.
+
+!!! info
+    Since the model explicitly discounts, all the inputs for costs should be given in the costs of the relevant year. For example, to model investments in 2030 and 2050, the `investment_cost` should be given in 2030 costs and 2050 costs, respectively.
+
+For more details on the formulas for economic representation, please visit the [`mathematical formulation`](@ref formulation) section.

--- a/docs/src/20-tutorials.md
+++ b/docs/src/20-tutorials.md
@@ -102,21 +102,22 @@ There is currently no reason to manually create and maintain these structures yo
 
 To avoid having to update this documentation whenever we make changes to the internals of TulipaEnergyModel before the v1.0.0 release, we will keep this section empty until then.
 
-### Change optimizer and specify parameters
+## Change optimizer and specify parameters
 
 By default, the model is solved using the [HiGHS](https://github.com/jump-dev/HiGHS.jl) optimizer (or solver).
 To change this, we can give the functions `run_scenario` or `solve_model!` a
 different optimizer.
 
 !!! warning
-    HiGHS is the only open source solver that we recommend. GLPK and Cbc are missing features and are not (fully) tested for Tulipa.
+    HiGHS is the only open source solver that we recommend. GLPK and Cbc are not (fully) tested for Tulipa.
 
-For instance, we run the [GLPK](https://github.com/jump-dev/GLPK.jl) optimizer below:
+For instance, let's run the Tiny example using the [GLPK](https://github.com/jump-dev/GLPK.jl) optimizer:
 
 ```@example
 using DuckDB, TulipaIO, TulipaEnergyModel, GLPK
 
 input_dir = "../../test/inputs/Tiny" # hide
+# input_dir should be the path to Tiny as a string (something like "test/inputs/Tiny")
 connection = DBInterface.connect(DuckDB.DB)
 read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
 energy_problem = run_scenario(connection, optimizer = GLPK.Optimizer)
@@ -130,8 +131,8 @@ using GLPK
 solution = solve_model!(energy_problem, GLPK.Optimizer)
 ```
 
-Notice that, in any of these cases, we need to explicitly add the GLPK package
-ourselves and add `using GLPK` before using `GLPK.Optimizer`.
+!!! info
+    Notice that, in any of these cases, we need to explicitly add the GLPK package ourselves and add `using GLPK` before using `GLPK.Optimizer`.
 
 In any of these cases, default parameters for the `GLPK` optimizer are used,
 which you can query using [`default_parameters`](@ref).

--- a/docs/src/20-tutorials.md
+++ b/docs/src/20-tutorials.md
@@ -154,6 +154,7 @@ For the complete list of parameters, check your chosen optimizer.
 
 These parameters can also be passed via a file. See the
 [`read_parameters_from_file`](@ref) function for more details.
+
 ### Writing the output to CSV
 
 To save the solution to CSV files, you can use [`export_solution_to_csv_files`](@ref):

--- a/docs/src/20-tutorials.md
+++ b/docs/src/20-tutorials.md
@@ -82,11 +82,11 @@ save_solution!(energy_problem)
 ```
 
 The solutions will be saved in the variable and constraints tables.
-To save these tables to files, use
+To save the solution to CSV files, you can use [`export_solution_to_csv_files`](@ref)
 
 ```@example manual-energy-problem
 mkdir("output_folder")
-save_solution_to_file("output_folder", energy_problem)
+export_solution_to_csv_files("output_folder", energy_problem)
 ```
 
 The objective value and the termination status are also included in the energy problem:
@@ -154,12 +154,3 @@ For the complete list of parameters, check your chosen optimizer.
 
 These parameters can also be passed via a file. See the
 [`read_parameters_from_file`](@ref) function for more details.
-
-### Writing the output to CSV
-
-To save the solution to CSV files, you can use [`export_solution_to_csv_files`](@ref):
-
-```@example solution
-mkdir("outputs")
-export_solution_to_csv_files("outputs", energy_problem)
-```

--- a/docs/src/20-tutorials.md
+++ b/docs/src/20-tutorials.md
@@ -72,12 +72,24 @@ energy_problem.solved
 Finally, we can solve the model:
 
 ```@example manual-energy-problem
-solution = solve_model!(energy_problem)
+solve_model!(energy_problem)
 ```
 
-The solution is included in the individual assets and flows, but for completeness, we return the full `solution` object, also defined in the [Structures](@ref structures) section.
+The compute the solution and save it in the DuckDB connection, we can use
 
-In particular, the objective value and the termination status are also included in the energy problem:
+```@example manual-energy-problem
+save_solution!(energy_problem)
+```
+
+The solutions will be saved in the variable and constraints tables.
+To save these tables to files, use
+
+```@example manual-energy-problem
+mkdir("output_folder")
+save_solution_to_file("output_folder", energy_problem)
+```
+
+The objective value and the termination status are also included in the energy problem:
 
 ```@example manual-energy-problem
 energy_problem.objective_value, energy_problem.termination_status
@@ -85,68 +97,19 @@ energy_problem.objective_value, energy_problem.termination_status
 
 ### Manually creating all structures without EnergyProblem
 
-For additional control, it might be desirable to use the internal structures of `EnergyProblem` directly.
-This can be error-prone, so use it with care.
-The full description for these structures can be found in [Structures](@ref structures).
+The `EnergyProblem` structure holds various internal structures, including the JuMP model and the DuckDB connection.
+There is currently no reason to manually create and maintain these structures yourself, so we recommend that you use the previous sections instead.
 
-```@example manual
-using DuckDB, TulipaIO, TulipaEnergyModel
-
-input_dir = "../../test/inputs/Tiny" # hide
-# input_dir should be the path to Tiny as a string (something like "test/inputs/Tiny")
-connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
-model_parameters = ModelParameters(connection)
-graph, representative_periods, timeframe, groups, years = create_internal_structures(connection)
-```
-
-We also need a time partition for the constraints to create the model.
-Creating an energy problem automatically computes this data, but since we are doing it manually, we need to calculate it ourselves.
-
-```@example manual
-constraints_partitions = compute_constraints_partitions(graph, representative_periods, years)
-```
-
-The `constraints_partitions` has two dictionaries with the keys `:lowest_resolution` and `:highest_resolution`. The lowest resolution dictionary is mainly used to create the constraints for energy balance, whereas the highest resolution dictionary is mainly used to create the capacity constraints in the model.
-
-We also need dataframes that store the linearized indices of the variables.
-
-```@example manual
-dataframes = construct_dataframes(connection, graph, representative_periods, constraints_partitions, years)
-```
-
-We need the sets and the variables indices.
-
-```@example manual
-sets = create_sets(graph, years)
-variables = compute_variables_indices(connection, dataframes)
-```
-
-Now we can compute the model.
-
-```@example manual
-model = create_model(graph, sets, variables, representative_periods, dataframes, years, timeframe, groups, model_parameters)
-```
-
-Finally, we can compute the solution.
-
-```@example manual
-solution = solve_model(model, variables)
-```
-
-or, if we want to store the `flow`, `storage_level_rep_period`, and `storage_level_over_clustered_year` optimal value in the dataframes:
-
-```@example manual
-solution = solve_model!(dataframes, model, variables)
-```
-
-This `solution` structure is the same as the one returned when using an `EnergyProblem`.
+To avoid having to update this documentation whenever we make changes to the internals of TulipaEnergyModel before the v1.0.0 release, we will keep this section empty until then.
 
 ### Change optimizer and specify parameters
 
 By default, the model is solved using the [HiGHS](https://github.com/jump-dev/HiGHS.jl) optimizer (or solver).
-To change this, we can give the functions `run_scenario`, `solve_model`, or
-`solve_model!` a different optimizer.
+To change this, we can give the functions `run_scenario` or `solve_model!` a
+different optimizer.
+
+!!! warning
+    HiGHS is the only open source solver that we recommend. GLPK and Cbc are missing features and are not (fully) tested for Tulipa.
 
 For instance, we run the [GLPK](https://github.com/jump-dev/GLPK.jl) optimizer below:
 
@@ -165,14 +128,6 @@ or
 using GLPK
 
 solution = solve_model!(energy_problem, GLPK.Optimizer)
-```
-
-or
-
-```@example manual
-using GLPK
-
-solution = solve_model(model, variables, GLPK.Optimizer)
 ```
 
 Notice that, in any of these cases, we need to explicitly add the GLPK package
@@ -199,295 +154,6 @@ For the complete list of parameters, check your chosen optimizer.
 
 These parameters can also be passed via a file. See the
 [`read_parameters_from_file`](@ref) function for more details.
-
-### [Using the graph structure](@id graph-tutorial)
-
-Read about the graph structure in the [Graph](@ref) section first.
-
-We will use the `graph` created above for the "Tiny" dataset.
-
-The first thing that we can do is access all assets.
-They are the labels of the graph and can be accessed via the MetaGraphsNext API:
-
-```@example manual
-using MetaGraphsNext
-# Accessing assets
-labels(graph)
-```
-
-Notice that the result is a generator, so if we want the actual results, we have to collect it:
-
-```@example manual
-labels(graph) |> collect
-```
-
-To access the asset data, we can index the graph with an asset label:
-
-```@example manual
-graph["ocgt"]
-```
-
-This is a Julia struct, or composite type, named [GraphAssetData](@ref).
-We can access its fields with `.`:
-
-```@example manual
-graph["ocgt"].type
-```
-
-Since `labels` returns a generator, we can iterate over its contents without collecting it into a vector.
-
-```@example manual
-for a in labels(graph)
-    println("Asset $a has type $(graph[a].type)")
-end
-```
-
-To get all flows we can use `edge_labels`:
-
-```@example manual
-edge_labels(graph) |> collect
-```
-
-To access the flow data, we index with `graph[u, v]`:
-
-```@example manual
-graph["ocgt", "demand"]
-```
-
-The type of the flow struct is [GraphFlowData](@ref).
-
-We can easily find all assets `v` for which a flow `(a, v)` exists for a given asset `a` (in this case, demand):
-
-```@example manual
-inneighbor_labels(graph, "demand") |> collect
-```
-
-Similarly, all assets `u` for which a flow `(u, a)` exists for a given asset `a` (in this case, ocgt):
-
-```@example manual
-outneighbor_labels(graph, "ocgt") |> collect
-```
-
-## [Manipulating the solution](@id solution-tutorial)
-
-First, see the description of the [solution](@ref Solution) object.
-
-Let's consider the larger dataset "Norse" in this section. And let's talk about two ways to access the solution.
-
-### The solution returned by solve_model
-
-The solution, as shown before, can be obtained when calling [`solve_model`](@ref) or [`solve_model!`](@ref).
-
-```@example solution
-using DuckDB, TulipaIO, TulipaEnergyModel
-
-input_dir = "../../test/inputs/Norse" # hide
-# input_dir should be the path to Norse as a string (something like "test/inputs/Norse")
-connection = DBInterface.connect(DuckDB.DB)
-read_csv_folder(connection, input_dir; schemas = TulipaEnergyModel.schema_per_table_name)
-energy_problem = EnergyProblem(connection)
-create_model!(energy_problem)
-solution = solve_model!(energy_problem)
-nothing # hide
-```
-
-To create a traditional array in the order given by the investable assets, one can run
-
-The `solution.flow`, `solution.storage_level_rep_period`, and `solution.storage_level_over_clustered_year` values are linearized according to the dataframes in the dictionary `energy_problem.dataframes` with keys `:flows`, `:storage_level_rep_period`, and `:storage_level_over_clustered_year`, respectively.
-You need to query the data from these dataframes and then use the column `index` to select the appropriate value.
-
-To create a vector with all values of `flow` for a given `(u, v)` and `rp`, one can run
-
-```@example solution
-using MetaGraphsNext
-graph = energy_problem.graph
-
-(u, v) = first(edge_labels(graph))
-rp = 1
-df = filter(
-    row -> row.rep_period == rp && row.from == u && row.to == v,
-    energy_problem.dataframes[:flows],
-    view = true,
-)
-[solution.flow[row.index] for row in eachrow(df)]
-```
-
-To create a vector with the all values of `storage_level_rep_period` for a given `a` and `rp`, one can run
-
-```@example solution
-a = energy_problem.dataframes[:storage_level_rep_period].asset[1]
-rp = 1
-df = filter(
-    row -> row.asset == a && row.rep_period == rp,
-    energy_problem.dataframes[:storage_level_rep_period],
-    view = true,
-)
-[solution.storage_level_rep_period[row.index] for row in eachrow(df)]
-```
-
-To create a vector with the all values of `storage_level_over_clustered_year` for a given `a`, one can run
-
-```@example solution
-a = energy_problem.dataframes[:storage_level_over_clustered_year].asset[1]
-df = filter(
-    row -> row.asset == a,
-    energy_problem.dataframes[:storage_level_over_clustered_year],
-    view = true,
-)
-[solution.storage_level_over_clustered_year[row.index] for row in eachrow(df)]
-```
-
-### The solution inside the graph
-
-In addition to the solution object, the solution is also stored by the individual assets and flows when [`solve_model!`](@ref) is called (i.e., when using an [EnergyProblem](@ref) object).
-
-They can be accessed like any other value from [GraphAssetData](@ref) or [GraphFlowData](@ref), which means that we recreate the values from the previous section in a new way:
-
-```@example solution
-years = [year.id for year in energy_problem.years]
-Dict(
-    (y, a) => [
-        energy_problem.graph[a].investment[y]
-    ] for y in years for a in labels(graph) if graph[a].investable[y]
-)
-```
-
-```@example solution
-Dict(
-    (y, a) => [
-        energy_problem.graph[u, v].investment[y]
-    ] for y in years for (u, v) in edge_labels(graph) if graph[u, v].investable[y]
-)
-```
-
-```@example solution
-(u, v) = first(edge_labels(graph))
-rp = 1
-df = filter(
-    row -> row.rep_period == rp && row.from == u && row.to == v,
-    energy_problem.dataframes[:flows],
-    view = true,
-)
-[energy_problem.graph[u, v].flow[(rp, row.timesteps_block)] for row in eachrow(df)]
-```
-
-To create a vector with all the values of `storage_level_rep_period` for a given `a` and `rp`, one can run
-
-```@example solution
-a = energy_problem.dataframes[:storage_level_rep_period].asset[1]
-rp = 1
-df = filter(
-    row -> row.asset == a && row.rep_period == rp,
-    energy_problem.dataframes[:storage_level_rep_period],
-    view = true,
-)
-[energy_problem.graph[a].storage_level_rep_period[(rp, row.timesteps_block)] for row in eachrow(df)]
-```
-
-To create a vector with all the values of `storage_level_over_clustered_year` for a given `a`, one can run
-
-```@example solution
-a = energy_problem.dataframes[:storage_level_over_clustered_year].asset[1]
-df = filter(
-    row -> row.asset == a,
-    energy_problem.dataframes[:storage_level_over_clustered_year],
-    view = true,
-)
-[energy_problem.graph[a].storage_level_over_clustered_year[row.periods_block] for row in eachrow(df)]
-```
-
-### The solution inside the dataframes object
-
-In addition to being stored in the `solution` object, and in the `graph` object, the solution for the `flow`, `storage_level_rep_period`, and `storage_level_over_clustered_year` is also stored inside the corresponding DataFrame objects if `solve_model!` is called.
-
-The code below will do the same as in the two previous examples:
-
-```@example solution
-(u, v) = first(edge_labels(graph))
-rp = 1
-df = filter(
-    row -> row.rep_period == rp && row.from == u && row.to == v,
-    energy_problem.dataframes[:flows],
-    view = true,
-)
-df.solution
-```
-
-```@example solution
-a = energy_problem.dataframes[:storage_level_over_clustered_year].asset[1]
-df = filter(
-    row -> row.asset == a,
-    energy_problem.dataframes[:storage_level_over_clustered_year],
-    view = true,
-)
-df.solution
-```
-
-```@example solution
-a = energy_problem.dataframes[:storage_level_rep_period].asset[1]
-rp = 1
-df = filter(
-    row -> row.asset == a && row.rep_period == rp,
-    energy_problem.dataframes[:storage_level_rep_period],
-    view = true,
-)
-df.solution
-```
-
-### Values of constraints and expressions
-
-By accessing the model directly, we can query the values of constraints and expressions.
-We need to know the name of the constraint and how it is indexed, and for that, you will need to check the model.
-
-For instance, we can get all incoming flows in the lowest resolution for a given asset for a given representative period with the following:
-
-```@example solution
-using JuMP
-a = energy_problem.dataframes[:lowest].asset[end]
-rp = 1
-df = filter(
-    row -> row.asset == a && row.rep_period == rp,
-    energy_problem.dataframes[:lowest],
-    view = true,
-)
-[value(energy_problem.model[:incoming_flow_lowest_resolution][row.index]) for row in eachrow(df)]
-```
-
-The values of constraints can also be obtained, however, they are frequently indexed in a subset, which means that their indexing is not straightforward.
-To know how they are indexed, it is necessary to look at the model code.
-For instance, to get the consumer balance, we first need to filter the `:highest_in_out` dataframes by consumers:
-
-```@example solution
-df_consumers = filter(
-    row -> graph[row.asset].type == "consumer",
-    energy_problem.dataframes[:highest_in_out],
-    view = false,
-);
-nothing # hide
-```
-
-We set `view = false` to create a copy of this DataFrame so we can make our indices:
-
-```@example solution
-df_consumers.index = 1:size(df_consumers, 1) # overwrites existing index
-```
-
-Now we can filter this DataFrame. Note that the names in the stored dataframes are defined as Symbol.
-
-```@example solution
-a = "Asgard_E_demand"
-df = filter(
-    row -> row.asset == a && row.rep_period == rp,
-    df_consumers,
-    view = true,
-)
-value.(energy_problem.model[:consumer_balance][df.index])
-```
-
-Here `value.` (i.e., broadcasting) was used instead of the vector comprehension from previous examples just to show that it also works.
-
-The value of the constraint is obtained by looking only at the part with variables. So a constraint like `2x + 3y - 1 <= 4` would return the value of `2x + 3y`.
-
 ### Writing the output to CSV
 
 To save the solution to CSV files, you can use [`export_solution_to_csv_files`](@ref):
@@ -496,9 +162,3 @@ To save the solution to CSV files, you can use [`export_solution_to_csv_files`](
 mkdir("outputs")
 export_solution_to_csv_files("outputs", energy_problem)
 ```
-
-### Plotting
-
-In the previous sections, we have shown how to create vectors such as the one for flows. If you want simple plots, you can plot the vectors directly using any package you like.
-
-If you would like more custom plots, check out [TulipaPlots.jl](https://github.com/TulipaEnergy/TulipaPlots.jl), under development, which provides tailor-made plots for _TulipaEnergyModel.jl_.

--- a/docs/src/30-concepts.md
+++ b/docs/src/30-concepts.md
@@ -340,6 +340,9 @@ The level of reduction and approximation error will depend on the case study. So
 
 ## [Flexible Time Resolution in the Unit Commitment and Ramping Constraints](@id flex-time-res-uc)
 
+!!! danger
+    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
+
 In the previous section, we have seen how the flexible temporal resolution is handled for the model's flow capacity and balance constraints. Here, we show how flexible time resolution is applied when considering the model's unit commitment and ramping constraints. Let's consider the example in the folder [`test/inputs/UC-ramping`](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/tree/main/test/inputs/UC-ramping) to explain how all these constraints are created in _TulipaEnergyModel.jl_ when having the flexible time resolution.
 
 ![unit-commitment-case-study](./figs/unit-commitment-case-study.png)
@@ -350,10 +353,10 @@ The example demonstrates various assets that supply demand. Each asset has diffe
 using DataFrames # hide
 using CSV # hide
 input_dir = "../../test/inputs/UC-ramping" # hide
-assets_data = CSV.read(joinpath(input_dir, "assets-data.csv"), DataFrame, header = 1) # hide
-graph_assets = CSV.read(joinpath(input_dir, "graph-assets-data.csv"), DataFrame, header = 1) # hide
-assets = leftjoin(graph_assets, assets_data, on=:name) # hide
-filtered_assets = assets[assets.type .== "producer" .|| assets.type .== "conversion", ["name", "type", "capacity", "initial_units", "unit_commitment",  "ramping"]] # hide
+assets_data = CSV.read(joinpath(input_dir, "asset-both.csv"), DataFrame) # hide
+graph_assets = CSV.read(joinpath(input_dir, "asset.csv"), DataFrame) # hide
+assets = leftjoin(graph_assets, assets_data, on=:asset) # hide
+filtered_assets = assets[assets.type .== "producer" .|| assets.type .== "conversion", ["asset", "type", "capacity", "initial_units", "unit_commitment",  "ramping"]] # hide
 ```
 
 The `assets-rep-periods-partitions` file defines the time resolution for the assets in the `partition` column. For instance, here we can see that the time resolutions are 3h for the `ccgt` and 6h for the `smr`. These values mean that the unit commitment variables (e.g., `units_on`) in the model have three and six hours resolution, respectively.
@@ -546,6 +549,9 @@ The equations of intra- and inter-temporal constraints for energy storage are av
 
 ### Example to Model Seasonal and Non-seasonal Storage
 
+!!! danger
+    This section is out of date. The update of these docs is tracked in <https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/983>
+
 We use the example in the folder [`test/inputs/Storage`](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/tree/main/test/inputs/Storage) to explain how all these concepts come together in _TulipaEnergyModel.jl_.
 
 Let's first look at this feature's most relevant input data, starting with the `assets-data` file. Here, we show only the storage assets and the appropriate columns for this example, but all the input data can be found in the previously mentioned folder.
@@ -554,10 +560,10 @@ Let's first look at this feature's most relevant input data, starting with the `
 using DataFrames # hide
 using CSV # hide
 input_dir = "../../test/inputs/Storage" # hide
-assets_data = CSV.read(joinpath(input_dir, "assets-data.csv"), DataFrame, header = 1) # hide
-graph_assets = CSV.read(joinpath(input_dir, "graph-assets-data.csv"), DataFrame, header = 1) # hide
-assets = leftjoin(graph_assets, assets_data, on=:name) # hide
-filtered_assets = assets[assets.type .== "storage", ["name", "type", "capacity", "capacity_storage_energy", "initial_storage_units", "initial_storage_level", "is_seasonal"]] # hide
+assets_data = CSV.read(joinpath(input_dir, "asset-both.csv"), DataFrame) # hide
+graph_assets = CSV.read(joinpath(input_dir, "asset.csv"), DataFrame) # hide
+assets = leftjoin(graph_assets, assets_data, on=:asset) # hide
+filtered_assets = assets[assets.type .== "storage", ["asset", "type", "capacity", "capacity_storage_energy",  "is_seasonal"]] # hide
 ```
 
 The `is_seasonal` parameter determines whether or not the storage asset uses the inter-temporal constraints. The `phs` is the only storage asset with this type of constraint and inter-storage level variable (i.e., $v^{\text{inter-storage}}_{\text{phs},p}$), and has 100MW capacity and 4800MWh of storage capacity (i.e., 48h discharge duration). The `battery` will only consider intra-temporal constraints with intra-storage level variables (i.e., $v^{\text{intra-storage}}_{\text{battery},k,b_k}$), and has 10MW capacity with 20MWh of storage capacity (i.e., 2h discharge duration).

--- a/docs/src/40-formulation.md
+++ b/docs/src/40-formulation.md
@@ -361,7 +361,8 @@ Storage assets using the method to avoid charging and discharging simultaneously
 \end{aligned}
 ```
 
-**Note**: The negative sign before the $v^{\text{accumulated units}}_{a,y}$ is because the accumulated units include the $p^{\text{init units}}_{a,y}$ in its calculation.
+!!! info
+    The negative sign before the $v^{\text{accumulated units}}_{a,y}$ is because the accumulated units include the $p^{\text{init units}}_{a,y}$ in its calculation.
 
 - Maximum output flows limit for storage assets such that $a \in \mathcal{A}^{\text{sb}}_y \setminus \mathcal{A}^{\text{i}}_y$
 
@@ -397,7 +398,8 @@ Storage assets using the method to avoid charging and discharging simultaneously
 \end{aligned}
 ```
 
-**Note**: The negative sign before the $v^{\text{accumulated units}}_{a,y}$ is because the accumulated units include the $p^{\text{init units}}_{a,y}$ in its calculation.
+!!! info
+    The negative sign before the $v^{\text{accumulated units}}_{a,y}$ is because the accumulated units include the $p^{\text{init units}}_{a,y}$ in its calculation.
 
 - Maximum input flows limit for storage assets such that $a \in \mathcal{A}^{\text{sb}}_y \setminus \mathcal{A}^{\text{i}}_y$
 
@@ -415,7 +417,7 @@ v^{\text{flow}}_{f,k_y,b_{k_y}} \geq 0 \quad \forall y \in \mathcal{Y}, \forall 
 
 ### [Unit Commitment Constraints](@id uc-constraints)
 
-Production and conversion assets within the set $\mathcal{A}^{\text{uc}}$ will contain the unit commitment constraints in the model. These constraints are based on the work of [Morales-España et al. (2013)](https://ieeexplore.ieee.org/document/6485014) and [Morales-España et al. (2014)](https://ieeexplore.ieee.org/document/6514884).
+Production and conversion assets within the set $\mathcal{A}^{\text{uc}}$ will contain the unit commitment constraints in the model. These constraints are based on the work of [Morales-España et al. (2013)](@ref math-references) and [Morales-España et al. (2014)](@ref math-references).
 
 The current version of the code only incorporates a basic unit commitment version of the constraints (i.e., utilizing only the unit commitment variable $v^{\text{units on}}$). However, upcoming versions will include more detailed constraints, incorporating startup and shutdown variables.
 
@@ -451,9 +453,10 @@ e^{\text{flow above min}}_{a,k_y,b_{k_y}} \geq 0  \quad
 
 Ramping constraints restrict the rate at which the output flow of a production or conversion asset can change. If the asset is part of the unit commitment set (e.g., $\mathcal{A}^{\text{uc}}_y$), the ramping limits apply to the flow above the minimum output, but if it is not, the ramping limits apply to the total output flow.
 
-Ramping constraints that take into account unit commitment variables are based on the work done by [Damcı-Kurt et. al (2016)](https://link.springer.com/article/10.1007/s10107-015-0919-9). Also, please note that since the current version of the code only handles the basic unit commitment implementation, the ramping constraints are applied to the assets in the set $\mathcal{A}^{\text{uc basic}}_y$.
+Ramping constraints that take into account unit commitment variables are based on the work done by [Damcı-Kurt et. al (2016)](@ref math-references). Also, please note that since the current version of the code only handles the basic unit commitment implementation, the ramping constraints are applied to the assets in the set $\mathcal{A}^{\text{uc basic}}_y$.
 
-> **Duration parameter**: The following constraints are multiplied by $p^{\text{duration}}_{b_{k_y}}$ on the right-hand side to adjust for the duration of the timesteps since the ramp parameters are defined as rates. This assumption is based on the idea that all timesteps are the same in this section, which simplifies the formulation. However, in a flexible temporal resolution context, this may not hold true, and the duration needs to be the minimum duration of all the outgoing flows at the timestep block $b_{k_y}$. For more information, please visit the concept section on flexible time resolution.
+!!! info "Duration parameter"
+    The following constraints are multiplied by $p^{\text{duration}}_{b_{k_y}}$ on the right-hand side to adjust for the duration of the timesteps since the ramp parameters are defined as rates. This assumption is based on the idea that all timesteps are the same in this section, which simplifies the formulation. However, in a flexible temporal resolution context, this may not hold true, and the duration needs to be the minimum duration of all the outgoing flows at the timestep block $b_{k_y}$. For more information, please visit the concept section on flexible time resolution.
 
 #### Maximum Ramp-Up Rate Limit WITH Unit Commitment Method
 
@@ -501,7 +504,7 @@ The balance constraint sense depends on the method selected in the asset file's 
 
 ### Constraints for Energy Storage Assets
 
-There are two types of constraints for energy storage assets: intra-temporal and inter-temporal. Intra-temporal constraints impose limits inside a representative period, while inter-temporal constraints combine information from several representative periods (e.g., to model seasonal storage). For more information on this topic, refer to the [concepts section](@ref storage-modeling) or [Tejada-Arango et al. (2018)](https://ieeexplore.ieee.org/document/8334256) and [Tejada-Arango et al. (2019)](https://doi.org/10.1016/j.energy.2019.116079).
+There are two types of constraints for energy storage assets: intra-temporal and inter-temporal. Intra-temporal constraints impose limits inside a representative period, while inter-temporal constraints combine information from several representative periods (e.g., to model seasonal storage). For more information on this topic, refer to the [concepts section](@ref storage-modeling) or [Tejada-Arango et al. (2018)](@ref math-references) and [Tejada-Arango et al. (2019)](@ref math-references).
 
 In addition, we define the following expression to determine the energy investment limit of the storage assets. This expression takes two different forms depending on whether the storage asset belongs to the set $\mathcal{A}^{\text{se}}$ or not.
 
@@ -727,7 +730,8 @@ The following constraints aggregate variables of different assets depending on t
 
 These constraints apply to assets in a group using the investment method $\mathcal{G}^{\text{ai}}_y$. They help impose an investment potential of a spatial area commonly shared by several assets that can be invested there.
 
-> **Note**: These constraints are applied to the investments each year. The model does not yet have investment limits to a group's accumulated invested capacity.
+!!! info
+    These constraints are applied to the investments each year. The model does not yet have investment limits to a group's accumulated invested capacity.
 
 ##### Minimum Investment Limit of a Group
 

--- a/docs/src/40-formulation.md
+++ b/docs/src/40-formulation.md
@@ -577,7 +577,7 @@ v^{\text{intra-storage}}_{a,k_y,b^{\text{first}}_{k_y}} \geq p^{\text{init stora
 
 This constraint allows us to consider the storage seasonality throughout the model's timeframe (e.g., a year). The parameter $p^{\text{map}}_{p_y,k_y}$ determines how much of the representative period $k_y$ is in the period $p_y$, and you can use a clustering technique to calculate it. For _TulipaEnergyModel.jl_, we recommend using [_TulipaClustering.jl_](https://github.com/TulipaEnergy/TulipaClustering.jl) to compute the clusters for the representative periods and their map.
 
-For the sake of simplicity, we show the constraint assuming the inter-storage level between two consecutive periods $p_y$; however, _TulipaEnergyModel.jl_ can handle more flexible period block definition through the timeframe definition in the model using the information in the file [`assets-timeframe-partitions.csv`](@ref assets-timeframe-partitions).
+For the sake of simplicity, we show the constraint assuming the inter-storage level between two consecutive periods $p_y$; however, _TulipaEnergyModel.jl_ can handle more flexible period block definition through the timeframe definition in the model using the information in the timeframe partitions file, see [schemas](@ref schemas).
 
 ```math
 \begin{aligned}
@@ -679,7 +679,7 @@ v^{\text{flow}}_{f,k_y,b_{k_y}} \geq - p^{\text{availability profile}}_{f,y,k_y,
 v^{\text{inv}}_{a,y} \leq \frac{p^{\text{inv limit}}_{a,y}}{p^{\text{capacity}}_{a}} \quad \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{i}}_y
 ```
 
-If the parameter `investment_integer` in the [`assets-data.csv`](@ref assets-data) file is set to true, then the right-hand side of this constraint uses a least integer function (floor function) to guarantee that the limit is integer.
+If the parameter `investment_integer` is set to true, then the right-hand side of this constraint uses a least integer function (floor function) to guarantee that the limit is integer.
 
 #### Maximum Energy Investment Limit for Assets
 
@@ -687,7 +687,7 @@ If the parameter `investment_integer` in the [`assets-data.csv`](@ref assets-dat
 v^{\text{inv energy}}_{a,y} \leq \frac{p^{\text{inv limit energy}}_{a,y}}{p^{\text{energy capacity}}_{a}} \quad \forall y \in \mathcal{Y},  \forall a \in \mathcal{A}^{\text{i}}_y \cap \mathcal{A}^{\text{se}}_y
 ```
 
-If the parameter `investment_integer_storage_energy` in the [`assets-data.csv`](@ref assets-data) file is set to true, then the right-hand side of this constraint uses a least integer function (floor function) to guarantee that the limit is integer.
+If the parameter `investment_integer_storage_energy` is set to true, then the right-hand side of this constraint uses a least integer function (floor function) to guarantee that the limit is integer.
 
 #### Maximum Investment Limit for Flows
 
@@ -695,7 +695,7 @@ If the parameter `investment_integer_storage_energy` in the [`assets-data.csv`](
 v^{\text{inv}}_{f,y} \leq \frac{p^{\text{inv limit}}_{f,y}}{p^{\text{capacity}}_{f}} \quad \forall y \in \mathcal{Y}, \forall f \in \mathcal{F}^{\text{ti}}_y
 ```
 
-If the parameter `investment_integer` in the [`flows-data.csv`](@ref flows-data) file is set to true, then the right-hand side of this constraint uses a least integer function (floor function) to guarantee that the limit is integer.
+If the parameter `investment_integer` is set to true, then the right-hand side of this constraint uses a least integer function (floor function) to guarantee that the limit is integer.
 
 ### [Inter-temporal Energy Constraints](@id inter-temporal-energy-constraints)
 

--- a/docs/src/50-schemas.md
+++ b/docs/src/50-schemas.md
@@ -1,0 +1,18 @@
+# [Model Parameters](@id schemas)
+
+The optimization model parameters with the input data must follow the schema below for each table. To create these tables we currently use CSV files that follow this same schema and then convert them into tables using TulipaIO, as shown in the basic example of the [Tutorials](@ref basic-example) section.
+
+The schemas can be accessed at any time after loading the package by typing `TulipaEnergyModel.schema_per_table_name` in the Julia console. Here is the complete list of model parameters in the schemas per table (or CSV file):
+
+```@eval
+using Markdown, TulipaEnergyModel
+
+Markdown.parse(
+    join(["- **`$filename`**\n" *
+        join(
+            ["  - `$f: $t`" for (f, t) in schema],
+            "\n",
+        ) for (filename, schema) in TulipaEnergyModel.schema_per_table_name
+    ] |> sort, "\n")
+)
+```

--- a/docs/src/60-structures.md
+++ b/docs/src/60-structures.md
@@ -1,0 +1,74 @@
+# [Model Structures](@id structures)
+
+```@contents
+Pages = ["60-structures.md"]
+Depth = 3
+```
+
+The list of relevant structures used in this package are listed below:
+
+## EnergyProblem
+
+The `EnergyProblem` structure is a wrapper around various other relevant structures.
+It hides the complexity behind the energy problem, making the usage more friendly, although more verbose.
+
+### Fields
+
+- `db_connection`: A DuckDB connection to the input tables in the model
+- `graph`: The Graph object that defines the geometry of the energy problem.
+- `model`: A JuMP.Model object representing the optimization model.
+- `objective_value`: The objective value of the solved problem (Float64).
+- `variables`: A [TulipaVariable](@ref TulipaVariable) structure to store all the information related to the variables in the model.
+- `constraints`: A [TulipaConstraint](@ref TulipaConstraint) structure to store all the information related to the constraints in the model.
+- `representative_periods`: A vector of [Representative Periods](@ref representative-periods).
+- `solved`: A boolean indicating whether the `model` has been solved or not.
+- `termination_status`: The termination status of the optimization model.
+- `timeframe`: A structure with the number of periods in the `representative_periods` and the mapping between the periods and their representatives.
+- `model_parameters`: A [ModelParameters](@ref ModelParameters) structure to store all the parameters that are exclusive of the model.
+- `years`: A vector with the information of all the milestone years.
+
+### Constructor
+
+The `EnergyProblem` can also be constructed using the minimal constructor below.
+
+- `EnergyProblem(connection)`: Constructs a new `EnergyProblem` object with the given `connection` that has been created and the data loaded into it using [TulipaIO](https://github.com/TulipaEnergy/TulipaIO.jl). The `graph`, `representative_periods`, `timeframe`, and `years` are computed using `create_internal_structures`.
+
+See the [basic example tutorial](@ref basic-example) to see how these can be used.
+
+## GraphAssetData
+
+This structure holds all the information of a given asset.
+These are stored inside the Graph.
+Given a graph `graph`, an asset `a` can be accessed through `graph[a]`.
+
+## GraphFlowData
+
+This structure holds all the information of a given flow.
+These are stored inside the Graph.
+Given a graph `graph`, a flow from asset `u` to asset `v` can be accessed through `graph[u, v]`.
+
+## [Timeframe](@id timeframe)
+
+The timeframe is the total period we want to analyze with the model. Usually this is a year, but it can be any length of time. A timeframe has two fields:
+
+- `num_periods`: The timeframe is defined by a certain number of periods. For instance, a year can be defined by 365 periods, each describing a day.
+- `map_periods_to_rp`: Indicates the periods of the timeframe that map into a [representative period](@ref representative-periods) and the weight of the representative period to construct that period.
+
+## [Representative Periods](@id representative-periods)
+
+The [timeframe](@ref timeframe) (e.g., a full year) is described by a selection of representative periods, for instance, days or weeks, that nicely summarize other similar periods. For example, we could model the year into 3 days, by clustering all days of the year into 3 representative days. Each one of these days is called a representative period. _TulipaEnergyModel.jl_ has the flexibility to consider representative periods of different lengths for the same timeframe (e.g., a year can be represented by a set of 4 days and 2 weeks). To obtain the representative periods, we recommend using [TulipaClustering](https://github.com/TulipaEnergy/TulipaClustering.jl).
+
+A representative period has three fields:
+
+- `weight`: Indicates how many representative periods are contained in the [timeframe](@ref timeframe); this is inferred automatically from `map_periods_to_rp` in the [timeframe](@ref timeframe).
+- `timesteps`: The number of timesteps blocks in the representative period.
+- `resolution`: The duration in time of each timestep.
+
+The number of timesteps and resolution work together to define the coarseness of the period.
+Nothing is defined outside of these timesteps; for instance, if the representative period represents a day and you want to specify a variable or constraint with a coarseness of 30 minutes. You need to define the number of timesteps to 48 and the resolution to `0.5`.
+
+## [Time Blocks](@id time-blocks)
+
+A time block is a range for which a variable or constraint is defined.
+It is a range of numbers, i.e., all integer numbers inside an interval.
+Time blocks are used for the periods in the [timeframe](@ref timeframe) and the timesteps in the [representative period](@ref representative-periods). Time blocks are disjunct (not overlapping), but do not have to be sequential.

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -28,9 +28,9 @@ function create_model!(energy_problem; kwargs...)
 end
 
 """
-    model = create_model(connection, graph, representative_periods, dataframes, timeframe; write_lp_file = false, enable_names = true)
+    model = create_model(args...; write_lp_file = false, enable_names = true)
 
-Create the energy model given the `graph`, `representative_periods`, dictionary of `dataframes` (created by [`construct_dataframes`](@ref)), and timeframe.
+Create the energy model manually. We recommend using [`create_model!`](@ref) instead.
 """
 function create_model(
     connection,

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -1,4 +1,4 @@
-export solve_model!, solve_model
+export solve_model!, solve_model, save_solution!
 
 """
     solve_model!(energy_problem[, optimizer; parameters, save_solution = true])

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -51,6 +51,9 @@ mutable struct TulipaVariable
     end
 end
 
+"""
+Structure to hold the JuMP constraints for the TulipaEnergyModel
+"""
 mutable struct TulipaConstraint
     indices::DataFrame
     table_name::String
@@ -311,16 +314,18 @@ Structure to hold all parts of an energy problem. It is a wrapper around various
 It hides the complexity behind the energy problem, making the usage more friendly, although more verbose.
 
 # Fields
+- `db_connection`: A DuckDB connection to the input tables in the model
 - `graph`: The Graph object that defines the geometry of the energy problem.
-- `representative_periods`: A vector of [Representative Periods](@ref representative-periods).
-- `constraints_partitions`: Dictionaries that connect pairs of asset and representative periods to [time partitions (vectors of time blocks)](@ref Partition)
-- `timeframe`: The number of periods of the `representative_periods`.
-- `dataframes`: The data frames used to linearize the variables and constraints. These are used internally in the model only.
-- `model_parameters`: The model parameters.
 - `model`: A JuMP.Model object representing the optimization model.
+- `objective_value`: The objective value of the solved problem (Float64).
+- `variables`: A [TulipaVariable](@ref TulipaVariable) structure to store all the information related to the variables in the model.
+- `constraints`: A [TulipaConstraint](@ref TulipaConstraint) structure to store all the information related to the constraints in the model.
+- `representative_periods`: A vector of [Representative Periods](@ref representative-periods).
 - `solved`: A boolean indicating whether the `model` has been solved or not.
-- `objective_value`: The objective value of the solved problem.
 - `termination_status`: The termination status of the optimization model.
+- `timeframe`: A structure with the number of periods in the `representative_periods` and the mapping between the periods and their representatives.
+- `model_parameters`: A [ModelParameters](@ref ModelParameters) structure to store all the parameters that are exclusive of the model.
+- `years`: A vector with the information of all the milestone years.
 
 # Constructor
 - `EnergyProblem(connection)`: Constructs a new `EnergyProblem` object with the given connection. The `constraints_partitions` field is computed from the `representative_periods`, and the other fields are initialized with default values.

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -311,7 +311,7 @@ Structure to hold all parts of an energy problem. It is a wrapper around various
 It hides the complexity behind the energy problem, making the usage more friendly, although more verbose.
 
 # Fields
-- `graph`: The [Graph](@ref) object that defines the geometry of the energy problem.
+- `graph`: The Graph object that defines the geometry of the energy problem.
 - `representative_periods`: A vector of [Representative Periods](@ref representative-periods).
 - `constraints_partitions`: Dictionaries that connect pairs of asset and representative periods to [time partitions (vectors of time blocks)](@ref Partition)
 - `timeframe`: The number of periods of the `representative_periods`.


### PR DESCRIPTION
~Blocked by #1000~

- Remove lower level usage of Tulipa to make it easier to update the internal until v1.0.0 is released.
- Add some notices indicating that the documentation is out-of-date (this only affects the latest build of the documentation, so we should make sure to update it before v0.11
- Fix small things to make the docs build

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #935

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
