### PR TITLE
Add vintage flow sum constraint

### DIFF
--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -34,6 +34,7 @@ function compute_constraints_indices(connection)
             :flows_relationships,
             :dc_power_flow,
             :limit_decommission_compact_method,
+            :vintage_flow_sum_semi_compact_method,
         )
     )
 

--- a/src/constraints/vintage-flow.jl
+++ b/src/constraints/vintage-flow.jl
@@ -1,0 +1,65 @@
+export add_vintage_flow_sum_constraints!
+
+"""
+    add_vintage_flow_sum_constraints!(connection, model, variables, constraints)
+
+Adds the vintage flow sum constraints to the model.
+"""
+function add_vintage_flow_sum_constraints!(connection, model, variables, constraints)
+    let table_name = :vintage_flow_sum_semi_compact_method,
+        cons = constraints[:vintage_flow_sum_semi_compact_method]
+
+        indices = _append_vintage_flow_data_to_indices(connection, table_name)
+
+        var_flow = variables[:flow].container
+        var_vintage_flow = variables[:vintage_flow].container
+
+        attach_constraint!(
+            model,
+            cons,
+            table_name,
+            [
+                @constraint(
+                    model,
+                    sum(var_vintage_flow[idx] for idx in row.var_vintage_flow_indices) ==
+                    var_flow[row.var_flow_id],
+                    base_name = "$table_name[$(row.from_asset),$(row.to_asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+                ) for row in indices
+            ],
+        )
+    end
+
+    return
+end
+
+function _append_vintage_flow_data_to_indices(connection, table_name)
+    return DuckDB.query(
+        connection,
+        "SELECT
+            cons.id,
+            cons.from_asset,
+            cons.to_asset,
+            cons.year,
+            cons.rep_period,
+            cons.time_block_start,
+            cons.time_block_end,
+            ANY_VALUE(var_flow.id) AS var_flow_id,
+            ARRAY_AGG(var_vintage_flow.id) AS var_vintage_flow_indices,
+        FROM cons_$table_name AS cons
+        LEFT JOIN var_flow
+            ON cons.from_asset = var_flow.from_asset
+            AND cons.to_asset = var_flow.to_asset
+            AND cons.year = var_flow.year
+            AND cons.rep_period = var_flow.rep_period
+            AND cons.time_block_start = var_flow.time_block_start
+        LEFT JOIN var_vintage_flow
+            ON var_vintage_flow.from_asset = cons.from_asset
+            AND var_vintage_flow.to_asset = cons.to_asset
+            AND var_vintage_flow.milestone_year = cons.year
+            AND var_vintage_flow.rep_period = cons.rep_period
+            AND var_vintage_flow.time_block_start = cons.time_block_start
+        GROUP BY cons.id, cons.from_asset, cons.to_asset, cons.year, cons.rep_period, cons.time_block_start, cons.time_block_end
+        ORDER BY cons.id
+        ",
+    )
+end

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -203,7 +203,7 @@ function create_model(
         model_parameters,
     )
 
-    @timeit to "add_vintage_flow_constraints!" add_vintage_flow_sum_constraints!(
+    @timeit to "add_vintage_flow_sum_constraints!" add_vintage_flow_sum_constraints!(
         connection,
         model,
         variables,

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -203,6 +203,13 @@ function create_model(
         model_parameters,
     )
 
+    @timeit to "add_vintage_flow_constraints!" add_vintage_flow_sum_constraints!(
+        connection,
+        model,
+        variables,
+        constraints,
+    )
+
     if model_file_name != ""
         @timeit to "save model file" JuMP.write_to_file(model, model_file_name)
     end

--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -651,3 +651,28 @@ where
 
 drop sequence id
 ;
+
+create sequence id start 1
+;
+
+drop table if exists cons_vintage_flow_sum_semi_compact_method
+;
+
+create table cons_vintage_flow_sum_semi_compact_method as
+select
+    nextval('id') as id,
+    from_asset,
+    to_asset,
+    year,
+    rep_period,
+    time_block_start,
+    time_block_end,
+from
+    var_flow
+left join asset on asset.asset = var_flow.from_asset
+where
+    asset.investment_method = 'semi-compact'
+;
+
+drop sequence id
+;

--- a/test/test-constraint-vintage-flow-sum.jl
+++ b/test/test-constraint-vintage-flow-sum.jl
@@ -1,0 +1,87 @@
+@testset "Test add_vintage_flow_sum_constraints!" begin
+    # Setup a temporary DuckDB connection and model
+    connection = DBInterface.connect(DuckDB.DB)
+    model = JuMP.Model()
+
+    # Create mock tables for testing using register_data_frame
+    # This first table is only necessary because we have a left join of var_flow with the asset table
+    table_rows = [("input_1", "semi-compact"), ("input_2", "compact"), ("death_star", "simple")]
+    asset = DataFrame(table_rows, [:asset, :investment_method])
+    DuckDB.register_data_frame(connection, asset, "asset")
+
+    table_rows = [
+        ("input_1", "death_star", false),
+        ("input_2", "death_star", false),
+        ("death_star", "input_1", false),
+        ("death_star", "input_2", false),
+    ]
+    flow = DataFrame(table_rows, [:from_asset, :to_asset, :is_transport])
+    DuckDB.register_data_frame(connection, flow, "flow")
+
+    table_rows = [
+        (1, "input_1", "death_star", 2025, 1, 1, 1),
+        (2, "input_2", "death_star", 2025, 1, 1, 1),
+        (3, "death_star", "input_1", 2025, 1, 1, 1),
+        (4, "death_star", "input_2", 2025, 1, 1, 1),
+    ]
+    var_flow = DataFrame(
+        table_rows,
+        [:id, :from_asset, :to_asset, :year, :rep_period, :time_block_start, :time_block_end],
+    )
+    DuckDB.register_data_frame(connection, var_flow, "var_flow")
+
+    table_rows = [
+        (1, "input_1", "death_star", 2025, 2025, 1, 1, 1),
+        (2, "input_1", "death_star", 2025, 2020, 1, 1, 1),
+    ]
+    var_vintage_flow = DataFrame(
+        table_rows,
+        [
+            :id,
+            :from_asset,
+            :to_asset,
+            :milestone_year,
+            :commission_year,
+            :rep_period,
+            :time_block_start,
+            :time_block_end,
+        ],
+    )
+    DuckDB.register_data_frame(connection, var_vintage_flow, "var_vintage_flow")
+
+    variables = Dict{Symbol,TulipaEnergyModel.TulipaVariable}(
+        key => TulipaEnergyModel.TulipaVariable(connection, "var_$key") for
+        key in (:flow, :vintage_flow)
+    )
+    TulipaEnergyModel.add_flow_variables!(connection, model, variables)
+    TulipaEnergyModel.add_vintage_flow_variables!(connection, model, variables)
+
+    table_rows = [(1, "input_1", "death_star", 2025, 1, 1, 1)]
+
+    cons_vintage_flow_sum_semi_compact_method = DataFrame(
+        table_rows,
+        [:id, :from_asset, :to_asset, :year, :rep_period, :time_block_start, :time_block_end],
+    )
+    DuckDB.register_data_frame(
+        connection,
+        cons_vintage_flow_sum_semi_compact_method,
+        "cons_vintage_flow_sum_semi_compact_method",
+    )
+
+    constraints = Dict{Symbol,TulipaEnergyModel.TulipaConstraint}(
+        key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key") for
+        key in (:vintage_flow_sum_semi_compact_method,)
+    )
+
+    TulipaEnergyModel.add_vintage_flow_sum_constraints!(connection, model, variables, constraints)
+
+    # test the constraints
+    var_flow = variables[:flow].container
+    var_vintage_flow = variables[:vintage_flow].container
+
+    expected_con = JuMP.@build_constraint(var_vintage_flow[1] + var_vintage_flow[2] == var_flow[1])
+
+    observed_con = JuMP.constraint_object(model[:vintage_flow_sum_semi_compact_method][1])
+
+    @test _is_constraint_equal(observed_con, expected_con)
+end

--- a/test/test-constraint-vintage-flow-sum.jl
+++ b/test/test-constraint-vintage-flow-sum.jl
@@ -68,21 +68,27 @@
         "cons_vintage_flow_sum_semi_compact_method",
     )
 
-    constraints = let key=:vintage_flow_sum_semi_compact_method
+    constraints = let key = :vintage_flow_sum_semi_compact_method
         Dict{Symbol,TulipaEnergyModel.TulipaConstraint}(
-            key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key")
+            key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key"),
         )
     end
 
     TulipaEnergyModel.add_vintage_flow_sum_constraints!(connection, model, variables, constraints)
 
-    # test the constraints
+    # Test the constraints
     var_flow = variables[:flow].container
     var_vintage_flow = variables[:vintage_flow].container
 
-    expected_con = JuMP.@build_constraint(var_vintage_flow[1] + var_vintage_flow[2] == var_flow[1])
+    expected_con =
+        [JuMP.@build_constraint(var_vintage_flow[1] + var_vintage_flow[2] == var_flow[1])]
 
-    observed_con = JuMP.constraint_object(model[:vintage_flow_sum_semi_compact_method][1])
+    observed_con =
+        [JuMP.constraint_object(con) for con in model[:vintage_flow_sum_semi_compact_method]]
 
-    @test _is_constraint_equal(observed_con, expected_con)
+    for (expected, observed) in zip(expected_con, observed_con)
+        @test _is_constraint_equal(expected, observed)
+    end
+
+    @test length(expected_con) == length(observed_con)
 end

--- a/test/test-constraint-vintage-flow-sum.jl
+++ b/test/test-constraint-vintage-flow-sum.jl
@@ -68,10 +68,11 @@
         "cons_vintage_flow_sum_semi_compact_method",
     )
 
-    constraints = Dict{Symbol,TulipaEnergyModel.TulipaConstraint}(
-        key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key") for
-        key in (:vintage_flow_sum_semi_compact_method,)
-    )
+    constraints = let key=:vintage_flow_sum_semi_compact_method
+        Dict{Symbol,TulipaEnergyModel.TulipaConstraint}(
+            key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key")
+        )
+    end
 
     TulipaEnergyModel.add_vintage_flow_sum_constraints!(connection, model, variables, constraints)
 


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

This PR adds a vintage flow sum constraint for semi-compact method.

After splitting the flow variable into vintage-specific flow variables in #1280 (which applies only to the semi-compact method and outgoing flows—for example, separating CCGT-to-demand flows by CCGT commission year), this PR adds a summation constraint to ensure that the original flow variable is correctly linked with the vintage flow variables.

Please let me know if the intention is not clear :)

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1290 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
