### PR TITLE
Create connection inside benchmark run because tables exist

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -15,17 +15,23 @@ end
 
 const OUTPUT_FOLDER_BM = mktempdir()
 
+SUITE["energy_problem"] = BenchmarkGroup()
+SUITE["energy_problem"]["input_and_constructor"] = @benchmarkable begin
+    connection = DBInterface.connect(DuckDB.DB)
+    TulipaIO.read_csv_folder(
+        connection,
+        $INPUT_FOLDER_BM;
+        schemas = $(TulipaEnergyModel.schema_per_table_name),
+    )
+    EnergyProblem(connection)
+end samples = 3 evals = 1 seconds = 86400
+
 connection = DBInterface.connect(DuckDB.DB)
 TulipaIO.read_csv_folder(
     connection,
     INPUT_FOLDER_BM;
     schemas = TulipaEnergyModel.schema_per_table_name,
 )
-
-SUITE["energy_problem"] = BenchmarkGroup()
-SUITE["energy_problem"]["input_and_constructor"] = @benchmarkable begin
-    EnergyProblem($connection)
-end samples = 3 evals = 1 seconds = 86400
 energy_problem = EnergyProblem(connection)
 
 SUITE["energy_problem"]["create_model"] = @benchmarkable begin


### PR DESCRIPTION
The benchmark run is failing due to `var_flow` existing.
This happened after we changed to SQL in files, I believe, because we change
from "create or replace" to "create".

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Bugfix

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
