### PR TITLE
Fix Windows failure due to tests introduced in #1079

### DIFF
--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -104,5 +104,6 @@ end
     @test energy_problem.termination_status == JuMP.INFEASIBLE
     io = IOBuffer()
     print(io, energy_problem)
-    @test String(take!(io)) == read("io-outputs/energy-problem-model-infeasible.txt", String)
+    @test split(String(take!(io))) ==
+          split(read("io-outputs/energy-problem-model-infeasible.txt", String))
 end

--- a/test/test-io.jl
+++ b/test/test-io.jl
@@ -52,16 +52,18 @@ end
         io = IOBuffer()
         energy_problem = TulipaEnergyModel.EnergyProblem(connection)
         print(io, energy_problem)
-        @test String(take!(io)) == read("io-outputs/energy-problem-empty.txt", String)
+        @test split(String(take!(io))) == split(read("io-outputs/energy-problem-empty.txt", String))
 
         io = IOBuffer()
         TulipaEnergyModel.create_model!(energy_problem)
         print(io, energy_problem)
-        @test String(take!(io)) == read("io-outputs/energy-problem-model-created.txt", String)
+        @test split(String(take!(io))) ==
+              split(read("io-outputs/energy-problem-model-created.txt", String))
 
         io = IOBuffer()
         TulipaEnergyModel.solve_model!(energy_problem)
         print(io, energy_problem)
-        @test String(take!(io)) == read("io-outputs/energy-problem-model-solved.txt", String)
+        @test split(String(take!(io))) ==
+              split(read("io-outputs/energy-problem-model-solved.txt", String))
     end
 end


### PR DESCRIPTION
Windows line ending cause the tests to fail. The solution is to split the
strings so that it automatically removes the line endings.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Related to #1079

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
