### PR TITLE
Validate group consistency in asset and group_asset tables

### DIFF
--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -23,15 +23,14 @@ Raises an error if the data is not valid.
 """
 function validate_data!(connection)
     error_messages = String[]
-    @timeit to "no duplicate rows" append!(error_messages, _validate_no_duplicate_rows!(connection))
-    @timeit to "valid schema's oneOf constraints" append!(
-        error_messages,
-        _validate_schema_one_of_constraints!(connection),
+
+    for (log_msg, validation_function) in (
+        ("no duplicate rows", _validate_no_duplicate_rows!),
+        ("valid schema's oneOf constraints", _validate_schema_one_of_constraints!),
+        ("only transport flows are investable", _validate_only_transport_flows_are_investable!),
     )
-    @timeit to "only transport flows are investable" append!(
-        error_messages,
-        _validate_only_transport_flows_are_investable!(connection),
-    )
+        @timeit to "$log_msg" append!(error_messages, validation_function(connection))
+    end
 
     if length(error_messages) > 0
         throw(DataValidationException(error_messages))

--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -160,5 +160,30 @@ function _validate_foreign_key!(
 end
 
 function _validate_group_consistency!(connection)
-    return _validate_foreign_key!(connection, "asset", :group, "group_asset", :name)
+    error_messages = String[]
+
+    # First, check if the values are valid
+    append!(
+        error_messages,
+        _validate_foreign_key!(connection, "asset", :group, "group_asset", :name),
+    )
+
+    # Second, these that the values are used
+    for row in DuckDB.query(
+        connection,
+        "FROM (
+            SELECT group_asset.name, COUNT(asset.group) AS group_count
+            FROM group_asset
+            LEFT JOIN asset
+                ON asset.group = group_asset.name
+            GROUP BY group_asset.name
+        ) WHERE group_count = 0",
+    )
+        push!(
+            error_messages,
+            "Group '$(row.name)' in 'group_asset' has no members in 'asset', column 'group'",
+        )
+    end
+
+    return error_messages
 end

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -23,8 +23,7 @@ end
     end
 
     @testset "Duplicating rows of Tiny data" begin
-        connection = DBInterface.connect(DuckDB.DB)
-        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+        connection = _tiny_fixture()
         # Duplicating rows in these specific tables
         for table in ("asset", "asset_both", "flow_both")
             DuckDB.query(connection, "INSERT INTO $table (FROM $table ORDER BY RANDOM() LIMIT 1)")
@@ -41,8 +40,7 @@ end
 
 @testset "Check Schema oneOf constraints" begin
     @testset "Changing Tiny data asset table (bad type)" begin
-        connection = DBInterface.connect(DuckDB.DB)
-        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+        connection = _tiny_fixture()
         # Change the table to force an error
         DuckDB.query(connection, "UPDATE asset SET type = 'badtype' WHERE asset = 'ccgt'")
         @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
@@ -51,8 +49,7 @@ end
     end
 
     @testset "Changing Tiny data asset table (bad consumer_balance_sense)" begin
-        connection = DBInterface.connect(DuckDB.DB)
-        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+        connection = _tiny_fixture()
         # Change the table to force an error
         DuckDB.query(
             connection,
@@ -107,8 +104,7 @@ end
     end
 
     @testset "Using Tiny data" begin
-        connection = DBInterface.connect(DuckDB.DB)
-        _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+        connection = _tiny_fixture()
         # Create all four combinations of is_transport and investable
         # First set ccgt and ocgt to transport = TRUE
         DuckDB.query(
@@ -124,5 +120,72 @@ end
         error_messages = TEM._validate_only_transport_flows_are_investable!(connection)
         @test error_messages ==
               ["Flow ('wind', 'demand') is investable but is not a transport flow"]
+    end
+end
+
+@testset "Check that foreign keys are valid" begin
+    @testset "Using fake data" begin
+        # Main table
+        main_table = DataFrame(
+            :asset => ["A1", "A2", "A3"],
+            :cat1 => [missing, "good", "bad"],
+            :cat2 => ["good", missing, "ugly"],
+        )
+        # Foreign table
+        foreign_table = DataFrame(:category => ["good", "ugly"], :value => [1, 2])
+        connection = DBInterface.connect(DuckDB.DB)
+        DuckDB.register_data_frame(connection, main_table, "main_table")
+        DuckDB.register_data_frame(connection, foreign_table, "foreign_table")
+
+        @testset "'bad' value for cat1" begin
+            error_messages = TEM._validate_foreign_key!(
+                connection,
+                "main_table",
+                :cat1,
+                "foreign_table",
+                :category;
+                allow_missing = true,
+            )
+            @test error_messages == [
+                "Table 'main_table' column 'cat1' has invalid value 'bad'. Valid values should be among column 'category' of 'foreign_table'",
+            ]
+        end
+
+        @testset "missing value for cat2" begin
+            error_messages = TEM._validate_foreign_key!(
+                connection,
+                "main_table",
+                :cat2,
+                "foreign_table",
+                :category;
+                allow_missing = true,
+            )
+            @test error_messages == String[]
+
+            error_messages = TEM._validate_foreign_key!(
+                connection,
+                "main_table",
+                :cat2,
+                "foreign_table",
+                :category;
+                allow_missing = false,
+            )
+            @test error_messages == [
+                "Table 'main_table' column 'cat2' has invalid value 'missing'. Valid values should be among column 'category' of 'foreign_table'",
+            ]
+        end
+    end
+
+    @testset "Using Tiny data" begin
+        connection = _tiny_fixture()
+
+        # Doesn't throw
+        TEM.create_internal_tables!(connection)
+
+        # Modify group value to bad value
+        DuckDB.query(connection, "UPDATE asset SET \"group\" = 'bad' WHERE asset = 'ccgt'")
+        @test_throws "Table 'asset' column 'group' has invalid value 'bad'. Valid values should be among column 'name' of 'group_asset'" TEM.create_internal_tables!(
+            connection,
+        )
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,3 +4,9 @@ function _read_csv_folder(connection, input_dir)
     schemas = TulipaEnergyModel.schema_per_table_name
     return TulipaIO.read_csv_folder(connection, input_dir; schemas)
 end
+
+function _tiny_fixture()
+    connection = DBInterface.connect(DuckDB.DB)
+    _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Tiny"))
+    return connection
+end


### PR DESCRIPTION
- **Make validation loop more maintainable**
- **Validate that the group foreign key has valid values**
- **Validate that any group listed in group_asset has matching assets**

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1105

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
