### PR TITLE
Remove variable lookup that was created only for the strangle pattern

### DIFF
--- a/src/structures.jl
+++ b/src/structures.jl
@@ -22,14 +22,12 @@ mutable struct TulipaVariable
     indices::DataFrame
     table_name::String
     container::Vector{JuMP.VariableRef}
-    lookup::OrderedDict # TODO: This is probably not type stable so it's only used for strangling
 
     function TulipaVariable(connection, table_name::String)
         return new(
             DuckDB.query(connection, "SELECT * FROM $table_name") |> DataFrame,
             table_name,
             JuMP.VariableRef[],
-            Dict(),
         )
     end
 end

--- a/src/variables/investments.jl
+++ b/src/variables/investments.jl
@@ -19,10 +19,6 @@ function _create_investment_variable!(
             base_name = "$name[" * join(keys_from_row(row), ",") * "]"
         ) for row in eachrow(this_var.indices)
     ]
-    this_var.lookup = OrderedDict(
-        keys_from_row(row) => var for
-        (var, row) in zip(this_var.container, eachrow(this_var.indices))
-    )
     return
 end
 


### PR DESCRIPTION
This was created for the strangle pattern during refactoring, and now it is not necessary anymore.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Related to #701 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
