### PR TITLE
Create highest resolution table for flows and their connecting assets

### DIFF
--- a/src/data-preparation.jl
+++ b/src/data-preparation.jl
@@ -514,8 +514,15 @@ function create_highest_resolution_table!(connection)
     # - keep all unique time_block_start
     # - create corresponing time_block_end
 
-    for merged_table in
-        ("merged_" * x for x in ("in_flows", "out_flows", "assets_and_out_flows", "all_flows"))
+    for merged_table in (
+        "merged_" * x for x in (
+            "in_flows",
+            "out_flows",
+            "assets_and_out_flows",
+            "all_flows",
+            "flows_and_connecting_assets",
+        )
+    )
         table_name = replace(merged_table, "merged" => "t_highest")
         DuckDB.execute(
             connection,

--- a/src/sql/create-merged-tables.sql
+++ b/src/sql/create-merged-tables.sql
@@ -88,3 +88,36 @@ create or replace temp table merged_flows_relationship as
         )
         and ftrrp.year = fr.milestone_year
 ;
+
+-- merged table for flows and connecting assets:
+-- 1. Define the asset as the flow
+-- 2. Get the resolution of the flow and the connecting asset (i.e., UNION)
+
+create or replace temp table merged_flows_and_connecting_assets as
+select distinct
+    CONCAT(ftrrp.from_asset, '_', ftrrp.to_asset) as asset,
+    ftrrp.year,
+    ftrrp.rep_period,
+    ftrrp.time_block_start,
+    ftrrp.time_block_end
+from
+    flow_time_resolution_rep_period as ftrrp
+
+union
+
+select distinct
+    CONCAT(ftrrp.from_asset, '_', ftrrp.to_asset) as asset,
+    atrrp.year,
+    atrrp.rep_period,
+    atrrp.time_block_start,
+    atrrp.time_block_end
+from
+    asset_time_resolution_rep_period as atrrp
+join
+    flow_time_resolution_rep_period as ftrrp
+    on (
+        atrrp.asset = ftrrp.from_asset
+        or atrrp.asset = ftrrp.to_asset
+    )
+    and atrrp.year = ftrrp.year
+;

--- a/src/sql/create-merged-tables.sql
+++ b/src/sql/create-merged-tables.sql
@@ -102,11 +102,17 @@ select distinct
     ftrrp.time_block_end
 from
     flow_time_resolution_rep_period as ftrrp
+-- we only want the flows with dc_opf method
+left join flow_milestone as fm
+    on fm.from_asset = ftrrp.from_asset
+     and fm.to_asset = ftrrp.to_asset
+     and fm.milestone_year = ftrrp.year
+where fm.dc_opf
 
 union
 
 select distinct
-    CONCAT(flow.from_asset, '_', flow.to_asset) as asset,
+    CONCAT(fm.from_asset, '_', fm.to_asset) as asset,
     atrrp.year,
     atrrp.rep_period,
     atrrp.time_block_start,
@@ -114,9 +120,11 @@ select distinct
 from
     asset_time_resolution_rep_period as atrrp
 join
-    flow
+    flow_milestone as fm
     on (
-        atrrp.asset = flow.from_asset
-        or atrrp.asset = flow.to_asset
+        atrrp.asset = fm.from_asset
+        or atrrp.asset = fm.to_asset
     )
+      and fm.milestone_year = atrrp.year
+where fm.dc_opf
 ;

--- a/src/sql/create-merged-tables.sql
+++ b/src/sql/create-merged-tables.sql
@@ -106,7 +106,7 @@ from
 union
 
 select distinct
-    CONCAT(ftrrp.from_asset, '_', ftrrp.to_asset) as asset,
+    CONCAT(flow.from_asset, '_', flow.to_asset) as asset,
     atrrp.year,
     atrrp.rep_period,
     atrrp.time_block_start,
@@ -114,10 +114,9 @@ select distinct
 from
     asset_time_resolution_rep_period as atrrp
 join
-    flow_time_resolution_rep_period as ftrrp
+    flow
     on (
-        atrrp.asset = ftrrp.from_asset
-        or atrrp.asset = ftrrp.to_asset
+        atrrp.asset = flow.from_asset
+        or atrrp.asset = flow.to_asset
     )
-    and atrrp.year = ftrrp.year
 ;

--- a/test/test-data-preparation.jl
+++ b/test/test-data-preparation.jl
@@ -16,6 +16,15 @@
 
     # Create mock tables for testing using register_data_frame
     table_rows = [
+        ("input_1", "death_star"),
+        ("input_2", "death_star"),
+        ("death_star", "output_1"),
+        ("death_star", "output_2"),
+    ]
+    flow = DataFrame(table_rows, [:from_asset, :to_asset])
+    DuckDB.register_data_frame(connection, flow, "flow")
+
+    table_rows = [
         ("input_1", "death_star", 2025, 1, 1, 1),
         ("input_1", "death_star", 2025, 1, 2, 5),
         ("input_2", "death_star", 2025, 1, 1, 2),
@@ -262,5 +271,5 @@
     end
 
     # test that the final number of tables is correct
-    @test DataFrames.nrow(TulipaIO.show_tables(connection)) == 19
+    @test DataFrames.nrow(TulipaIO.show_tables(connection)) == 20
 end

--- a/test/test-data-preparation.jl
+++ b/test/test-data-preparation.jl
@@ -15,14 +15,9 @@
     connection = DBInterface.connect(DuckDB.DB)
 
     # Create mock tables for testing using register_data_frame
-    table_rows = [
-        ("input_1", "death_star"),
-        ("input_2", "death_star"),
-        ("death_star", "output_1"),
-        ("death_star", "output_2"),
-    ]
-    flow = DataFrame(table_rows, [:from_asset, :to_asset])
-    DuckDB.register_data_frame(connection, flow, "flow")
+    table_rows = [("input_1", "death_star", 2025, true), ("input_2", "death_star", 2025, false)]
+    flow_milestone = DataFrame(table_rows, [:from_asset, :to_asset, :milestone_year, :dc_opf])
+    DuckDB.register_data_frame(connection, flow_milestone, "flow_milestone")
 
     table_rows = [
         ("input_1", "death_star", 2025, 1, 1, 1),
@@ -170,7 +165,7 @@
         merged_flows_and_connecting_assets = TulipaIO.select_tbl(
             connection,
             "merged_flows_and_connecting_assets";
-            where_ = "asset = 'input_1_death_star' ORDER BY asset, rep_period, time_block_start, time_block_end",
+            where_ = "asset LIKE '%death_star' ORDER BY asset, rep_period, time_block_start, time_block_end",
         )
         expected_rows = [
             ("input_1_death_star", 2025, 1, 1, 1),
@@ -259,7 +254,7 @@
         t_highest_flows_and_connecting_assets = TulipaIO.select_tbl(
             connection,
             "t_highest_flows_and_connecting_assets";
-            where_ = "asset = 'input_1_death_star' ORDER BY asset, rep_period, time_block_start, time_block_end",
+            where_ = "asset LIKE '%death_star' ORDER BY asset, rep_period, time_block_start, time_block_end",
         )
         expected_rows = [
             ("input_1_death_star", 2025, 1, 1, 1),


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

The goal is to obtain the highest resolution between a flow and its connecting assets.
Used the same trick as in #1183, by creating a fake asset called (`from_asset`, `_`, `to_asset`).

This is a workaround and note by doing this, I'll need to split this asset later as I need the flow names.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1187 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
