### PR TITLE
Fix bug in objective function causing misaligned units_on_cost

### DIFF
--- a/src/objective.jl
+++ b/src/objective.jl
@@ -285,9 +285,7 @@ function add_objective!(connection, model, variables, expressions, model_paramet
 
     units_on_cost = @expression(
         model,
-        sum(
-            row.cost * units_on for (row, units_on) in zip(indices, variables[:units_on].container)
-        )
+        sum(row.cost * variables[:units_on].container[row.id] for row in indices)
     )
 
     ## Objective function


### PR DESCRIPTION
I have found a bug in the objective function. If there are assets in asset_milestone.csv without a units_on_cost (and this is not the last asset in the generated table), the units_on_cost in objective.jl will be computed wrong, as the indices and var_units_on will be misaligned. To reproduce, delete the units_on_cost for the smr asset in TulipaEnergyModel.jl\test\inputs\UC-ramping/asset_milestone.csv and run the model on this case study. In the objective function in the model.lp file, you will observe that there are four terms of the form 
![Screenshot 2025-05-27 223841](https://github.com/user-attachments/assets/19b6279e-e29e-44ab-852d-4a20e9691f18)
and that the units_on_cost terms for the last four timeblocks for the ocgt asset are missing. Furthermore, the t_objective_assets table is as follows, showing that the units_on_cost for the smr asset is indeed missing, and that this asset's units_on_cost should not be included in the objective function:
![Screenshot 2025-05-27 223913](https://github.com/user-attachments/assets/36368434-a43b-4586-9cc7-c0323c343715)

This pull request fixes this bug by matching the units_on variables with the indices from the SQL query when defining the objective function.

## Related issues

There is no related issue.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
