### PR TITLE
Fix CompareMPS when files differ in length

### DIFF
--- a/.github/workflows/CompareMPS.yml
+++ b/.github/workflows/CompareMPS.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: This was CompareMPS
+          body-includes: CompareMPS report
       - name: Comment on PR with CompareMPS
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v4
@@ -36,11 +36,11 @@ jobs:
           comment-id: ${{ steps.find-old-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
+            ## :robot: CompareMPS report
+
             ### :hourglass: Running MPS comparison
 
             Please wait.
-
-            :robot: This was CompareMPS, we hope you have enjoyed this program.
           edit-mode: replace
       - name: Clone
         uses: actions/checkout@v4
@@ -59,9 +59,11 @@ jobs:
       - name: Create PR body
         if: failure()
         run: |
-          echo '## :warning: MPS files differ
+          echo '## :robot: CompareMPS report
 
-          ### What to do?
+          ### :warning: MPS files differ
+
+          What to do?
 
           #### :+1: If this is expected
 
@@ -71,7 +73,7 @@ jobs:
           julia --project=. utils/scripts/model-mps-update.jl
           ```
 
-          #### :-1: This is bad
+          #### :-1: If this is bad
 
           Then, review the log below to figure out why the files differ:
 
@@ -84,8 +86,6 @@ jobs:
           </details>
 
           For more details about this workflow, check <https://tulipaenergy.github.io/TulipaEnergyModel.jl/dev/91-developer/#Testing-the-generate-MPS-files>.
-
-          :robot: This was CompareMPS, we hope you have enjoyed this program.
           ' >> body.md
           echo "::warning title=MPS files are different::$(cat body.md)"
       - name: Find Comment
@@ -95,7 +95,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: This was CompareMPS
+          body-includes: CompareMPS report
       - name: Comment on PR with log if failed
         if: failure() && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v4
@@ -111,7 +111,7 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ### :white_check_mark: MPS files match
+            ## :robot: CompareMPS report
 
-            :robot: This was CompareMPS, we hope you have enjoyed this program.
+            ### :white_check_mark: MPS files match
           edit-mode: replace

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -588,7 +588,7 @@ When creating a pull request, the workflow `CompareMPS.yml` will run the compari
 2. **Unexpected failure**: If you made modifications that were not supposed to change the model, then you need to investigate what happened. Use the MPS difference to debug what you have done. There is no easy fix for this. If you think there are bugs in the comparison script, discuss with your PR reviewer and open an issue if necessary.
 
 !!! warning
-    The comparison workflow only writes PR comments if the branch is made from within `TulipaEnergyModel`. To see the log online in that case, you have to open the GitHub action log, or run the comparison locally, as explained in the previous section.
+    The comparison workflow only writes PR comments if the branch is made from within `TulipaEnergyModel` (i.e., not from forks). To see the log online in that case, you have to open the GitHub action log, or run the comparison locally, as explained in the previous section.
 
 ## Procedure for Releasing a New Version (Julia Registry)
 

--- a/utils/scripts/model-mps-compare.jl
+++ b/utils/scripts/model-mps-compare.jl
@@ -39,6 +39,7 @@ function compare_mps(existing_mps_folder)
         new_lines = readlines(new_mps_file)
 
         if length(existing_lines) != length(new_lines)
+            no_issues = false
             @error "Files don't have the same size"
         else
             zipped_lines = zip(existing_lines, new_lines)


### PR DESCRIPTION
If the files had different length, the script prints errors,
but was not returning errors. This returns the correct
exit flag.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1188

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
