### PR TITLE
Add generic functions to create variables with specifications per row

### DIFF
--- a/utils/scripts/model-mps-compare.jl
+++ b/utils/scripts/model-mps-compare.jl
@@ -17,6 +17,15 @@ function compare_mps(existing_mps_folder)
 
     exit_flag = 0
 
+    @warn """This comparison is not fail-proof. The new and existing MPS are
+    compared by first remove all MARKER lines, sorting all lines, and comparing
+    line by line."""
+    function get_relevant_lines(filename)
+        return filter(readlines(filename)) do line
+            return !contains(line, "MARKER")
+        end |> sort
+    end
+
     for folder in filter(isdir, readdir(test_inputs; join = true))
         existing_mps_file = joinpath(existing_mps_folder, basename(folder) * ".mps")
         @assert isfile(existing_mps_file)
@@ -35,8 +44,8 @@ function compare_mps(existing_mps_folder)
         create_mps(folder, new_mps_folder)
         @assert isfile(new_mps_file)
 
-        existing_lines = sort(readlines(existing_mps_file))
-        new_lines = sort(readlines(new_mps_file))
+        existing_lines = get_relevant_lines(existing_mps_file)
+        new_lines = get_relevant_lines(new_mps_file)
 
         if length(existing_lines) != length(new_lines)
             no_issues = false
@@ -103,4 +112,8 @@ else
     end
 end
 
-exit(exit_flag)
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(exit_flag)
+else
+    @info "Exit flag: $exit_flag"
+end


### PR DESCRIPTION
The MARKER INTORG/INTEND blocks denote blocks of integer variables.
If a model reorders the variables, there may be a different number of blocks
leading to a false negative.


<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Observed in PR #1291

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
