### PR TITLE
Change sum(coef * var) to JuMP.add_to_expression

### DIFF
--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -225,9 +225,11 @@ function add_expression_terms_rep_period_constraints!(
                 end
                 if length(workspace_agg) > 0
                     # Step 1.2.2.
-                    cons.expressions[case.expr_key][cons_idx] = sum(
-                        duration * flow.container[var_idx] for (var_idx, duration) in workspace_agg
-                    )
+                    cons.expressions[case.expr_key][cons_idx] = JuMP.AffExpr(0.0)
+                    this_expr = cons.expressions[case.expr_key][cons_idx]
+                    for (var_idx, duration) in workspace_agg
+                        JuMP.add_to_expression!(this_expr, duration, flow.container[var_idx])
+                    end
                 end
                 if conditions_to_add_min_outgoing_flow_duration
                     cons.coefficients[:min_outgoing_flow_duration][cons_idx] =
@@ -537,10 +539,11 @@ function add_expression_terms_over_clustered_year_constraints!(
                 end
 
                 if length(workspace_aggregation) > 0
-                    cons.expressions[case.expr_key][cons_idx] = sum(
-                        coefficient * flow.container[var_idx] for
-                        (var_idx, coefficient) in workspace_aggregation
-                    )
+                    cons.expressions[case.expr_key][cons_idx] = JuMP.AffExpr(0.0)
+                    this_expr = cons.expressions[case.expr_key][cons_idx]
+                    for (var_idx, coefficient) in workspace_aggregation
+                        JuMP.add_to_expression!(this_expr, coefficient, flow.container[var_idx])
+                    end
                 end
             end
         end


### PR DESCRIPTION
@datejada identified the warning for summation generating expressions, but I could not figure out where. @matbesancon helped figure out that `sum(coef * var)` also falls into that situation.
A more visually appealing solution would be changing that to `dot(coeffs, vars)`, but we would need to create the vectors for that, so we resort to `JuMP.add_to_expression!`.
Hopefully the benchmark should reveal some speed up. 

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Related to #1014, missing warning.

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
