### PR TITLE
Add electricity angle variables

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -89,6 +89,7 @@ function create_model(
     @timeit to "add_flow_variables!" add_flow_variables!(connection, model, variables)
     @timeit to "add_investment_variables!" add_investment_variables!(model, variables)
     @timeit to "add_unit_commitment_variables!" add_unit_commitment_variables!(model, variables)
+    @timeit to "add_power_flow_variables!" add_power_flow_variables!(model, variables)
     @timeit to "add_storage_variables!" add_storage_variables!(connection, model, variables)
 
     @timeit to "add_expressions_to_constraints!" add_expressions_to_constraints!(

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -45,6 +45,30 @@ drop sequence id
 create sequence id start 1
 ;
 
+create table var_electricity_angle as
+select
+    nextval('id') as id,
+    atr.asset,
+    atr.year,
+    atr.rep_period,
+    atr.time_block_start,
+    atr.time_block_end,
+from
+    asset_time_resolution_rep_period as atr
+    left join flow on flow.from_asset = atr.asset
+    or flow.to_asset = atr.asset
+where
+    flow.is_transport
+group by
+    atr.asset, atr.year, atr.rep_period, atr.time_block_start, atr.time_block_end
+;
+
+drop sequence id
+;
+
+create sequence id start 1
+;
+
 create table var_is_charging as
 select
     nextval('id') as id,

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -54,14 +54,25 @@ select
     atr.time_block_start,
     atr.time_block_end,
 from
+    -- The angle resolution is the same as the time resolution of the asset
     asset_time_resolution_rep_period as atr
+    -- We need to check if the asset has any connecting flows that are transport
+    -- We only get the assets that have outgoing flows OR incoming flows
+    -- With the condition that the flows are transport
     left join flow on flow.from_asset = atr.asset
     or flow.to_asset = atr.asset
+    -- After that we need to also check if the flows have dc_opf method
+    -- This is by joining the flow_milestone table
+    -- Here we use AND because we need to match flow_milestone with flow
     left join flow_milestone on flow_milestone.from_asset = flow.from_asset
     and flow_milestone.to_asset = flow.to_asset
+    and flow_milestone.milestone_year = atr.year
 where
     flow.is_transport
     and flow_milestone.dc_opf
+-- We may end up with duplicates because an asset can have both incoming and outgoing flows
+-- Or it can have multiple flows
+-- GROUP BY is used to remove duplicates
 group by
     atr.asset, atr.year, atr.rep_period, atr.time_block_start, atr.time_block_end
 ;

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -57,8 +57,11 @@ from
     asset_time_resolution_rep_period as atr
     left join flow on flow.from_asset = atr.asset
     or flow.to_asset = atr.asset
+    left join flow_milestone on flow_milestone.from_asset = flow.from_asset
+    and flow_milestone.to_asset = flow.to_asset
 where
     flow.is_transport
+    and flow_milestone.dc_opf
 group by
     atr.asset, atr.year, atr.rep_period, atr.time_block_start, atr.time_block_end
 ;

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -52,7 +52,7 @@ select
     atr.year,
     atr.rep_period,
     atr.time_block_start,
-    atr.time_block_end,
+    any_value(atr.time_block_end) as time_block_end,
 from
     -- The angle resolution is the same as the time resolution of the asset
     asset_time_resolution_rep_period as atr
@@ -73,8 +73,9 @@ where
 -- We may end up with duplicates because an asset can have both incoming and outgoing flows
 -- Or it can have multiple flows
 -- GROUP BY is used to remove duplicates
+-- Note SELECT only happens after the GROUP BY, so id is unique for each row.
 group by
-    atr.asset, atr.year, atr.rep_period, atr.time_block_start, atr.time_block_end
+    atr.asset, atr.year, atr.rep_period, atr.time_block_start
 ;
 
 drop sequence id

--- a/src/variables/create.jl
+++ b/src/variables/create.jl
@@ -11,6 +11,7 @@ function compute_variables_indices(connection)
             :flow,
             :units_on,
             :is_charging,
+            :electricity_angle,
             :storage_level_rep_period,
             :storage_level_over_clustered_year,
             :assets_investment,

--- a/src/variables/create.jl
+++ b/src/variables/create.jl
@@ -10,8 +10,8 @@ function compute_variables_indices(connection)
         key => TulipaVariable(connection, "var_$key") for key in (
             :flow,
             :units_on,
-            :is_charging,
             :electricity_angle,
+            :is_charging,
             :storage_level_rep_period,
             :storage_level_over_clustered_year,
             :assets_investment,

--- a/src/variables/power-flow.jl
+++ b/src/variables/power-flow.jl
@@ -1,0 +1,20 @@
+export add_power_flow_variables!
+
+"""
+    add_power_flow_variables!(model, variables)
+
+Adds power flow variables to the optimization `model` based on the `:electricity_angle` indices.
+
+"""
+function add_power_flow_variables!(model, variables)
+    electricity_angle_indices = variables[:electricity_angle].indices
+
+    variables[:electricity_angle].container = [
+        @variable(
+            model,
+            base_name = "electricity_angle[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]",
+        ) for row in electricity_angle_indices
+    ]
+
+    return
+end


### PR DESCRIPTION
Adding electricity angle variables based on asset resolution.

The variable is created if there is a connecting flow (incoming OR outgoing) that is transport and has dc_opf method.


## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1181

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
