### PR TITLE
Use absolute path to include json file

### DIFF
--- a/src/input-schemas.jl
+++ b/src/input-schemas.jl
@@ -1,6 +1,6 @@
 # read schema from file
 
-schema = JSON.parsefile("src/input-schemas.json"; dicttype = OrderedDict);
+schema = JSON.parsefile(joinpath(@__DIR__, "input-schemas.json"); dicttype = OrderedDict);
 
 const schema_per_table_name = OrderedDict(
     schema_key => OrderedDict(key => value["type"] for (key, value) in schema_content) for


### PR DESCRIPTION
Using `@__DIR__` to define a path is more robust.
Fixes a bug importing Tulipa
