### PR TITLE
Refactor names in the ramping constraints

### DIFF
--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -16,10 +16,9 @@ function compute_constraints_indices(connection)
             :capacity_outgoing_non_investable_storage_with_binary,
             :capacity_outgoing_investable_storage_with_binary,
             :limit_units_on,
-            :ramping_with_unit_commitment,
+            :min_output_flow_with_unit_commitment,
             :max_output_flow_with_basic_unit_commitment,
             :max_ramp_with_unit_commitment,
-            :ramping_without_unit_commitment,
             :max_ramp_without_unit_commitment,
             :balance_storage_rep_period,
             :balance_storage_over_clustered_year,
@@ -207,7 +206,7 @@ function _create_constraints_tables(connection)
     DuckDB.query(
         connection,
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_ramping_with_unit_commitment AS
+        CREATE OR REPLACE TABLE cons_min_output_flow_with_unit_commitment AS
         SELECT
             nextval('id') AS index,
             t_high.*
@@ -252,22 +251,6 @@ function _create_constraints_tables(connection)
             AND asset.ramping
             AND asset.unit_commitment
             AND asset.unit_commitment_method = 'basic'
-        ",
-    )
-
-    DuckDB.query(
-        connection,
-        "CREATE OR REPLACE TEMP SEQUENCE id START 1;
-        CREATE OR REPLACE TABLE cons_ramping_without_unit_commitment AS
-        SELECT
-            nextval('id') AS index,
-            t_high.*
-        FROM t_highest_out_flows AS t_high
-        LEFT JOIN asset
-            ON t_high.asset = asset.asset
-        WHERE
-            asset.type in ('producer', 'storage', 'conversion')
-            AND NOT asset.unit_commitment
         ",
     )
 

--- a/src/constraints/ramping-and-unit-commitment.jl
+++ b/src/constraints/ramping-and-unit-commitment.jl
@@ -9,8 +9,7 @@ function add_ramping_constraints!(connection, model, variables, expressions, con
     indices_dict = Dict(
         table_name => _append_ramping_data_to_indices(connection, table_name) for
         table_name in (
-            :ramping_with_unit_commitment,
-            :ramping_without_unit_commitment,
+            :min_output_flow_with_unit_commitment,
             :max_ramp_without_unit_commitment,
             :max_ramp_with_unit_commitment,
             :max_output_flow_with_basic_unit_commitment,
@@ -32,8 +31,7 @@ function add_ramping_constraints!(connection, model, variables, expressions, con
                 ) * row.capacity for row in indices
             ]
         end for table_name in (
-            :ramping_with_unit_commitment,
-            :ramping_without_unit_commitment,
+            :min_output_flow_with_unit_commitment,
             :max_ramp_without_unit_commitment,
             :max_ramp_with_unit_commitment,
             :max_output_flow_with_basic_unit_commitment,
@@ -42,7 +40,7 @@ function add_ramping_constraints!(connection, model, variables, expressions, con
 
     # - Flow that is above the minimum operating point of the asset
     for table_name in (
-        :ramping_with_unit_commitment,
+        :min_output_flow_with_unit_commitment,
         :max_output_flow_with_basic_unit_commitment,
         :max_ramp_with_unit_commitment,
     )
@@ -84,7 +82,7 @@ function add_ramping_constraints!(connection, model, variables, expressions, con
     end
 
     # - Minimum output flow above the minimum operating point
-    let table_name = :ramping_with_unit_commitment, cons = constraints[table_name]
+    let table_name = :min_output_flow_with_unit_commitment, cons = constraints[table_name]
         indices = indices_dict[table_name]
         attach_constraint!(
             model,
@@ -214,7 +212,7 @@ function add_ramping_constraints!(connection, model, variables, expressions, con
         attach_constraint!(
             model,
             constraints[table_name],
-            :max_ramp_up_without_unit_commitment,
+            :max_ramp_down_without_unit_commitment,
             [
                 if row.time_block_start == 1
                     @constraint(model, 0 == 0) # Placeholder for case k = 1

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -143,16 +143,14 @@ function create_model(
         constraints,
     )
 
-    if !isempty(constraints[:ramping_with_unit_commitment].indices)
-        @timeit to "add_ramping_constraints!" add_ramping_constraints!(
-            connection,
-            model,
-            variables,
-            expressions,
-            constraints,
-            profiles,
-        )
-    end
+    @timeit to "add_ramping_constraints!" add_ramping_constraints!(
+        connection,
+        model,
+        variables,
+        expressions,
+        constraints,
+        profiles,
+    )
 
     if write_lp_file
         @timeit to "write lp file" JuMP.write_to_file(model, "model.lp")

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -660,8 +660,7 @@ function add_expressions_to_constraints!(
     end
 
     for table_name in (
-        :ramping_without_unit_commitment,
-        :ramping_with_unit_commitment,
+        :min_output_flow_with_unit_commitment,
         :max_ramp_with_unit_commitment,
         :max_ramp_without_unit_commitment,
         :max_output_flow_with_basic_unit_commitment,
@@ -700,8 +699,7 @@ function add_expressions_to_constraints!(
         expression_workspace,
     )
     for table_name in (
-        :ramping_without_unit_commitment,
-        :ramping_with_unit_commitment,
+        :min_output_flow_with_unit_commitment,
         :max_output_flow_with_basic_unit_commitment,
         :max_ramp_with_unit_commitment,
     )


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

This pull request involve renaming and removing certain constraints to better reflect their functionality.

Key changes include:

### Renaming Constraints:
* Renamed `:ramping_with_unit_commitment` to `:min_output_flow_with_unit_commitment` in various functions and queries, since it is only use for that constraint. [[1]](diffhunk://#diff-69d05e81e3a0108b62f96ef5cc25a2d0ee158dd1003e7addead1510c792aa005L19-L22) [[2]](diffhunk://#diff-69d05e81e3a0108b62f96ef5cc25a2d0ee158dd1003e7addead1510c792aa005L210-R209) [[3]](diffhunk://#diff-9670152e2f4006a9ce07817b6dbca4ba8573bd1b4484e1fb6de8d48295f8d928L12-R12) [[4]](diffhunk://#diff-9670152e2f4006a9ce07817b6dbca4ba8573bd1b4484e1fb6de8d48295f8d928L35-R34) [[5]](diffhunk://#diff-9670152e2f4006a9ce07817b6dbca4ba8573bd1b4484e1fb6de8d48295f8d928L45-R43) [[6]](diffhunk://#diff-9670152e2f4006a9ce07817b6dbca4ba8573bd1b4484e1fb6de8d48295f8d928L87-R85)

### Removing Constraints:
* Removed the `:ramping_without_unit_commitment` constraint from several functions and queries as it is no longer needed. [[1]](diffhunk://#diff-69d05e81e3a0108b62f96ef5cc25a2d0ee158dd1003e7addead1510c792aa005L258-L273) [[2]](diffhunk://#diff-9670152e2f4006a9ce07817b6dbca4ba8573bd1b4484e1fb6de8d48295f8d928L12-R12) [[3]](diffhunk://#diff-9670152e2f4006a9ce07817b6dbca4ba8573bd1b4484e1fb6de8d48295f8d928L35-R34) [[4]](diffhunk://#diff-43e9d15ce9a457e188412a614efc15efee4860e85525d1b47ef2892074e90d43L663-R663) [[5]](diffhunk://#diff-43e9d15ce9a457e188412a614efc15efee4860e85525d1b47ef2892074e90d43L703-R702)

### Adjusting Constraint Attachments:
* Fixed typo by changing the constraint attachment from `:max_ramp_up_without_unit_commitment` to `:max_ramp_down_without_unit_commitment` in the `add_ramping_constraints!` function.

### Simplifying Model Creation:
* Removed the conditional check for `:ramping_with_unit_commitment` before calling `add_ramping_constraints!` in the `create_model` function since we have both with and without ramping constraints in the function. So, this condition is no longer needed. [[1]](diffhunk://#diff-8f5d468dc215a26295813f05b1166efe656036ca27231da4e01c6a1657a7e03bL146) [[2]](diffhunk://#diff-8f5d468dc215a26295813f05b1166efe656036ca27231da4e01c6a1657a7e03bL155)

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1024 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
