### PR TITLE
Improvements to creating expressions attached to constraints

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -47,14 +47,6 @@ function create_model(
     write_lp_file = false,
     enable_names = true,
 )
-    # Maximum timestep
-    Tmax = only(
-        row[1] for
-        row in DuckDB.query(connection, "SELECT MAX(num_timesteps) FROM rep_periods_data")
-    )
-
-    expression_workspace = Vector{JuMP.AffExpr}(undef, Tmax)
-
     ## Model
     model = JuMP.Model()
 
@@ -71,7 +63,6 @@ function create_model(
         connection,
         variables,
         constraints,
-        expression_workspace,
     )
 
     ## Expressions for multi-year investment

--- a/src/expressions/intersection.jl
+++ b/src/expressions/intersection.jl
@@ -1,0 +1,164 @@
+"""
+    attach_expression_on_constraints_grouping_variables!(
+        connection,
+        constraint,
+        variable,
+        expr_name;
+        agg_strategy
+    )
+
+Computes the intersection of the constraint and variable grouping by (:asset,
+:year, :rep_period).
+
+The intersection is made on time blocks, so both the constraint table and the
+variable table must have columns index, time_block_start and time_block_end.
+
+The variable `expr_name` will be the name of the attached expression.
+
+The `agg_strategy` must be either `:sum`, `:mean`, and `:unique_sum`,
+indicating how to aggregate the variables for a given constraint time block.
+
+# Implementation
+
+The expression uses a workspace to store all variables defined for each timestep.
+The idea of this algorithm is to append all variables defined at time
+`timestep` in `workspace[timestep]` and then aggregate then for the constraint
+time block.
+
+The algorithm works like this:
+
+1. Loop over each group of (asset, year, rep_period)
+1.1. Loop over each variable in the group: (var_idx, var_time_block_start, var_time_block_end)
+1.1.1. Loop over each timestep in var_time_block_start:var_time_block_end
+1.1.1.1. Compute the coefficient of the variable based on the rep_period
+  resolution and the variable efficiency
+1.1.1.2. Store (var_idx, coefficient) in workspace[timestep]
+1.2. Loop over each constraint in the group: (cons_idx, cons_time_block_start, cons_time_block_end)
+1.2.1. Aggregate all variables in workspace[timestep] for timestep in the time
+  block to create a list of variable indices and their coefficients [(var_idx1, coef1), ...]
+1.2.2. Compute the expression using the variable container, the indices and coefficients
+
+Notes:
+- On step 1.2.1, the aggregation can be by either
+    - :sum - add the coefficients
+    - :mean - add the coefficients and divide by number of times the variable appears
+    - :unique_sum - use 1.0 for the coefficient (this is not robust)
+"""
+function attach_expression_on_constraints_grouping_variables!(
+    connection,
+    cons::TulipaConstraint,
+    var::TulipaVariable,
+    expr_name;
+    agg_strategy::Symbol,
+)
+    if !(agg_strategy in (:sum, :mean, :unique_sum))
+        error("Argument $agg_strategy must be :sum, :mean, or :unique_sum")
+    end
+    Tmax = only(
+        row[1] for
+        row in DuckDB.query(connection, "SELECT MAX(num_timesteps) FROM rep_periods_data")
+    )::Int32
+
+    workspace = [Dict{Int,Float64}() for _ in 1:Tmax]
+
+    grouped_cons_table_name = "t_grouped_$(cons.table_name)"
+    _create_group_table_if_not_exist!(
+        connection,
+        cons.table_name,
+        grouped_cons_table_name,
+        [:asset, :year, :rep_period],
+        [:index, :time_block_start, :time_block_end],
+    )
+
+    grouped_var_table_name = "t_grouped_$(var.table_name)"
+    _create_group_table_if_not_exist!(
+        connection,
+        var.table_name,
+        grouped_var_table_name,
+        [:asset, :year, :rep_period],
+        [:index, :time_block_start, :time_block_end],
+    )
+
+    num_rows = size(cons.indices, 1)
+    attach_expression!(cons, expr_name, Vector{JuMP.AffExpr}(undef, num_rows))
+    cons.expressions[expr_name] .= JuMP.AffExpr(0.0)
+
+    # Loop over each group
+    for group_row in DuckDB.query(
+        connection,
+        "SELECT
+            cons.asset,
+            cons.year,
+            cons.rep_period,
+            cons.index AS cons_idx,
+            cons.time_block_start AS cons_time_block_start,
+            cons.time_block_end AS cons_time_block_end,
+            var.index AS var_idx,
+            var.time_block_start AS var_time_block_start,
+            var.time_block_end AS var_time_block_end,
+        FROM $grouped_cons_table_name AS cons
+        LEFT JOIN $grouped_var_table_name AS var
+            ON cons.asset = var.asset
+            AND cons.year = var.year
+            AND cons.rep_period = var.rep_period
+        WHERE
+            len(var.index) > 0
+        ",
+    )
+        empty!.(workspace)
+        # Loop over each variable in the group
+        for (var_idx, time_block_start, time_block_end) in zip(
+            group_row.var_idx::Vector{Union{Missing,Int64}},
+            group_row.var_time_block_start::Vector{Union{Missing,Int32}},
+            group_row.var_time_block_end::Vector{Union{Missing,Int32}},
+        )
+            for timestep in time_block_start:time_block_end
+                workspace[timestep][var_idx] = 1.0
+            end
+        end
+
+        # Loop over each constraint
+        for (cons_idx, time_block_start, time_block_end) in zip(
+            group_row.cons_idx::Vector{Union{Missing,Int64}},
+            group_row.cons_time_block_start::Vector{Union{Missing,Int32}},
+            group_row.cons_time_block_end::Vector{Union{Missing,Int32}},
+        )
+            time_block = time_block_start:time_block_end
+            # We keep the coefficient and count to compute the mean later
+            workspace_coef_agg = Dict{Int,Float64}()
+            workspace_count_agg = Dict{Int,Int}()
+
+            for timestep in time_block
+                for (var_idx, var_coefficient) in workspace[timestep]
+                    if !haskey(workspace_coef_agg, var_idx)
+                        # First time a variable is encountered it adds to the aggregation
+                        workspace_coef_agg[var_idx] = var_coefficient
+                        workspace_count_agg[var_idx] = 1
+                    else
+                        # For the other times, aggregate the coefficient and increase the counter
+                        workspace_coef_agg[var_idx] += var_coefficient
+                        workspace_count_agg[var_idx] += 1
+                    end
+                end
+            end
+
+            if length(workspace_coef_agg) > 0
+                cons.expressions[expr_name][cons_idx] = JuMP.AffExpr(0.0)
+                this_expr = cons.expressions[expr_name][cons_idx]
+                for (var_idx, coef) in workspace_coef_agg
+                    count = workspace_count_agg[var_idx]
+
+                    if agg_strategy == :sum
+                        JuMP.add_to_expression!(this_expr, coef, var.container[var_idx])
+                    elseif agg_strategy == :mean
+                        JuMP.add_to_expression!(this_expr, coef / count, var.container[var_idx])
+                    elseif agg_strategy == :unique_sum
+                        JuMP.add_to_expression!(this_expr, 1.0, var.container[var_idx])
+                    end
+                end
+            end
+        end
+    end
+
+    return
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -67,9 +67,9 @@ function _create_group_table_if_not_exist!(
     if _check_if_table_exists(connection, grouped_table_name)
         return
     elseif length(group_by_columns) == 0
-        error("`group_by_columns` cannot be empty")
+        throw(ArgumentError("`group_by_columns` cannot be empty"))
     elseif length(array_agg_columns) == 0
-        error("`array_agg_columns` cannot be empty")
+        throw(ArgumentError("`array_agg_columns` cannot be empty"))
     end
 
     select_string = join(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,10 @@
 # Auxiliary functions to create the model
 
+"""
+    _check_if_table_exists(connection, table_name)
+
+Check if table `table_name` exists in the connection.
+"""
 function _check_if_table_exists(connection, table_name)
     existence_query = DBInterface.execute(
         connection,
@@ -28,4 +33,64 @@ function _profile_aggregate(profiles, tuple_key::Tuple, time_block, agg_function
     end
     profile_value = profiles[tuple_key]
     return agg_function(skipmissing(profile_value[time_block]))
+end
+
+"""
+    _create_group_table_if_not_exist!(
+        connection,
+        table_name,
+        grouped_table_name,
+        group_by_columns,
+        array_agg_columns;
+        rename_columns = Dict(),
+        order_agg_by = "index",
+    )
+
+Create a grouped table grouping the `table_name` into the `grouped_table_name`.
+The `group_by_columns` are the columns that are used in the group by (e.g., asset, year, rep_period),
+and the `array_agg_columns` are the columns that are aggregated into arrays (e.g., index, time_block_start, time_block_end).
+
+It is expected that the original table has an `index` column, which is used in the ordering of the `array_agg_columns`.
+Otherwise, please pass the argument `order_agg_by` with the column that should be used for this ordering.
+
+If one of the columns has to be renamed, use the `rename_columns` dictionary.
+"""
+function _create_group_table_if_not_exist!(
+    connection,
+    table_name,
+    grouped_table_name,
+    group_by_columns,
+    array_agg_columns;
+    rename_columns = Dict(),
+    order_agg_by = :index,
+)
+    if _check_if_table_exists(connection, grouped_table_name)
+        return
+    elseif length(group_by_columns) == 0
+        error("`group_by_columns` cannot be empty")
+    elseif length(array_agg_columns) == 0
+        error("`array_agg_columns` cannot be empty")
+    end
+
+    select_string = join(
+        (
+            "t.$col" * (haskey(rename_columns, col) ? " AS $(rename_columns[col])" : "") for
+            col in group_by_columns
+        ),
+        ", ",
+    )
+    group_by_string = join(("t.$col" for col in group_by_columns), ", ")
+    array_agg_string = join(
+        ("ARRAY_AGG(t.$col ORDER BY $order_agg_by) AS $col" for col in array_agg_columns),
+        ", ",
+    )
+
+    sql_query = "CREATE TEMP TABLE $grouped_table_name AS
+        SELECT $select_string, $array_agg_string,
+        FROM $table_name AS t
+        GROUP BY $group_by_string"
+
+    DuckDB.query(connection, sql_query)
+
+    return
 end

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -1,0 +1,83 @@
+@testset "Test _create_group_table_if_not_exist" begin
+    # Test data
+    table_name = "test_table"
+    connection = DBInterface.connect(DuckDB.DB)
+    DuckDB.register_table(
+        connection,
+        (
+            (index = 1, asset = "a", year = 1900),
+            (index = 2, asset = "a", year = 2000),
+            (index = 3, asset = "b", year = 1900),
+            (index = 4, asset = "b", year = 2000),
+        ),
+        table_name,
+    )
+
+    # First, the table does not exist
+    grouped_table_name = "grouped_$table_name"
+    @test !TulipaEnergyModel._check_if_table_exists(connection, grouped_table_name)
+
+    # Create the table and check content
+    TulipaEnergyModel._create_group_table_if_not_exist!(
+        connection,
+        table_name,
+        grouped_table_name,
+        [:asset],
+        [:index, :year],
+    )
+    @test TulipaEnergyModel._check_if_table_exists(connection, grouped_table_name)
+    df = DataFrame(DuckDB.query(connection, "FROM $grouped_table_name")) |> sort
+    @test names(df) == ["asset", "index", "year"]
+    @test size(df) == (2, 3)
+    @test df.asset == ["a", "b"]
+    @test df.index == [[1, 2], [3, 4]]
+    @test df.year == [[1900, 2000], [1900, 2000]]
+
+    # Run it again with different values to check that it doesn't run
+    TulipaEnergyModel._create_group_table_if_not_exist!(
+        connection,
+        table_name,
+        grouped_table_name,
+        [:year],
+        [:index, :asset],
+    )
+    df = DataFrame(DuckDB.query(connection, "FROM $grouped_table_name")) |> sort
+    @test names(df) == ["asset", "index", "year"]
+    @test size(df) == (2, 3)
+    @test df.asset == ["a", "b"]
+    @test df.index == [[1, 2], [3, 4]]
+    @test df.year == [[1900, 2000], [1900, 2000]]
+
+    # Delete table and run with different values
+    DuckDB.query(connection, "DROP TABLE $grouped_table_name")
+    TulipaEnergyModel._create_group_table_if_not_exist!(
+        connection,
+        table_name,
+        grouped_table_name,
+        [:year],
+        [:index, :asset],
+    )
+    df = DataFrame(DuckDB.query(connection, "FROM $grouped_table_name")) |> sort
+    @test names(df) == ["year", "index", "asset"]
+    @test size(df) == (2, 3)
+    @test df.year == [1900, 2000]
+    @test df.asset == [["a", "b"], ["a", "b"]]
+    @test df.index == [[1, 3], [2, 4]]
+
+    # Check failures
+    DuckDB.query(connection, "DROP TABLE $grouped_table_name")
+    @test_throws "`group_by_columns` cannot be empty" TulipaEnergyModel._create_group_table_if_not_exist!(
+        connection,
+        table_name,
+        grouped_table_name,
+        [],
+        [:index, :asset],
+    )
+    @test_throws "`array_agg_columns` cannot be empty" TulipaEnergyModel._create_group_table_if_not_exist!(
+        connection,
+        table_name,
+        grouped_table_name,
+        [:asset],
+        [],
+    )
+end


### PR DESCRIPTION
These are some improvements related to the creation of expressions attached to constraints.
There are three types of expressions attached to constraints:

- cons + var_flow on rep_period
- cons + var_flow over clustered year
- cons + asset-based var on rep_period (is_charging and units_on)

This PR makes it so the third one is used for both cases.

- Update is_charging expressions to use tables
- Create helper function `_create_group_table_if_not_exist`
- Create new file `src/expressions/intersection.jl` with a new function `attach_expression_on_constraints_grouping_variables`
- Use the new functions for both `is_charging` and `units_on`
- Pass workspace to attach_expressions_on_constraints...


<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Related to #701

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
