### PR TITLE
Add .gitattributes to ignore mps and csv files from language breakdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.mps linguist-generated
+benchmark/EU/*.csv linguist-vendored
+test/inputs/**/*.csv linguist-vendored


### PR DESCRIPTION
https://github.com/github-linguist/linguist is used to compute the language breakdown of the repo.
With this change, we inform linguist that MPS and CSV files should be ignored from the computation.