### PR TITLE
Run the case studies twice to ensure it doesn't raise an error

### DIFF
--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -1,4 +1,10 @@
+drop sequence if exists id
+;
+
 create sequence id start 1
+;
+
+drop table if exists cons_balance_conversion
 ;
 
 create table cons_balance_conversion as
@@ -27,6 +33,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_balance_consumer
+;
+
 create table cons_balance_consumer as
 select
     nextval('id') as id,
@@ -42,6 +51,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_balance_hub
 ;
 
 create table cons_balance_hub as
@@ -61,6 +73,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_capacity_incoming_simple_method
+;
+
 create table cons_capacity_incoming_simple_method as
 select
     nextval('id') as id,
@@ -76,6 +91,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_capacity_incoming_simple_method_non_investable_storage_with_binary
 ;
 
 create table cons_capacity_incoming_simple_method_non_investable_storage_with_binary as
@@ -99,6 +117,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_capacity_incoming_simple_method_investable_storage_with_binary
+;
+
 create table cons_capacity_incoming_simple_method_investable_storage_with_binary as
 select
     nextval('id') as id,
@@ -120,6 +141,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_capacity_outgoing_compact_method
+;
+
 create table cons_capacity_outgoing_compact_method as
 select
     nextval('id') as id,
@@ -129,13 +153,16 @@ from
     left join asset on t_high.asset = asset.asset
 where
     asset.type in ('producer', 'storage', 'conversion')
-    and asset.investment_method == 'compact'
+    and asset.investment_method = 'compact'
 ;
 
 drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_capacity_outgoing_simple_method
 ;
 
 create table cons_capacity_outgoing_simple_method as
@@ -154,6 +181,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_capacity_outgoing_simple_method_non_investable_storage_with_binary
 ;
 
 create table cons_capacity_outgoing_simple_method_non_investable_storage_with_binary as
@@ -177,6 +207,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_capacity_outgoing_simple_method_investable_storage_with_binary
+;
+
 create table cons_capacity_outgoing_simple_method_investable_storage_with_binary as
 select
     nextval('id') as id,
@@ -198,22 +231,31 @@ drop sequence id
 create sequence id start 1
 ;
 
-create table cons_min_outgoing_flow_for_transport_flows_without_unit_commitment as
+drop table if exists cons_min_outgoing_flow_for_transport_flows_without_unit_commitment
+;
 
+create table cons_min_outgoing_flow_for_transport_flows_without_unit_commitment as
 -- We want to check if the outgoing flows of an asset have transport flows
 -- This information is gathered from the flow table
 -- COALESCE is used to handle the case where there are no outgoing flows
-with transport_flow_info as (
-    select
-    asset.asset,
-    coalesce(
-        (select bool_or(flow.is_transport)
-         from flow
-         where flow.from_asset = asset.asset),
-         false
-    ) as outgoing_flows_have_transport_flows,
-    from asset
-)
+with
+    transport_flow_info as (
+        select
+            asset.asset,
+            coalesce(
+                (
+                    select
+                        bool_or(flow.is_transport)
+                    from
+                        flow
+                    where
+                        flow.from_asset = asset.asset
+                ),
+                false
+            ) as outgoing_flows_have_transport_flows,
+        from
+            asset
+    )
 select
     nextval('id') as id,
     t_high.*
@@ -234,21 +276,30 @@ drop sequence id
 create sequence id start 1
 ;
 
-create table cons_min_incoming_flow_for_transport_flows as
+drop table if exists cons_min_incoming_flow_for_transport_flows
+;
 
+create table cons_min_incoming_flow_for_transport_flows as
 -- Similar to the previous query, but for incoming flows
 -- Also for assets with unit commitment
-with transport_flow_info as (
-    select
-    asset.asset,
-    coalesce(
-        (select bool_or(flow.is_transport)
-         from flow
-         where flow.to_asset = asset.asset),
-         false
-    ) as incoming_flows_have_transport_flows,
-    from asset
-)
+with
+    transport_flow_info as (
+        select
+            asset.asset,
+            coalesce(
+                (
+                    select
+                        bool_or(flow.is_transport)
+                    from
+                        flow
+                    where
+                        flow.to_asset = asset.asset
+                ),
+                false
+            ) as incoming_flows_have_transport_flows,
+        from
+            asset
+    )
 select
     nextval('id') as id,
     t_high.*
@@ -264,13 +315,20 @@ where
 drop sequence id
 ;
 
+drop table if exists cons_limit_units_on_compact_method
+;
+
 create table cons_limit_units_on_compact_method as
 select
     *
 from
     var_units_on
     left join asset on var_units_on.asset = asset.asset
-    where asset.investment_method = 'compact'
+where
+    asset.investment_method = 'compact'
+;
+
+drop table if exists cons_limit_units_on_simple_method
 ;
 
 create table cons_limit_units_on_simple_method as
@@ -279,10 +337,14 @@ select
 from
     var_units_on
     left join asset on var_units_on.asset = asset.asset
-    where asset.investment_method in ('simple', 'none')
+where
+    asset.investment_method in ('simple', 'none')
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_min_output_flow_with_unit_commitment
 ;
 
 create table cons_min_output_flow_with_unit_commitment as
@@ -303,6 +365,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_max_output_flow_with_basic_unit_commitment
+;
+
 create table cons_max_output_flow_with_basic_unit_commitment as
 select
     nextval('id') as id,
@@ -320,6 +385,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_max_ramp_with_unit_commitment
 ;
 
 create table cons_max_ramp_with_unit_commitment as
@@ -342,6 +410,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_max_ramp_without_unit_commitment
+;
+
 create table cons_max_ramp_without_unit_commitment as
 select
     nextval('id') as id,
@@ -356,11 +427,17 @@ where
     and asset.unit_commitment_method != 'basic'
 ;
 
+drop table if exists cons_balance_storage_rep_period
+;
+
 create table cons_balance_storage_rep_period as
 select
     *
 from
     var_storage_level_rep_period
+;
+
+drop table if exists cons_balance_storage_over_clustered_year
 ;
 
 create table cons_balance_storage_over_clustered_year as
@@ -374,6 +451,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_min_energy_over_clustered_year
 ;
 
 create table cons_min_energy_over_clustered_year as
@@ -397,6 +477,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_max_energy_over_clustered_year
+;
+
 create table cons_max_energy_over_clustered_year as
 select
     nextval('id') as id,
@@ -416,6 +499,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_transport_flow_limit_simple_method
 ;
 
 create table cons_transport_flow_limit_simple_method as
@@ -442,6 +528,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_group_max_investment_limit
+;
+
 create table cons_group_max_investment_limit as
 select
     nextval('id') as id,
@@ -459,6 +548,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists cons_group_min_investment_limit
 ;
 
 create table cons_group_min_investment_limit as
@@ -484,6 +576,10 @@ create sequence id start 1
 -- It joins the `cons_flows_relationships` table with the `flows_relationships` table
 -- using a composite key created by concatenating the flows from/to columns in the `flows_relationships` table.
 -- since the asset created in the `t_lowest_flows_relationship` table is a composite key.
+--
+drop table if exists cons_flows_relationships
+;
+
 create table cons_flows_relationships as
 select
     nextval('id') as id,
@@ -497,11 +593,15 @@ select
     fr.ratio,
 from
     t_lowest_flows_relationship as t_low
-    left join flows_relationships AS fr
-    on t_low.asset = CONCAT(fr.flow_1_from_asset, '_',
-                           fr.flow_1_to_asset, '_',
-                           fr.flow_2_from_asset, '_',
-                           fr.flow_2_to_asset)
+    left join flows_relationships as fr on t_low.asset = concat(
+        fr.flow_1_from_asset,
+        '_',
+        fr.flow_1_to_asset,
+        '_',
+        fr.flow_2_from_asset,
+        '_',
+        fr.flow_2_to_asset
+    )
     and t_low.year = fr.milestone_year
 ;
 

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -1,4 +1,10 @@
+drop sequence if exists id
+;
+
 create sequence id start 1
+;
+
+drop table if exists var_flow
 ;
 
 create table var_flow as
@@ -20,6 +26,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists var_units_on
 ;
 
 create table var_units_on as
@@ -45,6 +54,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists var_electricity_angle
+;
+
 create table var_electricity_angle as
 select
     nextval('id') as id,
@@ -52,7 +64,7 @@ select
     atr.year,
     atr.rep_period,
     atr.time_block_start,
-    any_value(atr.time_block_end) as time_block_end,
+    any_value (atr.time_block_end) as time_block_end,
 from
     -- The angle resolution is the same as the time resolution of the asset
     asset_time_resolution_rep_period as atr
@@ -70,18 +82,24 @@ from
 where
     flow.is_transport
     and flow_milestone.dc_opf
--- We may end up with duplicates because an asset can have both incoming and outgoing flows
--- Or it can have multiple flows
--- GROUP BY is used to remove duplicates
--- Note SELECT only happens after the GROUP BY, so id is unique for each row.
+    -- We may end up with duplicates because an asset can have both incoming and outgoing flows
+    -- Or it can have multiple flows
+    -- GROUP BY is used to remove duplicates
+    -- Note SELECT only happens after the GROUP BY, so id is unique for each row.
 group by
-    atr.asset, atr.year, atr.rep_period, atr.time_block_start
+    atr.asset,
+    atr.year,
+    atr.rep_period,
+    atr.time_block_start
 ;
 
 drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists var_is_charging
 ;
 
 create table var_is_charging as
@@ -105,6 +123,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists var_storage_level_rep_period
 ;
 
 create table var_storage_level_rep_period as
@@ -141,6 +162,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists var_storage_level_over_clustered_year
+;
+
 create table var_storage_level_over_clustered_year as
 with
     filtered_assets as (
@@ -173,6 +197,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists var_flows_investment
+;
+
 create table var_flows_investment as
 select
     nextval('id') as id,
@@ -199,6 +226,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists var_assets_investment
+;
+
 create table var_assets_investment as
 select
     nextval('id') as id,
@@ -222,6 +252,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists var_assets_decommission
+;
+
 create table var_assets_decommission as
 select
     nextval('id') as id,
@@ -242,6 +275,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists var_flows_decommission
 ;
 
 create table var_flows_decommission as
@@ -267,6 +303,9 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists var_assets_investment_energy
+;
+
 create table var_assets_investment_energy as
 select
     nextval('id') as id,
@@ -290,6 +329,9 @@ drop sequence id
 ;
 
 create sequence id start 1
+;
+
+drop table if exists var_assets_decommission_energy
 ;
 
 create table var_assets_decommission_energy as

--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -27,6 +27,11 @@ end
         _read_csv_folder(connection, dir)
         energy_problem = TulipaEnergyModel.run_scenario(connection; optimizer, show_log = false)
         @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
+        @testset "populate_with_defaults shouldn't change the solution" begin
+            TulipaEnergyModel.populate_with_defaults!(connection)
+            energy_problem = TulipaEnergyModel.run_scenario(connection; optimizer, show_log = false)
+            @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
+        end
     end
 end
 
@@ -36,6 +41,11 @@ end
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
     @test energy_problem.objective_value ≈ 2542.234377 atol = 1e-5
+    @testset "populate_with_defaults shouldn't change the solution" begin
+        TulipaEnergyModel.populate_with_defaults!(connection)
+        energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
+        @test energy_problem.objective_value ≈ 2542.234377 atol = 1e-5
+    end
 end
 
 @testset "UC ramping Case Study" begin
@@ -52,6 +62,16 @@ end
         show_log = false,
     )
     @test energy_problem.objective_value ≈ 293074.923309 atol = 1e-5
+    @testset "populate_with_defaults shouldn't change the solution" begin
+        TulipaEnergyModel.populate_with_defaults!(connection)
+        energy_problem = TulipaEnergyModel.run_scenario(
+            connection;
+            optimizer,
+            optimizer_parameters,
+            show_log = false,
+        )
+        @test energy_problem.objective_value ≈ 293074.923309 atol = 1e-5
+    end
 end
 
 @testset "Tiny Variable Resolution Case Study" begin
@@ -60,6 +80,11 @@ end
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
     @test energy_problem.objective_value ≈ 28.45872 atol = 1e-5
+    @testset "populate_with_defaults shouldn't change the solution" begin
+        TulipaEnergyModel.populate_with_defaults!(connection)
+        energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
+        @test energy_problem.objective_value ≈ 28.45872 atol = 1e-5
+    end
 end
 
 @testset "Multi-year Case Study" begin
@@ -72,6 +97,15 @@ end
         show_log = false,
     )
     @test energy_problem.objective_value ≈ 3458577.01472 atol = 1e-5
+    @testset "populate_with_defaults shouldn't change the solution" begin
+        TulipaEnergyModel.populate_with_defaults!(connection)
+        energy_problem = TulipaEnergyModel.run_scenario(
+            connection;
+            model_parameters_file = joinpath(@__DIR__, "inputs", "model-parameters-example.toml"),
+            show_log = false,
+        )
+        @test energy_problem.objective_value ≈ 3458577.01472 atol = 1e-5
+    end
 end
 
 @testset "Power Flow Case Study" begin
@@ -80,6 +114,11 @@ end
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
     @test energy_problem.objective_value ≈ 417486.99986 atol = 1e-5
+    @testset "populate_with_defaults shouldn't change the solution" begin
+        TulipaEnergyModel.populate_with_defaults!(connection)
+        energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
+        @test energy_problem.objective_value ≈ 417486.99986 atol = 1e-5
+    end
 end
 
 @testset "Infeasible Case Study" begin


### PR DESCRIPTION
Ensure table creation is either 'create or replace' or drop the tables
before creating them. This ensures that they are overwritten.
Run the case studies tests once more running populate_with_defaults
before them to test two things:

- That populate_with_defaults does not change the solution
- That running twice does not raise errors because of existing structures.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1205

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
