### PR TITLE
Always saving the solution when using run scenario

### DIFF
--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -31,10 +31,11 @@ function run_scenario(
 
     @timeit to "create_model!" create_model!(energy_problem; write_lp_file, enable_names)
 
-    @timeit to "solve and store solution" solve_model!(energy_problem, optimizer; parameters)
+    @timeit to "solve_model!" solve_model!(energy_problem, optimizer; parameters)
+
+    @timeit to "save_solution!" save_solution!(energy_problem)
 
     if output_folder != ""
-        @timeit to "save_solution" save_solution!(energy_problem)
         @timeit to "export_solution_to_csv_files" export_solution_to_csv_files(
             output_folder,
             energy_problem,

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -1,7 +1,7 @@
 export run_scenario
 
 """
-    energy_problem = run_scenario(connection; optimizer, parameters, write_lp_file, log_file, show_log)
+    energy_problem = run_scenario(connection; output_folder, optimizer, parameters, model_parameters_file, write_lp_file, enable_names, log_file, show_log)
 
 Run the scenario in the given `connection` and return the energy problem.
 
@@ -11,6 +11,9 @@ The `optimizer` and `parameters` keyword arguments can be used to change the opt
 Set `write_lp_file = true` to export the problem that is sent to the solver to a file for viewing.
 Set `enable_names = false` to turn off variable and constraint names (faster model creation).
 Set `show_log = false` to silence printing the log while running.
+
+Specify a `output_folder` name to export the solution to CSV files.
+Specify a `model_parameters_file` name to load the model parameters from a TOML file.
 Specify a `log_file` name to export the log to a file.
 """
 function run_scenario(


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

This pull request includes changes in the `run_scenario` function. The changes focus on improving the names in the timing and always saving the solution when using this function. Since this function is a wrapper of the individual steps, keeping the solution should be part of the steps while exporting should remain optional.

Also there is improvements in the docstring of the funtion.


## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
There is no related issue.

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
