### PR TITLE
Add validation to align data between `asset_commission` and `asset_both`

### DIFF
--- a/src/objective.jl
+++ b/src/objective.jl
@@ -426,7 +426,7 @@ function _create_objective_auxiliary_table(connection, constants)
             ON asset_milestone.asset = in_between_years.asset
             AND asset_milestone.milestone_year = in_between_years.milestone_year
         LEFT JOIN asset
-            ON asset.asset = asset_commission.asset
+            ON asset.asset = asset_milestone.asset
         ",
     )
 

--- a/test/inputs/Multi-year Investments/asset-commission.csv
+++ b/test/inputs/Multi-year Investments/asset-commission.csv
@@ -1,10 +1,6 @@
 asset,commission_year,fixed_cost,investment_cost,investment_limit,fixed_cost_storage_energy,investment_cost_storage_energy,investment_limit_storage_energy,storage_loss_from_stored_energy,conversion_efficiency,storage_charging_efficiency,storage_discharging_efficiency
-battery,2020,21.0,71.0,,15.0,1.0,,0,1.0,0.95,0.95
-battery,2025,22.0,72.0,,25.0,2.0,,0,1.0,0.95,0.95
 battery,2030,23.0,73.0,,35.0,3.0,,0,1.0,0.95,0.95
-battery,2040,24.0,74.0,,45.0,4.0,,0,1.0,0.95,0.95
 battery,2050,25.0,75.0,,55.0,5.0,,0,1.0,0.95,0.95
-ccgt,2028,31.0,41.0,10000.0,0.0,0.0,,0,1.0,1.0,1.0
 ccgt,2030,32.0,42.0,10000.0,0.0,0.0,,0,1.0,1.0,1.0
 ccgt,2050,33.0,43.0,10000.0,0.0,0.0,,0,1.0,1.0,1.0
 demand,2030,0.0,0.0,,0.0,0.0,,0,1.0,1.0,1.0

--- a/test/inputs/Multi-year Investments/year-data.csv
+++ b/test/inputs/Multi-year Investments/year-data.csv
@@ -1,5 +1,4 @@
 year,length,is_milestone
 2020,8760,false
-2028,8760,false
 2030,8760,true
 2050,8760,true

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -564,34 +564,31 @@ end
     ]
 end
 
-@testset "Check consistency between asset_commission and asset_both" begin
-    @testset "Using fake data" begin
-        connection = DBInterface.connect(DuckDB.DB)
-        asset_both =
-            DataFrame(:asset => ["A", "A"], :milestone_year => [1, 2], :commission_year => [0, 0])
-        DuckDB.register_data_frame(connection, asset_both, "asset_both")
+@testitem "Check consistency between asset_commission and asset_both - using fake data" setup =
+    [CommonSetup] tags = [:unit, :data_validation, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    asset_both =
+        DataFrame(:asset => ["A", "A"], :milestone_year => [1, 2], :commission_year => [0, 0])
+    DuckDB.register_data_frame(connection, asset_both, "asset_both")
 
-        asset_commission = DataFrame(:asset => ["A", "A"], :commission_year => [-1, 1])
-        DuckDB.register_data_frame(connection, asset_commission, "asset_commission")
+    asset_commission = DataFrame(:asset => ["A", "A"], :commission_year => [-1, 1])
+    DuckDB.register_data_frame(connection, asset_commission, "asset_commission")
 
-        error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
-        @test error_messages == [
-            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 1, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
-            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
-            "Unexpected commission_year = -1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
-            "Unexpected commission_year = 1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
-        ]
-    end
-    @testset "Using Tiny data" begin
-        connection = _tiny_fixture()
-        DuckDB.query(
-            connection,
-            "UPDATE asset_commission SET commission_year = 0 WHERE asset = 'wind'",
-        )
-        error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
-        @test error_messages == [
-            "Missing commission_year = 2030 for asset 'wind' in 'asset_commission' given (asset 'wind', milestone_year = 2030, commission_year = 2030) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
-            "Unexpected commission_year = 0 for asset 'wind' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
-        ]
-    end
+    error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+    @test error_messages == [
+        "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 1, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
+        "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
+        "Unexpected commission_year = -1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
+        "Unexpected commission_year = 1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
+    ]
+end
+@testitem "Check consistency between asset_commission and asset_both - using Tiny data" setup =
+    [CommonSetup] tags = [:unit, :data_validation, :fast] begin
+    connection = _tiny_fixture()
+    DuckDB.query(connection, "UPDATE asset_commission SET commission_year = 0 WHERE asset = 'wind'")
+    error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+    @test error_messages == [
+        "Missing commission_year = 2030 for asset 'wind' in 'asset_commission' given (asset 'wind', milestone_year = 2030, commission_year = 2030) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
+        "Unexpected commission_year = 0 for asset 'wind' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
+    ]
 end

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -563,3 +563,35 @@ end
         "Incorrect use of investment method 'simple' for asset 'demand' of type 'consumer'. Hub and consumer assets can only have 'none' investment method.",
     ]
 end
+
+@testset "Check consistency between asset_commission and asset_both" begin
+    @testset "Using fake data" begin
+        connection = DBInterface.connect(DuckDB.DB)
+        asset_both =
+            DataFrame(:asset => ["A", "A"], :milestone_year => [1, 2], :commission_year => [0, 0])
+        DuckDB.register_data_frame(connection, asset_both, "asset_both")
+
+        asset_commission = DataFrame(:asset => ["A", "A"], :commission_year => [-1, 1])
+        DuckDB.register_data_frame(connection, asset_commission, "asset_commission")
+
+        error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+        @test error_messages == [
+            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 1, commission_year = 0). The commission_year should match the one in 'asset_both'",
+            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2, commission_year = 0). The commission_year should match the one in 'asset_both'.",
+            "Unexpected commission_year = -1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
+            "Unexpected commission_year = 1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
+        ]
+    end
+
+    @testset "Using Tiny data" begin
+        connection = _tiny_fixture()
+        DuckDB.query(
+            connection,
+            "UPDATE asset_commission SET commission_year = 0 WHERE asset = 'wind'",
+        )
+        error_messages = TEM.TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+        @test error_messages == [
+            "Missing commission_year = 2030 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2030, commission_year = 2030). The commission_year should match the one in 'asset_both'",
+        ]
+    end
+end

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -576,22 +576,22 @@ end
 
         error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
         @test error_messages == [
-            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 1, commission_year = 0). The commission_year should match the one in 'asset_both'",
-            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2, commission_year = 0). The commission_year should match the one in 'asset_both'.",
+            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 1, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
+            "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
             "Unexpected commission_year = -1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
             "Unexpected commission_year = 1 for asset 'A' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
         ]
     end
-
     @testset "Using Tiny data" begin
         connection = _tiny_fixture()
         DuckDB.query(
             connection,
             "UPDATE asset_commission SET commission_year = 0 WHERE asset = 'wind'",
         )
-        error_messages = TEM.TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+        error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
         @test error_messages == [
-            "Missing commission_year = 2030 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2030, commission_year = 2030). The commission_year should match the one in 'asset_both'",
+            "Missing commission_year = 2030 for asset 'wind' in 'asset_commission' given (asset 'wind', milestone_year = 2030, commission_year = 2030) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
+            "Unexpected commission_year = 0 for asset 'wind' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
         ]
     end
 end


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

There are two fixes:
- the JOIN in `t_objective_assets` has been changed: this means you would not need all milestone years in `asset_commission`, so it fixes #1309
- a validation has also been added to make sure the commission years between `asset_commission` and `asset_both` are consistent. That means if you have more commission_years in `asset_commission`, the validation will flag because this is not needed and is prone to errors. 

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1309 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
