### PR TITLE
docs(formulation): Update formatting of tip admonition blocks by indenting the content in the raw markdown

### DIFF
--- a/docs/src/40-formulation.md
+++ b/docs/src/40-formulation.md
@@ -364,7 +364,7 @@ Storage assets using the method to avoid charging and discharging simultaneously
 ```
 
 !!! info
-The negative sign before the $v^{\text{available units}}_{a,y}$ is because the available units include the $p^{\text{init units}}_{a,y}$ in its calculation.
+    The negative sign before the $v^{\text{available units}}_{a,y}$ is because the available units include the $p^{\text{init units}}_{a,y}$ in its calculation.
 
 - Maximum output flows limit for storage assets such that $a \in \mathcal{A}^{\text{sb}}_y \setminus \mathcal{A}^{\text{i}}_y$
 
@@ -401,7 +401,7 @@ Storage assets using the method to avoid charging and discharging simultaneously
 ```
 
 !!! info
-The negative sign before the $v^{\text{available units}}_{a,y}$ is because the available units include the $p^{\text{init units}}_{a,y}$ in its calculation.
+    The negative sign before the $v^{\text{available units}}_{a,y}$ is because the available units include the $p^{\text{init units}}_{a,y}$ in its calculation.
 
 - Maximum input flows limit for storage assets such that $a \in \mathcal{A}^{\text{sb}}_y \setminus \mathcal{A}^{\text{i}}_y$
 
@@ -458,7 +458,7 @@ Ramping constraints restrict the rate at which the output flow of a production o
 Ramping constraints that take into account unit commitment variables are based on the work done by [Damcı-Kurt et. al (2016)](@ref math-references). Also, please note that since the current version of the code only handles the basic unit commitment implementation, the ramping constraints are applied to the assets in the set $\mathcal{A}^{\text{uc basic}}_y$.
 
 !!! info "Duration parameter"
-The following constraints are multiplied by $p^{\text{duration}}_{b_{k_y}}$ on the right-hand side to adjust for the duration of the timesteps since the ramp parameters are defined as rates. This assumption is based on the idea that all timesteps are the same in this section, which simplifies the formulation. However, in a flexible temporal resolution context, this may not hold true, and the duration needs to be the minimum duration of all the outgoing flows at the timestep block $b_{k_y}$. For more information, please visit the concept section on flexible time resolution.
+    The following constraints are multiplied by $p^{\text{duration}}_{b_{k_y}}$ on the right-hand side to adjust for the duration of the timesteps since the ramp parameters are defined as rates. This assumption is based on the idea that all timesteps are the same in this section, which simplifies the formulation. However, in a flexible temporal resolution context, this may not hold true, and the duration needs to be the minimum duration of all the outgoing flows at the timestep block $b_{k_y}$. For more information, please visit the concept section on flexible time resolution.
 
 #### Maximum Ramp-Up Rate Limit WITH Unit Commitment Method
 
@@ -733,7 +733,7 @@ The following constraints aggregate variables of different assets depending on t
 These constraints apply to assets in a group using the investment method $\mathcal{G}^{\text{ai}}_y$. They help impose an investment potential of a spatial area commonly shared by several assets that can be invested there.
 
 !!! info
-These constraints are applied to the investments each year. The model does not yet have investment limits to a group's available invested capacity.
+    These constraints are applied to the investments each year. The model does not yet have investment limits to a group's available invested capacity.
 
 ##### Minimum Investment Limit of a Group
 


### PR DESCRIPTION
Currently the docs render blank callout notes on this page https://tulipaenergy.github.io/TulipaEnergyModel.jl/stable/40-formulation/:

Notice the empty "Info" below in the following screenshot:

<img width="870" alt="image" src="https://github.com/user-attachments/assets/db87fcc2-cfa8-4782-a67f-26b555266ce7" />

Admonition content should be indented to be rendered correctly: https://documenter.juliadocs.org/stable/showcase/#Admonitions

This PR indents the contents of all the `!!! tip` admonitions on the formulation page.

## Checklist


- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
