### PR TITLE
Rename index to id to prevent using sql keyword

### DIFF
--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -30,8 +30,8 @@ function add_capacity_constraints!(connection, model, expressions, constraints, 
                                     Statistics.mean,
                                     1.0,
                                 )
-                                availability_agg * expr_avail[avail_index]
-                            end for (avail_profile_name, avail_index) in
+                                availability_agg * expr_avail[avail_id]
+                            end for (avail_profile_name, avail_id) in
                             zip(row.avail_profile_name, row.avail_indices)
                         )
                     )
@@ -93,7 +93,7 @@ function add_capacity_constraints!(connection, model, expressions, constraints, 
                         row.capacity *
                         (
                             row.avail_initial_units * (1 - is_charging) +
-                            sum(expr_avail[avail_index] for avail_index in row.avail_indices)
+                            sum(expr_avail[avail_id] for avail_id in row.avail_indices)
                         )
                     )
                 end for (row, is_charging) in zip(indices, cons.expressions[:is_charging])
@@ -142,7 +142,7 @@ function add_capacity_constraints!(connection, model, expressions, constraints, 
                         model,
                         availability_agg *
                         row.capacity *
-                        sum(expr_avail[avail_index] for avail_index in row.avail_indices)
+                        sum(expr_avail[avail_id] for avail_id in row.avail_indices)
                     )
                 end for row in indices
             ],
@@ -199,7 +199,7 @@ function add_capacity_constraints!(connection, model, expressions, constraints, 
                         row.capacity *
                         (
                             row.avail_initial_units * is_charging +
-                            sum(expr_avail[avail_index] for avail_index in row.avail_indices)
+                            sum(expr_avail[avail_id] for avail_id in row.avail_indices)
                         )
                     )
                 end for (row, is_charging) in zip(indices, cons.expressions[:is_charging])
@@ -330,13 +330,13 @@ function _append_capacity_data_to_indices(connection, table_name)
     return DuckDB.query(
         connection,
         "SELECT
-            ANY_VALUE(cons.index) AS index,
+            ANY_VALUE(cons.id) AS id,
             ANY_VALUE(cons.asset) AS asset,
             ANY_VALUE(cons.year) AS year,
             ANY_VALUE(cons.rep_period) AS rep_period,
             ANY_VALUE(cons.time_block_start) AS time_block_start,
             ANY_VALUE(cons.time_block_end) AS time_block_end,
-            ARRAY_AGG(expr_avail.index) AS avail_indices,
+            ARRAY_AGG(expr_avail.id) AS avail_indices,
             ARRAY_AGG(expr_avail.commission_year) AS avail_commission_year,
             SUM(expr_avail.initial_units) AS avail_initial_units,
             ARRAY_AGG(avail_profile.profile_name) AS avail_profile_name,
@@ -361,8 +361,8 @@ function _append_capacity_data_to_indices(connection, table_name)
             ON cons.asset = avail_profile.asset
             AND expr_avail.commission_year = avail_profile.commission_year
             AND assets_profiles.profile_type = 'availability'
-        GROUP BY cons.index
-        ORDER BY cons.index
+        GROUP BY cons.id
+        ORDER BY cons.id
         ",
     )
 end

--- a/src/constraints/consumer.jl
+++ b/src/constraints/consumer.jl
@@ -75,7 +75,7 @@ function _create_consumer_table(connection)
             ON cons.asset = assets_profiles.asset
             AND cons.year = assets_profiles.commission_year
             AND assets_profiles.profile_type = 'demand' -- This must be a ON condition not a where (note 1)
-        ORDER BY cons.index -- order is important
+        ORDER BY cons.id -- order is important
         ",
     )
 end

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -39,7 +39,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_balance_conversion AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             asset.asset,
             t_low.year,
             t_low.rep_period,
@@ -63,7 +63,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_balance_consumer AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_all_flows AS t_high
         LEFT JOIN asset
@@ -78,7 +78,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_balance_hub AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_all_flows AS t_high
         LEFT JOIN asset
@@ -93,7 +93,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_capacity_incoming AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_in_flows AS t_high
         LEFT JOIN asset
@@ -107,7 +107,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_capacity_incoming_non_investable_storage_with_binary AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_in_flows AS t_high
         LEFT JOIN asset
@@ -127,7 +127,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_capacity_incoming_investable_storage_with_binary AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_in_flows AS t_high
         LEFT JOIN asset
@@ -147,7 +147,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_capacity_outgoing AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_out_flows AS t_high
         LEFT JOIN asset
@@ -161,7 +161,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_capacity_outgoing_non_investable_storage_with_binary AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_out_flows AS t_high
         LEFT JOIN asset
@@ -181,7 +181,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_capacity_outgoing_investable_storage_with_binary AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_out_flows AS t_high
         LEFT JOIN asset
@@ -208,7 +208,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_min_output_flow_with_unit_commitment AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_assets_and_out_flows AS t_high
         LEFT JOIN asset
@@ -224,7 +224,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_max_output_flow_with_basic_unit_commitment AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             t_high.*
         FROM t_highest_assets_and_out_flows AS t_high
         LEFT JOIN asset
@@ -241,7 +241,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_max_ramp_with_unit_commitment AS
         SELECT
-           nextval('id') AS index,
+           nextval('id') AS id,
            t_high.*
         FROM t_highest_assets_and_out_flows AS t_high
         LEFT JOIN asset
@@ -259,7 +259,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_max_ramp_without_unit_commitment AS
         SELECT
-           nextval('id') AS index,
+           nextval('id') AS id,
            t_high.*
         FROM t_highest_out_flows AS t_high
         LEFT JOIN asset
@@ -291,7 +291,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_min_energy_over_clustered_year AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             attr.asset,
             attr.year,
             attr.period_block_start,
@@ -312,7 +312,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_max_energy_over_clustered_year AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             attr.asset,
             attr.year,
             attr.period_block_start,
@@ -331,14 +331,14 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_transport_flow_limit AS
         SELECT
-           nextval('id') AS index,
+           nextval('id') AS id,
            var_flow.from,
            var_flow.to,
            var_flow.year,
            var_flow.rep_period,
            var_flow.time_block_start,
            var_flow.time_block_end,
-           var_flow.index AS var_flow_index
+           var_flow.id AS var_flow_id
         FROM var_flow
         LEFT JOIN flow
             ON flow.from_asset = var_flow.from
@@ -353,7 +353,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_group_max_investment_limit AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             ga.name,
             ga.milestone_year,
             ga.max_investment_limit,
@@ -369,7 +369,7 @@ function _create_constraints_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE cons_group_min_investment_limit AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             ga.name,
             ga.milestone_year,
             ga.min_investment_limit,

--- a/src/constraints/energy.jl
+++ b/src/constraints/energy.jl
@@ -78,7 +78,7 @@ function _append_energy_data_to_indices(connection, table_name, min_or_max)
             ON cons.asset = assets_timeframe_profiles.asset
             AND cons.year = assets_timeframe_profiles.commission_year
             AND assets_timeframe_profiles.profile_type = '$(min_or_max)_energy'
-        ORDER BY cons.index
+        ORDER BY cons.id
         ",
     )
 end

--- a/src/constraints/group.jl
+++ b/src/constraints/group.jl
@@ -17,7 +17,7 @@ function add_group_constraints!(connection, model, variables, constraints)
                 @expression(
                     model,
                     sum(
-                        asset_row.capacity * assets_investment[asset_row.index] for
+                        asset_row.capacity * assets_investment[asset_row.id] for
                         asset_row in _get_assets_in_group(connection, row.name)
                     )
                 ) for row in cons.indices
@@ -66,7 +66,7 @@ function _get_assets_in_group(connection, group)
     return DuckDB.query(
         connection,
         "SELECT
-            var.index,
+            var.id,
             asset.group,
             asset.capacity,
         FROM var_assets_investment AS var

--- a/src/expressions/intersection.jl
+++ b/src/expressions/intersection.jl
@@ -11,7 +11,7 @@ Computes the intersection of the constraint and variable grouping by (:asset,
 :year, :rep_period).
 
 The intersection is made on time blocks, so both the constraint table and the
-variable table must have columns index, time_block_start and time_block_end.
+variable table must have columns id, time_block_start and time_block_end.
 
 The variable `expr_name` will be the name of the attached expression.
 
@@ -28,15 +28,15 @@ time block.
 The algorithm works like this:
 
 1. Loop over each group of (asset, year, rep_period)
-1.1. Loop over each variable in the group: (var_idx, var_time_block_start, var_time_block_end)
+1.1. Loop over each variable in the group: (var_id, var_time_block_start, var_time_block_end)
 1.1.1. Loop over each timestep in var_time_block_start:var_time_block_end
 1.1.1.1. Compute the coefficient of the variable based on the rep_period
   resolution and the variable efficiency
-1.1.1.2. Store (var_idx, coefficient) in workspace[timestep]
-1.2. Loop over each constraint in the group: (cons_idx, cons_time_block_start, cons_time_block_end)
+1.1.1.2. Store (var_id, coefficient) in workspace[timestep]
+1.2. Loop over each constraint in the group: (cons_id, cons_time_block_start, cons_time_block_end)
 1.2.1. Aggregate all variables in workspace[timestep] for timestep in the time
-  block to create a list of variable indices and their coefficients [(var_idx1, coef1), ...]
-1.2.2. Compute the expression using the variable container, the indices and coefficients
+  block to create a list of variable ids and their coefficients [(var_id1, coef1), ...]
+1.2.2. Compute the expression using the variable container, the ids and coefficients
 
 Notes:
 - On step 1.2.1, the aggregation can be by either
@@ -62,7 +62,7 @@ function attach_expression_on_constraints_grouping_variables!(
         cons.table_name,
         grouped_cons_table_name,
         [:asset, :year, :rep_period],
-        [:index, :time_block_start, :time_block_end],
+        [:id, :time_block_start, :time_block_end],
     )
 
     grouped_var_table_name = "t_grouped_$(var.table_name)"
@@ -71,7 +71,7 @@ function attach_expression_on_constraints_grouping_variables!(
         var.table_name,
         grouped_var_table_name,
         [:asset, :year, :rep_period],
-        [:index, :time_block_start, :time_block_end],
+        [:id, :time_block_start, :time_block_end],
     )
 
     num_rows = get_num_rows(connection, cons)
@@ -85,39 +85,39 @@ function attach_expression_on_constraints_grouping_variables!(
             cons.asset,
             cons.year,
             cons.rep_period,
-            cons.index AS cons_idx,
-            cons.time_block_start AS cons_time_block_start,
-            cons.time_block_end AS cons_time_block_end,
-            var.index AS var_idx,
-            var.time_block_start AS var_time_block_start,
-            var.time_block_end AS var_time_block_end,
+            cons.id AS cons_id_vec,
+            cons.time_block_start AS cons_time_block_start_vec,
+            cons.time_block_end AS cons_time_block_end_vec,
+            var.id AS var_id_vec,
+            var.time_block_start AS var_time_block_start_vec,
+            var.time_block_end AS var_time_block_end_vec,
         FROM $grouped_cons_table_name AS cons
         LEFT JOIN $grouped_var_table_name AS var
             ON cons.asset = var.asset
             AND cons.year = var.year
             AND cons.rep_period = var.rep_period
         WHERE
-            len(var.index) > 0
+            len(var.id) > 0
         ",
     )
         empty!.(workspace)
 
         # Loop over each variable in the group
-        for (var_idx::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
-            group_row.var_idx::Vector{Union{Missing,Int64}},
-            group_row.var_time_block_start::Vector{Union{Missing,Int32}},
-            group_row.var_time_block_end::Vector{Union{Missing,Int32}},
+        for (var_id::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
+            group_row.var_id_vec::Vector{Union{Missing,Int64}},
+            group_row.var_time_block_start_vec::Vector{Union{Missing,Int32}},
+            group_row.var_time_block_end_vec::Vector{Union{Missing,Int32}},
         )
             for timestep in time_block_start:time_block_end
-                workspace[timestep][var_idx] = 1.0
+                workspace[timestep][var_id] = 1.0
             end
         end
 
         # Loop over each constraint
-        for (cons_idx::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
-            group_row.cons_idx::Vector{Union{Missing,Int64}},
-            group_row.cons_time_block_start::Vector{Union{Missing,Int32}},
-            group_row.cons_time_block_end::Vector{Union{Missing,Int32}},
+        for (cons_id::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
+            group_row.cons_id_vec::Vector{Union{Missing,Int64}},
+            group_row.cons_time_block_start_vec::Vector{Union{Missing,Int32}},
+            group_row.cons_time_block_end_vec::Vector{Union{Missing,Int32}},
         )
             time_block = time_block_start:time_block_end
 
@@ -126,31 +126,31 @@ function attach_expression_on_constraints_grouping_variables!(
             workspace_count_agg = Dict{Int,Int}()
 
             for timestep in time_block
-                for (var_idx, var_coefficient) in workspace[timestep]
-                    if !haskey(workspace_coef_agg, var_idx)
+                for (var_id, var_coefficient) in workspace[timestep]
+                    if !haskey(workspace_coef_agg, var_id)
                         # First time a variable is encountered it adds to the aggregation
-                        workspace_coef_agg[var_idx] = var_coefficient
-                        workspace_count_agg[var_idx] = 1
+                        workspace_coef_agg[var_id] = var_coefficient
+                        workspace_count_agg[var_id] = 1
                     else
                         # For the other times, aggregate the coefficient and increase the counter
-                        workspace_coef_agg[var_idx] += var_coefficient
-                        workspace_count_agg[var_idx] += 1
+                        workspace_coef_agg[var_id] += var_coefficient
+                        workspace_count_agg[var_id] += 1
                     end
                 end
             end
 
             if length(workspace_coef_agg) > 0
-                cons.expressions[expr_name][cons_idx] = JuMP.AffExpr(0.0)
-                this_expr = cons.expressions[expr_name][cons_idx]
-                for (var_idx, coef) in workspace_coef_agg
-                    count = workspace_count_agg[var_idx]
+                cons.expressions[expr_name][cons_id] = JuMP.AffExpr(0.0)
+                this_expr = cons.expressions[expr_name][cons_id]
+                for (var_id, coef) in workspace_coef_agg
+                    count = workspace_count_agg[var_id]
 
                     if agg_strategy == :sum
-                        JuMP.add_to_expression!(this_expr, coef, var.container[var_idx])
+                        JuMP.add_to_expression!(this_expr, coef, var.container[var_id])
                     elseif agg_strategy == :mean
-                        JuMP.add_to_expression!(this_expr, coef / count, var.container[var_idx])
+                        JuMP.add_to_expression!(this_expr, coef / count, var.container[var_id])
                     elseif agg_strategy == :unique_sum
-                        JuMP.add_to_expression!(this_expr, 1.0, var.container[var_idx])
+                        JuMP.add_to_expression!(this_expr, 1.0, var.container[var_id])
                     end
                 end
             end

--- a/src/expressions/storage.jl
+++ b/src/expressions/storage.jl
@@ -4,7 +4,7 @@ function add_storage_expressions!(connection, model, expressions)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE expr_available_energy_capacity AS
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             asset_milestone.asset,
             asset_milestone.milestone_year,
             ANY_VALUE(asset.capacity) AS capacity,
@@ -12,7 +12,7 @@ function add_storage_expressions!(connection, model, expressions)
             ANY_VALUE(asset.energy_to_power_ratio) AS energy_to_power_ratio,
             ANY_VALUE(asset.storage_method_energy) AS storage_method_energy,
             SUM(expr_avail.initial_storage_units) AS available_initial_storage_units,
-            ARRAY_AGG(expr_avail.index) AS avail_indices,
+            ARRAY_AGG(expr_avail.id) AS avail_indices,
         FROM asset_milestone
         LEFT JOIN asset
             ON asset_milestone.asset = asset.asset
@@ -24,7 +24,7 @@ function add_storage_expressions!(connection, model, expressions)
         GROUP BY
             asset_milestone.asset,
             asset_milestone.milestone_year
-        ORDER BY index
+        ORDER BY id
         ",
     )
 
@@ -56,7 +56,7 @@ function add_storage_expressions!(connection, model, expressions)
                         # the fixed cost in the objective function
                         capacity_for_initial * row.available_initial_storage_units +
                         capacity_for_variation * (
-                            sum(expr_avail[avail_index] for avail_index in row.avail_indices) -
+                            sum(expr_avail[avail_id] for avail_id in row.avail_indices) -
                             row.available_initial_storage_units
                         )
                     )

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -31,15 +31,15 @@ time block.
 The algorithm works like this:
 
 1. Loop over each group of (asset, year, rep_period)
-1.1. Loop over each variable in the group: (var_idx, var_time_block_start, var_time_block_end)
+1.1. Loop over each variable in the group: (var_id, var_time_block_start, var_time_block_end)
 1.1.1. Loop over each timestep in var_time_block_start:var_time_block_end
 1.1.1.1. Compute the coefficient of the variable based on the rep_period
   resolution and the variable efficiency
-1.1.1.2. Store (var_idx, coefficient) in workspace[timestep]
-1.2. Loop over each constraint in the group: (cons_idx, cons_time_block_start, cons_time_block_end)
+1.1.1.2. Store (var_id, coefficient) in workspace[timestep]
+1.2. Loop over each constraint in the group: (cons_id, cons_time_block_start, cons_time_block_end)
 1.2.1. Aggregate all variables in workspace[timestep] for timestep in the time
-  block to create a list of variable indices and their coefficients [(var_idx1, coef1), ...]
-1.2.2. Compute the expression using the variable container, the indices and coefficients
+  block to create a list of variable ids and their coefficients [(var_id1, coef1), ...]
+1.2.2. Compute the expression using the variable container, the ids and coefficients
 
 Notes:
 - On step 1.2.1, the aggregation can be either by uniqueness of not, i.e., if
@@ -77,7 +77,7 @@ function add_expression_terms_rep_period_constraints!(
         cons.table_name,
         grouped_cons_table_name,
         [:asset, :year, :rep_period],
-        [:index, :time_block_start, :time_block_end],
+        [:id, :time_block_start, :time_block_end],
     )
 
     for case in cases
@@ -96,7 +96,7 @@ function add_expression_terms_rep_period_constraints!(
             flow.table_name,
             grouped_var_table_name,
             [case.asset_match, :year, :rep_period],
-            [:index, :time_block_start, :time_block_end, :efficiency];
+            [:id, :time_block_start, :time_block_end, :efficiency];
             rename_columns = Dict(case.asset_match => :asset),
         )
 
@@ -110,12 +110,12 @@ function add_expression_terms_rep_period_constraints!(
                 cons.asset,
                 cons.year,
                 cons.rep_period,
-                cons.index AS cons_idx,
-                cons.time_block_start AS cons_time_block_start,
-                cons.time_block_end AS cons_time_block_end,
-                var.index AS var_idx,
-                var.time_block_start AS var_time_block_start,
-                var.time_block_end AS var_time_block_end,
+                cons.id AS cons_id_vec,
+                cons.time_block_start AS cons_time_block_start_vec,
+                cons.time_block_end AS cons_time_block_end_vec,
+                var.id AS var_id_vec,
+                var.time_block_start AS var_time_block_start_vec,
+                var.time_block_end AS var_time_block_end_vec,
                 var.efficiency,
                 asset.type AS type,
                 $resolution_query AS resolution,
@@ -130,7 +130,7 @@ function add_expression_terms_rep_period_constraints!(
                 ON cons.rep_period = rep_periods_data.rep_period
                 AND cons.year = rep_periods_data.year
             WHERE
-                len(var.index) > 0
+                len(var.id) > 0
             ",
         )
             resolution = group_row.resolution::Float64
@@ -139,14 +139,14 @@ function add_expression_terms_rep_period_constraints!(
 
             # Step 1.1. Loop over each variable in the group
             for (
-                var_idx::Int64,
+                var_id::Int64,
                 time_block_start::Int32,
                 time_block_end::Int32,
                 efficiency::Float64,
             ) in zip(
-                group_row.var_idx::Vector{Union{Missing,Int64}},
-                group_row.var_time_block_start::Vector{Union{Missing,Int32}},
-                group_row.var_time_block_end::Vector{Union{Missing,Int32}},
+                group_row.var_id_vec::Vector{Union{Missing,Int64}},
+                group_row.var_time_block_start_vec::Vector{Union{Missing,Int32}},
+                group_row.var_time_block_end_vec::Vector{Union{Missing,Int32}},
                 group_row.efficiency::Vector{Union{Missing,Float64}},
             )
                 time_block = time_block_start:time_block_end
@@ -167,7 +167,7 @@ function add_expression_terms_rep_period_constraints!(
                             end
                         end
                     # Step 1.1.1.2.
-                    workspace[timestep][var_idx] = resolution * efficiency_coefficient
+                    workspace[timestep][var_id] = resolution * efficiency_coefficient
                 end
                 if conditions_to_add_min_outgoing_flow_duration
                     outgoing_flow_durations =
@@ -176,37 +176,37 @@ function add_expression_terms_rep_period_constraints!(
             end
 
             # Step 1.2. Loop over each constraint
-            for (cons_idx::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
-                group_row.cons_idx::Vector{Union{Missing,Int64}},
-                group_row.cons_time_block_start::Vector{Union{Missing,Int32}},
-                group_row.cons_time_block_end::Vector{Union{Missing,Int32}},
+            for (cons_id::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
+                group_row.cons_id_vec::Vector{Union{Missing,Int64}},
+                group_row.cons_time_block_start_vec::Vector{Union{Missing,Int32}},
+                group_row.cons_time_block_end_vec::Vector{Union{Missing,Int32}},
             )
                 time_block = time_block_start:time_block_end
                 workspace_agg = Dict{Int,Float64}()
                 # Step 1.2.1.
                 for timestep in time_block
-                    for (var_idx, var_coefficient) in workspace[timestep]
-                        if !haskey(workspace_agg, var_idx)
+                    for (var_id, var_coefficient) in workspace[timestep]
+                        if !haskey(workspace_agg, var_id)
                             # First time a variable is encountered it adds to the aggregation
-                            workspace_agg[var_idx] = var_coefficient
+                            workspace_agg[var_id] = var_coefficient
                         elseif multiply_by_duration
                             # In this case, accumulates more of the variable,
                             # i.e., which effectively multiplies the variable
                             # by its duration in the time block
-                            workspace_agg[var_idx] += var_coefficient
+                            workspace_agg[var_id] += var_coefficient
                         end
                     end
                 end
                 if length(workspace_agg) > 0
                     # Step 1.2.2.
-                    cons.expressions[case.expr_key][cons_idx] = JuMP.AffExpr(0.0)
-                    this_expr = cons.expressions[case.expr_key][cons_idx]
-                    for (var_idx, duration) in workspace_agg
-                        JuMP.add_to_expression!(this_expr, duration, flow.container[var_idx])
+                    cons.expressions[case.expr_key][cons_id] = JuMP.AffExpr(0.0)
+                    this_expr = cons.expressions[case.expr_key][cons_id]
+                    for (var_id, duration) in workspace_agg
+                        JuMP.add_to_expression!(this_expr, duration, flow.container[var_id])
                     end
                 end
                 if conditions_to_add_min_outgoing_flow_duration
-                    cons.coefficients[:min_outgoing_flow_duration][cons_idx] =
+                    cons.coefficients[:min_outgoing_flow_duration][cons_id] =
                         outgoing_flow_durations
                 end
             end
@@ -257,7 +257,7 @@ function add_expression_terms_over_clustered_year_constraints!(
         cons.table_name,
         grouped_cons_table_name,
         [:asset, :year],
-        [:index, :period_block_start, :period_block_end],
+        [:id, :period_block_start, :period_block_end],
     )
 
     grouped_rpmap_over_rp_table_name = "t_grouped_rpmap_over_rp"
@@ -288,10 +288,10 @@ function add_expression_terms_over_clustered_year_constraints!(
             SELECT
                 cons.asset,
                 cons.year,
-                ANY_VALUE(cons.index) AS cons_indices,
+                ANY_VALUE(cons.id) AS cons_id_vec,
                 ANY_VALUE(cons.period_block_start) AS cons_period_block_start_vec,
                 ANY_VALUE(cons.period_block_end) AS cons_period_block_end_vec,
-                ARRAY_AGG(COALESCE(var.index, []) ORDER BY var.rep_period) AS var_indices,
+                ARRAY_AGG(COALESCE(var.id, []) ORDER BY var.rep_period) AS var_id_vec,
                 ARRAY_AGG(COALESCE(var.time_block_start, []) ORDER BY var.rep_period) AS var_time_block_start_vec,
                 ARRAY_AGG(COALESCE(var.time_block_end, []) ORDER BY var.rep_period) AS var_time_block_end_vec,
                 ARRAY_AGG(COALESCE(var.efficiency, []) ORDER BY var.rep_period) AS var_efficiencies,
@@ -320,14 +320,14 @@ function add_expression_terms_over_clustered_year_constraints!(
             empty!.(workspace)
 
             for (
-                var_indices::Vector{Union{Missing,Int64}},
+                var_id_vec::Vector{Union{Missing,Int64}},
                 var_time_block_start_vec::Vector{Union{Missing,Int32}},
                 var_time_block_end_vec::Vector{Union{Missing,Int32}},
                 var_efficiencies::Vector{Union{Missing,Float64}},
                 var_periods::Vector{Union{Missing,Int32}},
                 var_weights::Vector{Union{Missing,Float64}},
             ) in zip(
-                group_row.var_indices::Vector{Union{Missing,Vector{Union{Missing,Int64}}}},
+                group_row.var_id_vec::Vector{Union{Missing,Vector{Union{Missing,Int64}}}},
                 group_row.var_time_block_start_vec::Vector{
                     Union{Missing,Vector{Union{Missing,Int32}}},
                 },
@@ -343,12 +343,12 @@ function add_expression_terms_over_clustered_year_constraints!(
                 group_flows_accumulation = Dict{Int,Float64}()
 
                 for (
-                    var_idx::Int64,
+                    var_id::Int64,
                     time_block_start::Int32,
                     time_block_end::Int32,
                     var_efficiency::Float64,
                 ) in zip(
-                    var_indices::Vector{Union{Missing,Int64}},
+                    var_id_vec::Vector{Union{Missing,Int64}},
                     var_time_block_start_vec::Vector{Union{Missing,Int32}},
                     var_time_block_end_vec::Vector{Union{Missing,Int32}},
                     var_efficiencies::Vector{Union{Missing,Float64}},
@@ -361,7 +361,7 @@ function add_expression_terms_over_clustered_year_constraints!(
                             coefficient *= var_efficiency
                         end
                     end
-                    group_flows_accumulation[var_idx] = coefficient
+                    group_flows_accumulation[var_id] = coefficient
                 end
 
                 # Loop over each period in the group and add the accumulated flows to the workspace
@@ -375,18 +375,18 @@ function add_expression_terms_over_clustered_year_constraints!(
                     # Note to future. Using `mergewith!` did not work because the
                     # `combine` function is only applied for clashing entries, i.e., the weight is not applied uniformly to all entries.
                     # It passed for most cases, since `weight = 1` in most cases.
-                    for (var_idx, var_coef) in group_flows_accumulation
-                        if !haskey(workspace[period], var_idx)
-                            workspace[period][var_idx] = 0.0
+                    for (var_id, var_coef) in group_flows_accumulation
+                        if !haskey(workspace[period], var_id)
+                            workspace[period][var_id] = 0.0
                         end
-                        workspace[period][var_idx] += var_coef * weight
+                        workspace[period][var_id] += var_coef * weight
                     end
                 end
             end
 
             # Loop over each constraint and aggregate from the workspace into the expression
-            for (cons_idx::Int64, period_block_start::Int32, period_block_end::Int32) in zip(
-                group_row.cons_indices::Vector{Union{Missing,Int64}},
+            for (cons_id::Int64, period_block_start::Int32, period_block_end::Int32) in zip(
+                group_row.cons_id_vec::Vector{Union{Missing,Int64}},
                 group_row.cons_period_block_start_vec::Vector{Union{Missing,Int32}},
                 group_row.cons_period_block_end_vec::Vector{Union{Missing,Int32}},
             )
@@ -397,10 +397,10 @@ function add_expression_terms_over_clustered_year_constraints!(
                 end
 
                 if length(workspace_aggregation) > 0
-                    cons.expressions[case.expr_key][cons_idx] = JuMP.AffExpr(0.0)
-                    this_expr = cons.expressions[case.expr_key][cons_idx]
-                    for (var_idx, coefficient) in workspace_aggregation
-                        JuMP.add_to_expression!(this_expr, coefficient, flow.container[var_idx])
+                    cons.expressions[case.expr_key][cons_id] = JuMP.AffExpr(0.0)
+                    this_expr = cons.expressions[case.expr_key][cons_id]
+                    for (var_id, coefficient) in workspace_aggregation
+                        JuMP.add_to_expression!(this_expr, coefficient, flow.container[var_id])
                     end
                 end
             end
@@ -414,7 +414,7 @@ function add_expression_terms_over_clustered_year_constraints!(
                 connection,
                 "
                 SELECT
-                    cons.index,
+                    cons.id,
                     ANY_VALUE(cons.asset) AS asset,
                     ANY_VALUE(cons.year) AS year,
                     SUM(COALESCE(other.inflows_agg, 0.0)) AS inflows_agg,
@@ -445,8 +445,8 @@ function add_expression_terms_over_clustered_year_constraints!(
                     AND cons.year = other.year
                     AND cons.period_block_start <= other.period
                     AND cons.period_block_end >= other.period
-                GROUP BY cons.index
-                ORDER BY cons.index
+                GROUP BY cons.id
+                ORDER BY cons.id
                 ",
             )
         ]

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -21,7 +21,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            var.index,
+            var.id,
             t_objective_assets.weight_for_asset_investment_discount
                 * t_objective_assets.investment_cost
                 * t_objective_assets.capacity
@@ -31,7 +31,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             ON var.asset = t_objective_assets.asset
             AND var.milestone_year = t_objective_assets.milestone_year
         ORDER BY
-            var.index
+            var.id
         ",
     )
 
@@ -46,7 +46,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            expr.index,
+            expr.id,
             t_objective_assets.weight_for_operation_discounts
                 * asset_commission.fixed_cost
                 * t_objective_assets.capacity
@@ -59,7 +59,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             ON expr.asset = t_objective_assets.asset
             AND expr.milestone_year = t_objective_assets.milestone_year
         ORDER BY
-            expr.index
+            expr.id
         ",
     )
 
@@ -74,7 +74,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            var.index,
+            var.id,
             t_objective_assets.weight_for_asset_investment_discount
                 * t_objective_assets.investment_cost_storage_energy
                 * t_objective_assets.capacity_storage_energy
@@ -84,7 +84,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             ON var.asset = t_objective_assets.asset
             AND var.milestone_year = t_objective_assets.milestone_year
         ORDER BY
-            var.index
+            var.id
         ",
     )
 
@@ -99,7 +99,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            expr.index,
+            expr.id,
             t_objective_assets.weight_for_operation_discounts
                 * asset_commission.fixed_cost_storage_energy
                 * t_objective_assets.capacity_storage_energy
@@ -112,7 +112,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             ON expr.asset = t_objective_assets.asset
             AND expr.milestone_year = t_objective_assets.milestone_year
         ORDER BY
-            expr.index
+            expr.id
         ",
     )
 
@@ -127,7 +127,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            var.index,
+            var.id,
             t_objective_flows.weight_for_flow_investment_discount
                 * t_objective_flows.investment_cost
                 * t_objective_flows.capacity
@@ -138,7 +138,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             AND var.to_asset = t_objective_flows.to_asset
             AND var.milestone_year = t_objective_flows.milestone_year
         ORDER BY
-            var.index
+            var.id
         ",
     )
 
@@ -153,7 +153,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            expr.index,
+            expr.id,
             t_objective_flows.weight_for_operation_discounts
                 * flow_commission.fixed_cost / 2
                 * t_objective_flows.capacity
@@ -168,7 +168,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             AND expr.to_asset = t_objective_flows.to_asset
             AND expr.milestone_year = t_objective_flows.milestone_year
         ORDER BY
-            expr.index
+            expr.id
         ",
     )
 
@@ -187,7 +187,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            var.index,
+            var.id,
             t_objective_flows.weight_for_operation_discounts
                 * rpinfo.weight_sum
                 * rpinfo.resolution
@@ -212,7 +212,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
         ) AS rpinfo
             ON var.year = rpinfo.year
             AND var.rep_period = rpinfo.rep_period
-        ORDER BY var.index
+        ORDER BY var.id
         ",
     )
 
@@ -224,7 +224,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     indices = DuckDB.query(
         connection,
         "SELECT
-            var.index,
+            var.id,
             t_objective_assets.weight_for_operation_discounts
                 * rpinfo.weight_sum
                 * rpinfo.resolution
@@ -249,7 +249,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
             ON var.year = rpinfo.year
             AND var.rep_period = rpinfo.rep_period
         WHERE t_objective_assets.units_on_cost IS NOT NULL
-        ORDER BY var.index
+        ORDER BY var.id
         ",
     )
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,14 +43,14 @@ end
         group_by_columns,
         array_agg_columns;
         rename_columns = Dict(),
-        order_agg_by = "index",
+        order_agg_by = "id",
     )
 
 Create a grouped table grouping the `table_name` into the `grouped_table_name`.
 The `group_by_columns` are the columns that are used in the group by (e.g., asset, year, rep_period),
-and the `array_agg_columns` are the columns that are aggregated into arrays (e.g., index, time_block_start, time_block_end).
+and the `array_agg_columns` are the columns that are aggregated into arrays (e.g., id, time_block_start, time_block_end).
 
-It is expected that the original table has an `index` column, which is used in the ordering of the `array_agg_columns`.
+It is expected that the original table has an `id` column, which is used in the ordering of the `array_agg_columns`.
 Otherwise, please pass the argument `order_agg_by` with the column that should be used for this ordering.
 
 If one of the columns has to be renamed, use the `rename_columns` dictionary.
@@ -62,7 +62,7 @@ function _create_group_table_if_not_exist!(
     group_by_columns,
     array_agg_columns;
     rename_columns = Dict(),
-    order_agg_by = :index,
+    order_agg_by = :id,
 )
     if _check_if_table_exists(connection, grouped_table_name)
         return

--- a/src/variables/create.jl
+++ b/src/variables/create.jl
@@ -31,7 +31,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_flow AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             from_asset as from,
             to_asset as to,
             year,
@@ -48,7 +48,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_units_on AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             atr.asset,
             atr.year,
             atr.rep_period,
@@ -69,7 +69,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_is_charging AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             t_low.asset,
             t_low.year,
             t_low.rep_period,
@@ -109,7 +109,7 @@ function _create_variables_tables(connection)
                 t_low.time_block_start
         )
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             filtered_assets.*
         FROM filtered_assets
         ",
@@ -137,7 +137,7 @@ function _create_variables_tables(connection)
                 attr.period_block_start
         )
         SELECT
-            nextval('id') AS index,
+            nextval('id') AS id,
             filtered_assets.*
         FROM filtered_assets
         ",
@@ -148,7 +148,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_flows_investment AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             flow.from_asset,
             flow.to_asset,
             flow_milestone.milestone_year,
@@ -172,7 +172,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_assets_investment AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             asset.asset,
             asset_milestone.milestone_year,
             asset.investment_integer,
@@ -193,7 +193,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_assets_decommission AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             asset_both.asset,
             asset_both.milestone_year,
             asset_both.commission_year,
@@ -213,7 +213,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_flows_decommission AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             flow.from_asset,
             flow.to_asset,
             flow_both.milestone_year,
@@ -235,7 +235,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_assets_investment_energy AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             asset.asset,
             asset_milestone.milestone_year,
             asset.investment_integer_storage_energy,
@@ -259,7 +259,7 @@ function _create_variables_tables(connection)
         "CREATE OR REPLACE TEMP SEQUENCE id START 1;
         CREATE OR REPLACE TABLE var_assets_decommission_energy AS
         SELECT
-            nextval('id') as index,
+            nextval('id') as id,
             asset.asset,
             asset_both.milestone_year,
             asset_both.commission_year,

--- a/src/variables/flows.jl
+++ b/src/variables/flows.jl
@@ -42,7 +42,7 @@ function _create_flow_table(connection)
             ON var_flow.from = from_asset.asset
         LEFT JOIN asset AS to_asset
             ON var_flow.to = to_asset.asset
-        ORDER BY var_flow.index
+        ORDER BY var_flow.id
         ",
     )
 end

--- a/src/variables/storage.jl
+++ b/src/variables/storage.jl
@@ -44,7 +44,7 @@ function add_storage_variables!(connection, model, variables)
         for row in DuckDB.query(
             connection,
             "SELECT
-                last(var.index) AS last_index,
+                last(var.id) AS last_id,
                 var.asset, var.year, var.rep_period,
                 ANY_VALUE(asset_milestone.initial_storage_level) AS initial_storage_level,
             FROM $table_name AS var
@@ -55,7 +55,7 @@ function add_storage_variables!(connection, model, variables)
             GROUP BY var.asset, var.year, var.rep_period
             ",
         )
-            JuMP.set_lower_bound(var.container[row.last_index], row.initial_storage_level)
+            JuMP.set_lower_bound(var.container[row.last_id], row.initial_storage_level)
         end
     end
 
@@ -64,7 +64,7 @@ function add_storage_variables!(connection, model, variables)
         for row in DuckDB.query(
             connection,
             "SELECT
-                last(var.index) AS last_index,
+                last(var.id) AS last_id,
                 var.asset, var.year,
                 ANY_VALUE(asset_milestone.initial_storage_level) AS initial_storage_level,
             FROM $table_name AS var
@@ -75,7 +75,7 @@ function add_storage_variables!(connection, model, variables)
             GROUP BY var.asset, var.year
             ",
         )
-            JuMP.set_lower_bound(var.container[row.last_index], row.initial_storage_level)
+            JuMP.set_lower_bound(var.container[row.last_id], row.initial_storage_level)
         end
     end
 

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -5,10 +5,10 @@
     DuckDB.register_table(
         connection,
         (
-            (index = 1, asset = "a", year = 1900),
-            (index = 2, asset = "a", year = 2000),
-            (index = 3, asset = "b", year = 1900),
-            (index = 4, asset = "b", year = 2000),
+            (id = 1, asset = "a", year = 1900),
+            (id = 2, asset = "a", year = 2000),
+            (id = 3, asset = "b", year = 1900),
+            (id = 4, asset = "b", year = 2000),
         ),
         table_name,
     )
@@ -23,14 +23,14 @@
         table_name,
         grouped_table_name,
         [:asset],
-        [:index, :year],
+        [:id, :year],
     )
     @test TulipaEnergyModel._check_if_table_exists(connection, grouped_table_name)
     df = DataFrame(DuckDB.query(connection, "FROM $grouped_table_name")) |> sort
-    @test names(df) == ["asset", "index", "year"]
+    @test names(df) == ["asset", "id", "year"]
     @test size(df) == (2, 3)
     @test df.asset == ["a", "b"]
-    @test df.index == [[1, 2], [3, 4]]
+    @test df.id == [[1, 2], [3, 4]]
     @test df.year == [[1900, 2000], [1900, 2000]]
 
     # Run it again with different values to check that it doesn't run
@@ -39,13 +39,13 @@
         table_name,
         grouped_table_name,
         [:year],
-        [:index, :asset],
+        [:id, :asset],
     )
     df = DataFrame(DuckDB.query(connection, "FROM $grouped_table_name")) |> sort
-    @test names(df) == ["asset", "index", "year"]
+    @test names(df) == ["asset", "id", "year"]
     @test size(df) == (2, 3)
     @test df.asset == ["a", "b"]
-    @test df.index == [[1, 2], [3, 4]]
+    @test df.id == [[1, 2], [3, 4]]
     @test df.year == [[1900, 2000], [1900, 2000]]
 
     # Delete table and run with different values
@@ -55,14 +55,14 @@
         table_name,
         grouped_table_name,
         [:year],
-        [:index, :asset],
+        [:id, :asset],
     )
     df = DataFrame(DuckDB.query(connection, "FROM $grouped_table_name")) |> sort
-    @test names(df) == ["year", "index", "asset"]
+    @test names(df) == ["year", "id", "asset"]
     @test size(df) == (2, 3)
     @test df.year == [1900, 2000]
     @test df.asset == [["a", "b"], ["a", "b"]]
-    @test df.index == [[1, 3], [2, 4]]
+    @test df.id == [[1, 3], [2, 4]]
 
     # Check failures
     DuckDB.query(connection, "DROP TABLE $grouped_table_name")
@@ -71,7 +71,7 @@
         table_name,
         grouped_table_name,
         [],
-        [:index, :asset],
+        [:id, :asset],
     )
     @test_throws "`array_agg_columns` cannot be empty" TulipaEnergyModel._create_group_table_if_not_exist!(
         connection,


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->
Some cleaning in preparation to some SQL files. This changes all `index` to `id`, because `index` is a reserved keyword in some parts of SQL.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
