### PR TITLE
Add new table to define flows relationships

### DIFF
--- a/src/input-schemas.json
+++ b/src/input-schemas.json
@@ -649,6 +649,52 @@
       "type": "INTEGER"
     }
   },
+  "flows_relationships": {
+    "constant": {
+      "default": 0,
+      "description": "",
+      "type": "DOUBLE",
+      "unit_of_measure": "MWh"
+    },
+    "fixed_ratio": {
+      "default": 1,
+      "description": "",
+      "type": "DOUBLE",
+      "unit_of_measure": "p.u."
+    },
+    "flows_relationship_sense": {
+      "constraints": {
+        "oneOf": [
+          "==",
+          ">=",
+          "<="
+        ]
+      },
+      "default": "==",
+      "description": "Is the sense of the flows relationship constraint, equal to, greater than or less than.",
+      "type": "VARCHAR"
+    },
+    "from_asset_left_hand_side": {
+      "description": "Name of the `from_asset` of the flow in the left hand side of the flows relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "from_asset_right_hand_side": {
+      "description": "Name of the `from_asset` of the flow in the right hand side of the flows relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "milestone_year": {
+      "description": "Milestone year.",
+      "type": "INTEGER"
+    },
+    "to_asset_left_hand_side": {
+      "description": "Name of the `to_asset` of the flow in the left hand side of the flows relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "to_asset_right_hand_side": {
+      "description": "Name of the `to_asset` of the flow in the right hand side of the flows relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    }
+  },
   "flows_rep_periods_partitions": {
     "from_asset": {
       "description": "Name of the asset. Same as the one in the `asset` table.",

--- a/src/input-schemas.json
+++ b/src/input-schemas.json
@@ -652,17 +652,37 @@
   "flows_relationships": {
     "constant": {
       "default": 0,
-      "description": "",
+      "description": "Constant `C` in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint",
       "type": "DOUBLE",
       "unit_of_measure": "MWh"
     },
-    "fixed_ratio": {
+    "flow_1_from_asset": {
+      "description": "Name of the `from_asset` of the `flow_1` in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "flow_1_to_asset": {
+      "description": "Name of the `to_asset` of the `flow_1` in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "flow_2_from_asset": {
+      "description": "Name of the `from_asset` of the `flow_2` in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "flow_2_to_asset": {
+      "description": "Name of the `to_asset` of the `flow_2` in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint. Same as the one in the `asset` table.",
+      "type": "VARCHAR"
+    },
+    "milestone_year": {
+      "description": "Milestone year.",
+      "type": "INTEGER"
+    },
+    "ratio": {
       "default": 1,
-      "description": "",
+      "description": "Ratio `A` in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint",
       "type": "DOUBLE",
       "unit_of_measure": "p.u."
     },
-    "flows_relationship_sense": {
+    "sense": {
       "constraints": {
         "oneOf": [
           "==",
@@ -671,27 +691,7 @@
         ]
       },
       "default": "==",
-      "description": "Is the sense of the flows relationship constraint, equal to, greater than or less than.",
-      "type": "VARCHAR"
-    },
-    "from_asset_left_hand_side": {
-      "description": "Name of the `from_asset` of the flow in the left hand side of the flows relationship constraint. Same as the one in the `asset` table.",
-      "type": "VARCHAR"
-    },
-    "from_asset_right_hand_side": {
-      "description": "Name of the `from_asset` of the flow in the right hand side of the flows relationship constraint. Same as the one in the `asset` table.",
-      "type": "VARCHAR"
-    },
-    "milestone_year": {
-      "description": "Milestone year.",
-      "type": "INTEGER"
-    },
-    "to_asset_left_hand_side": {
-      "description": "Name of the `to_asset` of the flow in the left hand side of the flows relationship constraint. Same as the one in the `asset` table.",
-      "type": "VARCHAR"
-    },
-    "to_asset_right_hand_side": {
-      "description": "Name of the `to_asset` of the flow in the right hand side of the flows relationship constraint. Same as the one in the `asset` table.",
+      "description": "Is the sense in `flow_1 {==;>=;<=} C + A x flow_2` relationship constraint, equal to, greater than or less than.",
       "type": "VARCHAR"
     }
   },

--- a/src/io.jl
+++ b/src/io.jl
@@ -7,6 +7,7 @@ const tables_allowed_to_be_missing = [
     "assets_timeframe_partitions"
     "assets_timeframe_profiles"
     "flows_profiles"
+    "flows_relationships"
     "flows_rep_periods_partitions"
     "group_asset"
     "profiles_rep_periods"


### PR DESCRIPTION
This pull request introduces a new table needed to define flow relationship constraints.

The changes include adding a new schema for `flows_relationships` in the input JSON and ensuring compatibility in the `io.jl` file.

### Additions to support flow relationship constraints:

* [`src/input-schemas.json`](diffhunk://#diff-25ff778353f0e7ecf765d8a10289d3b1e38faa2b8f3e4b8d2bd6f5f47b9f0c5fR652-R697): Added a new schema `flows_relationships` to define constraints between two flows.

### Compatibility updates:

* [`src/io.jl`](diffhunk://#diff-db104fa7ac6c3097a327fc13a1076a2f1dd30a49057cae4caebe58563a97030eR10): Updated the `tables_allowed_to_be_missing` list to include `flows_relationships` since this table is not always needed in the model.

## Related issues

Closes #1166 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
