### PR TITLE
Update CompareMPS to not make multiple comments and link to docs

### DIFF
--- a/.github/workflows/CompareMPS.yml
+++ b/.github/workflows/CompareMPS.yml
@@ -21,9 +21,9 @@ jobs:
     name: Compare MPS files
     runs-on: ubuntu-latest
     steps:
-      - name: Find Comment
+      - name: Find older comment (to avoid multiple comments)
         uses: peter-evans/find-comment@v3
-        id: find-comment
+        id: find-old-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
@@ -31,7 +31,7 @@ jobs:
       - name: Comment on PR with CompareMPS
         uses: peter-evans/create-or-update-comment@v4
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          comment-id: ${{ steps.find-old-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ### :hourglass: Running MPS comparison
@@ -81,9 +81,18 @@ jobs:
 
           </details>
 
+          For more details about this workflow, check <https://tulipaenergy.github.io/TulipaEnergyModel.jl/dev/91-developer/#Testing-the-generate-MPS-files>.
+
           :robot: This was CompareMPS, we hope you have enjoyed this program.
           ' >> body.md
           echo "::warning title=MPS files are different::$(cat body.md)"
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: This was CompareMPS
       - name: Comment on PR with log if failed
         if: failure()
         uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

The CompareMPS workflow should find older comments in the PR to replace, instead of creating new comments every time. (This is already done by the Benchmark workflow, I just missed it).
Add the link to the docs to the PR comment.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
There is no related issue.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
