### PR TITLE
Don't require expressions as argument for create_solver

### DIFF
--- a/benchmark/profiling.jl
+++ b/benchmark/profiling.jl
@@ -57,6 +57,6 @@ end
 
 #%%
 
-@time model = create_model(graph, representative_periods, dataframes, timeframe);
+@time model, expressions = create_model(graph, representative_periods, dataframes, timeframe);
 @benchmark create_model($graph, $representative_periods, $dataframes, $timeframe)
 # @profview create_model(graph, representative_periods, dataframes, timeframe);

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -7,10 +7,9 @@ Create the internal model of an [`TulipaEnergyModel.EnergyProblem`](@ref).
 Any keyword argument will be passed to the underlyting [`create_model`](@ref).
 """
 function create_model!(energy_problem; kwargs...)
-    energy_problem.model = @timeit to "create_model" create_model(
+    energy_problem.model, energy_problem.expressions = @timeit to "create_model" create_model(
         energy_problem.db_connection,
         energy_problem.variables,
-        energy_problem.expressions,
         energy_problem.constraints,
         energy_problem.profiles,
         energy_problem.model_parameters;
@@ -24,10 +23,9 @@ function create_model!(energy_problem; kwargs...)
 end
 
 """
-    model = create_model(
+    model, expressions = create_model(
         connection,
         variables,
-        expressions,
         constraints,
         profiles,
         model_parameters;
@@ -40,7 +38,6 @@ Create the energy model manually. We recommend using [`create_model!`](@ref) ins
 function create_model(
     connection,
     variables,
-    expressions,
     constraints,
     profiles,
     model_parameters;
@@ -63,6 +60,9 @@ function create_model(
         variables,
         constraints,
     )
+
+    ## Expressions
+    expressions = Dict{Symbol,TulipaExpression}()
 
     ## Expressions for multi-year investment
     @timeit to "create_multi_year_expressions!" create_multi_year_expressions!(
@@ -149,5 +149,5 @@ function create_model(
         @timeit to "save model file" JuMP.write_to_file(model, model_file_name)
     end
 
-    return model
+    return model, expressions
 end

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -282,7 +282,7 @@ mutable struct EnergyProblem
         energy_problem = new(
             connection,
             variables,
-            Dict(),
+            Dict{Symbol,TulipaExpression}(),
             constraints,
             profiles,
             ModelParameters(connection, model_parameters_file),

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -24,15 +24,13 @@ end
     TulipaEnergyModel.create_internal_tables!(connection)
     model_parameters = TulipaEnergyModel.ModelParameters(connection)
     variables = TulipaEnergyModel.compute_variables_indices(connection)
-    expressions = Dict()
     constraints = TulipaEnergyModel.compute_constraints_indices(connection)
     profiles = TulipaEnergyModel.prepare_profiles_structure(connection)
 
     # Create model
-    model = TulipaEnergyModel.create_model(
+    model, expressions = TulipaEnergyModel.create_model(
         connection,
         variables,
-        expressions,
         constraints,
         profiles,
         model_parameters,


### PR DESCRIPTION
The argument `expressions` was removed. Instead, it is now created inside
`create_model`, and returned alongside `model`.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1113

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
