### PR TITLE
Make populate_with_defaults enforce schema (correct types and fill NULLs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ SparseArrays = "1"
 Statistics = "1"
 TOML = "1"
 TimerOutputs = "0.5"
-TulipaIO = "0.4"
+TulipaIO = "0.5"
 julia = "1.10"
 
 [extras]

--- a/src/input-schemas.json
+++ b/src/input-schemas.json
@@ -279,7 +279,7 @@
       "constraints": {
         "minimum": 0
       },
-      "default": 0,
+      "default": null,
       "description": "The initial storage level at the beginning of the optimization. The final storage level needs to be above this initial value. If the initial value is null, empty, or missing, it will be optimized using a cycling constraint that links the last period to the initial period.",
       "type": "DOUBLE",
       "unit_of_measure": "MWh"
@@ -306,7 +306,7 @@
       "constraints": {
         "minimum": 0
       },
-      "default": 0.0,
+      "default": null,
       "description": "The minimum amount of energy across the timeframe (e.g., a year) that the asset must produce. If the initial value is null, empty, or missing, it will be no limit.",
       "type": "DOUBLE",
       "unit_of_measure": "MWh"
@@ -333,7 +333,7 @@
       "constraints": {
         "minimum": 0
       },
-      "default": 0,
+      "default": null,
       "description": "Cost of keeping unit online for one hour or the objective function coefficient on `units_on` variable. e.g., no_load cost or idling cost",
       "type": "DOUBLE",
       "unit_of_measure": "CUR/p.u./h"


### PR DESCRIPTION
`populate_with_defaults` now creates a table using the schema and copies the data from the old tables enforcing the data types and defaults. Adds two tests, one for the type correction and one for filling NULLs.


<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->

Closes #1156
<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
