### PR TITLE
Update error message when saving solution

### DIFF
--- a/src/data-preparation.jl
+++ b/src/data-preparation.jl
@@ -265,7 +265,7 @@ end
 
 """
     create_merged_tables!(connection)
- 
+
 Create the internal tables of merged flows and assets time partitions to be used in the computation of the lowest and highest resolution tables.
 The inputs tables are the flows table `flow_time_resolution_rep_period` and the assets table `asset_time_resolution_rep_period`.
 All merged tables have the same columns: `asset`, `year`, `rep_period`, `time_block_start`, and `time_block_end`.

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -98,7 +98,7 @@ function save_solution!(connection, model, variables, constraints; compute_duals
     # Check if it's solved
     if !JuMP.is_solved_and_feasible(model)
         @error(
-            "The model has a termination status: $JuMP.termination_status(model), with primal status $JuMP.primal_status(model), and dual status $JuMP.dual_status(model)"
+            "The model has a termination status: $string(JuMP.termination_status(model)), with primal status $string(JuMP.primal_status(model)), and dual status $string(JuMP.dual_status(model))"
         )
         return
     end

--- a/src/solve-model.jl
+++ b/src/solve-model.jl
@@ -98,7 +98,7 @@ function save_solution!(connection, model, variables, constraints; compute_duals
     # Check if it's solved
     if !JuMP.is_solved_and_feasible(model)
         @error(
-            "The model has a termination status: $string(JuMP.termination_status(model)), with primal status $string(JuMP.primal_status(model)), and dual status $string(JuMP.dual_status(model))"
+            "The model has a termination status: $(string(JuMP.termination_status(model))), with primal status $(string(JuMP.primal_status(model))), and dual status $(string(JuMP.dual_status(model)))"
         )
         return
     end


### PR DESCRIPTION
This pull request includes a minor change to the error logging in the `save_solution!` function within the `src/solve-model.jl` file. The change ensures that the termination status, primal status, and dual status are converted to strings before being included in the error message.

* [`src/solve-model.jl`](diffhunk://#diff-f2bfe53eac044e75e0a0cb4abfea814584599e7da61f46bc87968bb1e1d72ee6L101-R101): Modified the error message in the `save_solution!` function to convert the statuses to strings for better readability.

## Related issues

There is no related issue.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
