### PR TITLE
Add upper bound to the decommission variable

### DIFF
--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -383,7 +383,6 @@ function add_limit_decommission_compact_method_constraints!(
             connection,
             table_name,
         )
-
         attach_constraint!(
             model,
             cons,
@@ -391,7 +390,7 @@ function add_limit_decommission_compact_method_constraints!(
             [
                 @constraint(
                     model,
-                    expressions[row.id] ≥ 0,
+                    expressions[row.avail_id] ≥ 0,
                     base_name = "$table_name[$(row.asset),$(row.milestone_year),$(row.commission_year)]"
                 ) for row in indices
             ],
@@ -492,7 +491,8 @@ function _append_expression_available_capacity_id_to_indices_compact_method(conn
     return DuckDB.query(
         connection,
         "SELECT
-            expr_avail_compact_method.id AS id,
+            cons.id AS id,
+            expr_avail_compact_method.id AS avail_id,
             cons.asset AS asset,
             cons.milestone_year AS milestone_year,
             cons.commission_year AS commission_year,
@@ -501,6 +501,7 @@ function _append_expression_available_capacity_id_to_indices_compact_method(conn
             ON cons.asset = expr_avail_compact_method.asset
             AND cons.milestone_year = expr_avail_compact_method.milestone_year
             AND cons.commission_year = expr_avail_compact_method.commission_year
+        ORDER BY cons.id
         ",
     )
 end

--- a/src/constraints/capacity.jl
+++ b/src/constraints/capacity.jl
@@ -356,6 +356,28 @@ function add_capacity_constraints!(connection, model, expressions, constraints, 
     ## Create lower bound for available capacity compact method
     # - Only apply to decommissionable assets using the compact investment method
     # - The simple method has the capacity constraint to guarantee the lower bound
+    add_limit_decommission_compact_method_constraints!(
+        connection,
+        model,
+        expr_avail_compact_method,
+        constraints,
+    )
+
+    return
+end
+
+"""
+    add_limit_decommission_compact_method_constraints!(connection, model, expressions, constraints)
+
+Adds the lower bound for the available capacity of decommissionable assets for the compact investment method.
+This is used to give a upper bound for the decommission variable.
+"""
+function add_limit_decommission_compact_method_constraints!(
+    connection,
+    model,
+    expressions,
+    constraints,
+)
     let table_name = :limit_decommission_compact_method, cons = constraints[table_name]
         indices = _append_expression_available_capacity_id_to_indices_compact_method(
             connection,
@@ -369,7 +391,7 @@ function add_capacity_constraints!(connection, model, expressions, constraints, 
             [
                 @constraint(
                     model,
-                    expr_avail_compact_method[row.id] ≥ 0,
+                    expressions[row.id] ≥ 0,
                     base_name = "$table_name[$(row.asset),$(row.milestone_year),$(row.commission_year)]"
                 ) for row in indices
             ],

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -33,6 +33,7 @@ function compute_constraints_indices(connection)
             :group_min_investment_limit,
             :flows_relationships,
             :dc_power_flow,
+            :limit_decommission_compact_method,
         )
     )
 

--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -636,3 +636,27 @@ where
 
 drop sequence id
 ;
+
+
+
+create sequence id start 1
+;
+
+drop table if exists cons_limit_decommission_compact_method
+;
+
+create table cons_limit_decommission_compact_method as
+select
+    nextval('id') as id,
+    var_assets_decommission.asset,
+    var_assets_decommission.milestone_year,
+    var_assets_decommission.commission_year,
+from
+    var_assets_decommission
+left join asset on asset.asset = var_assets_decommission.asset
+where
+    asset.investment_method = 'compact'
+;
+
+drop sequence id
+;

--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -637,8 +637,6 @@ where
 drop sequence id
 ;
 
-
-
 create sequence id start 1
 ;
 

--- a/test/test-constraint-limit-decommission-compact-method.jl
+++ b/test/test-constraint-limit-decommission-compact-method.jl
@@ -1,0 +1,100 @@
+@testset "Test add_limit_decommission_compact_method_constraints!" begin
+    # Setup a temporary DuckDB connection and model
+    connection = _multi_year_fixture()
+    model = JuMP.Model()
+
+    # Create variable tables
+    table_rows = [(1, "wind", 2030, true, 50, Inf), (2, "wind", 2050, true, 50, Inf)]
+    var_assets_investment = DataFrame(
+        table_rows,
+        [:id, :asset, :milestone_year, :investment_integer, :capacity, :investment_limit],
+    )
+    DuckDB.register_data_frame(connection, var_assets_investment, "var_assets_investment")
+
+    table_rows = [(1, "wind", 2030, 2020, true), (2, "wind", 2050, 2030, true)]
+    var_assets_decommission =
+        DataFrame(table_rows, [:id, :asset, :milestone_year, :commission_year, :investment_integer])
+    DuckDB.register_data_frame(connection, var_assets_decommission, "var_assets_decommission")
+
+    df = DataFrame(;
+        id = Int[],
+        from_asset = String[],
+        to_asset = String[],
+        milestone_year = Int[],
+        investment_integer = Bool[],
+        capacity = Float64[],
+        investment_limit = Float64[],
+    )
+    DuckDB.register_data_frame(connection, df, "var_flows_investment")
+
+    df = DataFrame(;
+        id = Int[],
+        from_asset = String[],
+        to_asset = String[],
+        milestone_year = Int[],
+        commission_year = Int[],
+        investment_integer = Bool[],
+    )
+    DuckDB.register_data_frame(connection, df, "var_flows_decommission")
+
+    df = DataFrame(; id = Int[], asset = String[], milestone_year = Int[])
+    DuckDB.register_data_frame(connection, df, "var_assets_investment_energy")
+
+    df = DataFrame(; id = Int[], asset = String[], milestone_year = Int[], commission_year = Int[])
+    DuckDB.register_data_frame(connection, df, "var_assets_decommission_energy")
+
+    variables = Dict{Symbol,TulipaEnergyModel.TulipaVariable}(
+        key => TulipaEnergyModel.TulipaVariable(connection, "var_$key") for key in (
+            :assets_investment,
+            :assets_decommission,
+            :flows_investment,
+            :flows_decommission,
+            :assets_investment_energy,
+            :assets_decommission_energy,
+        )
+    )
+    # Create JuMP variables
+    TulipaEnergyModel.add_investment_variables!(model, variables)
+
+    # Create expressions
+    expressions = Dict{Symbol,TulipaEnergyModel.TulipaExpression}()
+    TulipaEnergyModel.create_multi_year_expressions!(connection, model, variables, expressions)
+    expr_avail_compact_method =
+        expressions[:available_asset_units_compact_method].expressions[:assets]
+
+    # Create constraint tables
+    table_rows = [(1, "wind", 2030, 2020), (2, "wind", 2050, 2030)]
+    cons_limit_decommission_compact_method =
+        DataFrame(table_rows, [:id, :asset, :milestone_year, :commission_year])
+    DuckDB.register_data_frame(
+        connection,
+        cons_limit_decommission_compact_method,
+        "cons_limit_decommission_compact_method",
+    )
+
+    constraints = Dict{Symbol,TulipaEnergyModel.TulipaConstraint}(
+        key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key") for
+        key in (:limit_decommission_compact_method,)
+    )
+
+    # Create JuMP constraints
+    TulipaEnergyModel.add_limit_decommission_compact_method_constraints!(
+        connection,
+        model,
+        expr_avail_compact_method,
+        constraints,
+    )
+
+    var_assets_investment = variables[:assets_investment].container
+    var_assets_decommission = variables[:assets_decommission].container
+
+    expected_cons = [
+        JuMP.@build_constraint(0.07 - var_assets_decommission[1] ≥ 0),
+        JuMP.@build_constraint(0.02 + var_assets_investment[1] - var_assets_decommission[2] ≥ 0)
+    ]
+    for (i, constraint) in enumerate(model[:limit_decommission_compact_method])
+        observed_con = JuMP.constraint_object(constraint)
+        expected_con = expected_cons[i]
+        @test _is_constraint_equal(observed_con, expected_con)
+    end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -18,6 +18,12 @@ function _storage_fixture()
     return connection
 end
 
+function _multi_year_fixture()
+    connection = DBInterface.connect(DuckDB.DB)
+    _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Multi-year Investments"))
+    return connection
+end
+
 function _is_constraint_equal(left, right)
     if !_is_constraint_equal_kernel(left, right)
         println("LEFT")


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

This only applies to the compact method, since in the simple method, the capacity constraint guarantees this.
In this PR, instead of bounds, a general constraint is applied to the available capacity per (asset, milestone year, commission year) where `decommissionable==true` .

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1230


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
