### PR TITLE
Refactor add investment variables

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -90,6 +90,7 @@ function create_model(
         variables,
     )
     @timeit to "add_investment_variables!" add_investment_variables!(model, variables)
+    @timeit to "add_decommission_variables!" add_decommission_variables!(model, variables)
     @timeit to "add_unit_commitment_variables!" add_unit_commitment_variables!(model, variables)
     @timeit to "add_power_flow_variables!" add_power_flow_variables!(model, variables)
     @timeit to "add_storage_variables!" add_storage_variables!(connection, model, variables)

--- a/src/variables/decommission.jl
+++ b/src/variables/decommission.jl
@@ -1,0 +1,43 @@
+export add_decommission_variables!
+
+"""
+    _get_decommission_variable_specifications()
+
+Returns a dictionary containing specifications for all decommission variables.
+Each specification includes the keys extraction function, bounds functions, and integer constraint function.
+"""
+function _get_decommission_variable_specifications()
+    return Dict{Symbol,NamedTuple}(
+        :assets_decommission => (
+            keys_from_row = row -> (row.asset, row.milestone_year, row.commission_year),
+            lower_bound_from_row = _ -> 0.0,
+            upper_bound_from_row = _ -> Inf,
+            integer_from_row = row -> row.investment_integer,
+        ),
+        :flows_decommission => (
+            keys_from_row = row ->
+                ((row.from_asset, row.to_asset), row.milestone_year, row.commission_year),
+            lower_bound_from_row = _ -> 0.0,
+            upper_bound_from_row = _ -> Inf,
+            integer_from_row = row -> row.investment_integer,
+        ),
+        :assets_decommission_energy => (
+            keys_from_row = row -> (row.asset, row.milestone_year, row.commission_year),
+            lower_bound_from_row = _ -> 0.0,
+            upper_bound_from_row = _ -> Inf,
+            integer_from_row = row -> row.investment_integer_storage_energy,
+        ),
+    )
+end
+
+"""
+    add_decommission_variables!(model, variables)
+
+Adds decommission variables to the optimization `model`,
+and sets bounds on selected variables based on the input data.
+"""
+function add_decommission_variables!(model, variables)
+    specifications = _get_decommission_variable_specifications()
+    _create_variables_from_specifications!(model, variables, specifications)
+    return
+end

--- a/test/test-constraint-limit-decommission-compact-method.jl
+++ b/test/test-constraint-limit-decommission-compact-method.jl
@@ -55,6 +55,7 @@
     )
     # Create JuMP variables
     TulipaEnergyModel.add_investment_variables!(model, variables)
+    TulipaEnergyModel.add_decommission_variables!(model, variables)
 
     # Create expressions
     expressions = Dict{Symbol,TulipaEnergyModel.TulipaExpression}()

--- a/test/test-variable-decommission.jl
+++ b/test/test-variable-decommission.jl
@@ -1,0 +1,85 @@
+@testset "Test add_decommission_variables!" begin
+    # Setup a temporary DuckDB connection and model
+    connection = DBInterface.connect(DuckDB.DB)
+    model = JuMP.Model()
+
+    # Create test data for assets decommission variables
+    asset_decommission_data = DataFrame(;
+        id = [1, 2],
+        asset = ["wind", "solar"],
+        milestone_year = [2030, 2040],
+        commission_year = [2020, 2030],
+        investment_integer = [true, false],
+    )
+    DuckDB.register_data_frame(connection, asset_decommission_data, "var_assets_decommission")
+
+    # Create test data for flows decommission variables
+    flow_decommission_data = DataFrame(;
+        id = [1],
+        from_asset = ["wind"],
+        to_asset = ["demand"],
+        milestone_year = [2030],
+        commission_year = [2020],
+        investment_integer = [true],
+    )
+    DuckDB.register_data_frame(connection, flow_decommission_data, "var_flows_decommission")
+
+    # Create test data for assets decommission energy variables
+    asset_decommission_energy_data = DataFrame(;
+        id = [1],
+        asset = ["battery"],
+        milestone_year = [2040],
+        commission_year = [2030],
+        investment_integer_storage_energy = [false],
+    )
+    DuckDB.register_data_frame(
+        connection,
+        asset_decommission_energy_data,
+        "var_assets_decommission_energy",
+    )
+
+    # Create TulipaVariable objects
+    variables = Dict{Symbol,TulipaEnergyModel.TulipaVariable}(
+        key => TulipaEnergyModel.TulipaVariable(connection, "var_$key") for
+        key in (:assets_decommission, :flows_decommission, :assets_decommission_energy)
+    )
+
+    # Call the function under test
+    TulipaEnergyModel.add_decommission_variables!(model, variables)
+
+    # Test that variables were created correctly
+    @test length(variables[:assets_decommission].container) ==
+          asset_decommission_data |> DataFrames.nrow
+    @test length(variables[:flows_decommission].container) ==
+          flow_decommission_data |> DataFrames.nrow
+    @test length(variables[:assets_decommission_energy].container) ==
+          asset_decommission_energy_data |> DataFrames.nrow
+
+    # Test bounds and integer constraints for assets decommission
+    # Note: Decommission variables don't have upper bounds
+    asset_vars = variables[:assets_decommission].container
+    for row in eachrow(asset_decommission_data)
+        var = asset_vars[row.id]
+        @test JuMP.lower_bound(var) == 0.0
+        @test !JuMP.has_upper_bound(var)
+        @test JuMP.is_integer(var) == row.investment_integer
+    end
+
+    # Test bounds and integer constraints for flows decommission
+    flow_vars = variables[:flows_decommission].container
+    for row in eachrow(flow_decommission_data)
+        var = flow_vars[row.id]
+        @test JuMP.lower_bound(var) == 0.0
+        @test !JuMP.has_upper_bound(var)
+        @test JuMP.is_integer(var) == row.investment_integer
+    end
+
+    # Test bounds and integer constraints for assets decommission energy
+    energy_vars = variables[:assets_decommission_energy].container
+    for row in eachrow(asset_decommission_energy_data)
+        var = energy_vars[row.id]
+        @test JuMP.lower_bound(var) == 0.0
+        @test !JuMP.has_upper_bound(var)
+        @test JuMP.is_integer(var) == row.investment_integer_storage_energy
+    end
+end

--- a/test/test-variable-decommission.jl
+++ b/test/test-variable-decommission.jl
@@ -59,27 +59,33 @@
     # Note: Decommission variables don't have upper bounds
     asset_vars = variables[:assets_decommission].container
     for row in eachrow(asset_decommission_data)
-        var = asset_vars[row.id]
-        @test JuMP.lower_bound(var) == 0.0
-        @test !JuMP.has_upper_bound(var)
-        @test JuMP.is_integer(var) == row.investment_integer
+        _test_variable_properties(
+            asset_vars[row.id],
+            0.0,
+            nothing;
+            is_integer = row.investment_integer,
+        )
     end
 
     # Test bounds and integer constraints for flows decommission
     flow_vars = variables[:flows_decommission].container
     for row in eachrow(flow_decommission_data)
-        var = flow_vars[row.id]
-        @test JuMP.lower_bound(var) == 0.0
-        @test !JuMP.has_upper_bound(var)
-        @test JuMP.is_integer(var) == row.investment_integer
+        _test_variable_properties(
+            flow_vars[row.id],
+            0.0,
+            nothing;
+            is_integer = row.investment_integer,
+        )
     end
 
     # Test bounds and integer constraints for assets decommission energy
     energy_vars = variables[:assets_decommission_energy].container
     for row in eachrow(asset_decommission_energy_data)
-        var = energy_vars[row.id]
-        @test JuMP.lower_bound(var) == 0.0
-        @test !JuMP.has_upper_bound(var)
-        @test JuMP.is_integer(var) == row.investment_integer_storage_energy
+        _test_variable_properties(
+            energy_vars[row.id],
+            0.0,
+            nothing;
+            is_integer = row.investment_integer_storage_energy,
+        )
     end
 end

--- a/test/test-variable-investment.jl
+++ b/test/test-variable-investment.jl
@@ -1,0 +1,95 @@
+@testset "Test add_investment_variables!" begin
+    # Setup a temporary DuckDB connection and model
+    connection = DBInterface.connect(DuckDB.DB)
+    model = JuMP.Model()
+
+    # Create test data for assets investment variables
+    asset_investment_data = DataFrame(;
+        id = [1, 2, 3, 4],
+        asset = ["wind", "solar", "battery", "ccgt"],
+        milestone_year = [2030, 2030, 2040, 2040],
+        investment_integer = [true, false, true, true],
+        capacity = [100.0, 50.0, 25.0, 125.0],
+        investment_limit = [1000.0, missing, 500.0, 650.0],  # Should result in [10.0, Inf, 20.0, 5.0]
+    )
+    DuckDB.register_data_frame(connection, asset_investment_data, "var_assets_investment")
+
+    # Create test data for flows investment variables
+    flow_investment_data = DataFrame(;
+        id = [1, 2],
+        from_asset = ["wind", "solar"],
+        to_asset = ["demand", "demand"],
+        milestone_year = [2030, 2030],
+        investment_integer = [false, true],
+        capacity = [80.0, 60.0],
+        investment_limit = [800.0, missing],
+    )
+    DuckDB.register_data_frame(connection, flow_investment_data, "var_flows_investment")
+
+    # Create test data for assets investment energy variables
+    asset_investment_energy_data = DataFrame(;
+        id = [1],
+        asset = ["battery"],
+        milestone_year = [2040],
+        investment_integer_storage_energy = [true],
+        capacity_storage_energy = [100.0],
+        investment_limit_storage_energy = [1200.0],
+    )
+    DuckDB.register_data_frame(
+        connection,
+        asset_investment_energy_data,
+        "var_assets_investment_energy",
+    )
+
+    # Create TulipaVariable objects
+    variables = Dict{Symbol,TulipaEnergyModel.TulipaVariable}(
+        key => TulipaEnergyModel.TulipaVariable(connection, "var_$key") for
+        key in (:flows_investment, :assets_investment, :assets_investment_energy)
+    )
+
+    # Call the function under test
+    TulipaEnergyModel.add_investment_variables!(model, variables)
+
+    # Test that variables were created correctly
+    @test length(variables[:assets_investment].container) ==
+          asset_investment_data |> DataFrames.nrow
+    @test length(variables[:flows_investment].container) == flow_investment_data |> DataFrames.nrow
+    @test length(variables[:assets_investment_energy].container) ==
+          asset_investment_energy_data |> DataFrames.nrow
+
+    # Test bounds and integer constraints for assets investment
+    asset_vars = variables[:assets_investment].container
+    for row in eachrow(asset_investment_data)
+        var = asset_vars[row.id]
+        @test JuMP.lower_bound(var) == 0.0
+        if ismissing(row.investment_limit)
+            @test !JuMP.has_upper_bound(var)
+        else
+            @test JuMP.upper_bound(var) == floor(row.investment_limit / row.capacity)
+        end
+        @test JuMP.is_integer(var) == row.investment_integer
+    end
+
+    # Test bounds and integer constraints for flows investment
+    flow_vars = variables[:flows_investment].container
+    for row in eachrow(flow_investment_data)
+        var = flow_vars[row.id]
+        @test JuMP.lower_bound(var) == 0.0
+        if ismissing(row.investment_limit)
+            @test !JuMP.has_upper_bound(var)
+        else
+            @test JuMP.upper_bound(var) == floor(row.investment_limit / row.capacity)
+        end
+        @test JuMP.is_integer(var) == row.investment_integer
+    end
+
+    # Test bounds and integer constraints for assets investment energy
+    energy_vars = variables[:assets_investment_energy].container
+    for row in eachrow(asset_investment_energy_data)
+        var = energy_vars[row.id]
+        @test JuMP.lower_bound(var) == 0.0
+        @test JuMP.upper_bound(var) ==
+              floor(row.investment_limit_storage_energy / row.capacity_storage_energy)
+        @test JuMP.is_integer(var) == row.investment_integer_storage_energy
+    end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -80,3 +80,28 @@ function _is_constraint_equal_kernel(left, right)
     end
     return result
 end
+
+function _test_variable_properties(
+    variable::JuMP.GenericVariableRef,
+    lower_bound::Union{Nothing,Float64},
+    upper_bound::Union{Nothing,Float64};
+    is_integer::Bool = false,
+    is_binary::Bool = false,
+)
+    if isnothing(lower_bound)
+        @test !JuMP.has_lower_bound(variable)
+    else
+        @test JuMP.lower_bound(variable) == lower_bound
+    end
+
+    if isnothing(upper_bound)
+        @test !JuMP.has_upper_bound(variable)
+    else
+        @test JuMP.upper_bound(variable) == upper_bound
+    end
+
+    @test JuMP.is_integer(variable) == is_integer
+    @test JuMP.is_binary(variable) == is_binary
+
+    return nothing
+end


### PR DESCRIPTION
The main idea is to give more flexibility and readability to the investment and decommission variable creation by splitting their creation and addition to the model. Two new tests are added for the variable creation.

## Related issues

Closes #1272

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [N.A.] Docs were updated and workflow is passing
