### PR TITLE
Validate schema's oneOf constraints

### DIFF
--- a/src/input-schemas.jl
+++ b/src/input-schemas.jl
@@ -1,6 +1,6 @@
 # read schema from file
 
-schema = JSON.parsefile(joinpath(@__DIR__, "input-schemas.json"); dicttype = OrderedDict);
+const schema = JSON.parsefile(joinpath(@__DIR__, "input-schemas.json"); dicttype = OrderedDict);
 
 const schema_per_table_name = OrderedDict(
     schema_key => OrderedDict(key => value["type"] for (key, value) in schema_content) for

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -38,3 +38,49 @@ end
         @test occursin("Table flow_both has duplicate entries", error_messages[3])
     end
 end
+
+@testset "Check Schema oneOf constraints" begin
+    @testset "Changing Tiny data asset table (bad type)" begin
+        connection = DBInterface.connect(DuckDB.DB)
+        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+        # Change the table to force an error
+        DuckDB.query(connection, "UPDATE asset SET type = 'badtype' WHERE asset = 'ccgt'")
+        @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
+        error_messages = TEM._validate_schema_one_of_constraints!(connection)
+        @test error_messages == ["Table 'asset' has bad value for column 'type': 'badtype'"]
+    end
+
+    @testset "Changing Tiny data asset table (bad consumer_balance_sense)" begin
+        connection = DBInterface.connect(DuckDB.DB)
+        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+        # Change the table to force an error
+        DuckDB.query(
+            connection,
+            "UPDATE asset SET consumer_balance_sense = '<>' WHERE asset = 'demand'",
+        )
+        @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
+        error_messages = TEM._validate_schema_one_of_constraints!(connection)
+        @test error_messages ==
+              ["Table 'asset' has bad value for column 'consumer_balance_sense': '<>'"]
+    end
+
+    @testset "Changing Norse data flows_rep_periods_partitions table (bad specification)" begin
+        connection = DBInterface.connect(DuckDB.DB)
+        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Norse"))
+        # Change the table to force an error
+        DuckDB.query(
+            connection,
+            "UPDATE flows_rep_periods_partitions
+            SET specification = 'bad'
+            WHERE from_asset = 'Asgard_Solar'
+                AND to_asset = 'Asgard_Battery'
+                AND year = 2030
+                AND rep_period = 1",
+        )
+        @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
+        error_messages = TEM._validate_schema_one_of_constraints!(connection)
+        @test error_messages == [
+            "Table 'flows_rep_periods_partitions' has bad value for column 'specification': 'bad'",
+        ]
+    end
+end


### PR DESCRIPTION
Add a validation step to check the schema's oneOf constraints.
I.e., loop over each table and their columns and find the ones
that have constraints of the type oneOf, and check if the
corresponding table in the connection have the correct specification.

Closes #1098
