### PR TITLE
Fix data validation of oneOf constraints and fix MIMO use_binary_storage_method column

### DIFF
--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -163,7 +163,8 @@ function _validate_schema_one_of_constraints!(connection)
     for (table_name, table) in TulipaEnergyModel.schema, (col, attr) in table
         if haskey(attr, "constraints") && haskey(attr["constraints"], "oneOf")
             valid_types = attr["constraints"]["oneOf"]
-            valid_types_string = join([TulipaIO.FmtSQL.fmt_quote(s) for s in valid_types], ", ")
+            valid_types_string =
+                join([TulipaIO.FmtSQL.fmt_quote(s) for s in valid_types if !isnothing(s)], ", ")
 
             query_str = "SELECT $col FROM $table_name WHERE $col NOT IN ($valid_types_string)"
             # The query above alone does not catch NULL. So if NULLs are not in the list, improve the query

--- a/test/inputs/MIMO/asset.csv
+++ b/test/inputs/MIMO/asset.csv
@@ -1,9 +1,9 @@
 asset,capacity,capacity_storage_energy,consumer_balance_sense,discount_rate,economic_lifetime,energy_to_power_ratio,group,investment_integer,investment_integer_storage_energy,investment_method,is_seasonal,max_ramp_down,max_ramp_up,min_operating_point,ramping,storage_method_energy,technical_lifetime,type,unit_commitment,unit_commitment_integer,unit_commitment_method,use_binary_storage_method
-power_plant,400,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,conversion,false,false,,false
-chp_backpressure,35,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,conversion,false,false,,false
-chp_extraction,35,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,conversion,false,false,,false
-gas_market,1000,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,producer,false,false,,false
-biomass,400,2400,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,storage,false,false,,false
-electricity_demand,0,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,consumer,false,false,,false
-heat_demand,0,,>=,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,consumer,false,false,,false
-atmosphere,0,,>=,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,consumer,false,false,,false
+power_plant,400,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,conversion,false,false,,
+chp_backpressure,35,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,conversion,false,false,,
+chp_extraction,35,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,conversion,false,false,,
+gas_market,1000,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,producer,false,false,,
+biomass,400,2400,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,storage,false,false,,
+electricity_demand,0,,==,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,consumer,false,false,,
+heat_demand,0,,>=,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,consumer,false,false,,
+atmosphere,0,,>=,0.0,1,0.0,,false,false,none,false,0.0,0.0,0.0,false,false,1,consumer,false,false,,

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -84,6 +84,20 @@ end
           ["Table 'asset' has bad value for column 'consumer_balance_sense': '<>'"]
 end
 
+@testitem "Test schema oneOf constraints - bad unit commitment method" setup = [CommonSetup] tags =
+    [:unit, :data_validation, :fast] begin
+    connection = _tiny_fixture()
+    # Change the table to force an error
+    DuckDB.query(
+        connection,
+        "UPDATE asset SET unit_commitment_method = 'bad' WHERE asset = 'demand'",
+    )
+    @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
+    error_messages = TEM._validate_schema_one_of_constraints!(connection)
+    @test error_messages ==
+          ["Table 'asset' has bad value for column 'unit_commitment_method': 'bad'"]
+end
+
 @testitem "Test schema oneOf constraints - bad specification" setup = [CommonSetup] tags =
     [:unit, :data_validation, :fast] begin
     connection = DBInterface.connect(DuckDB.DB)


### PR DESCRIPTION
Fix data validation of oneOf constraints by excluding NULL from valid types, as it is already checked in the correcy way.
Add a test using unit_commitment_method.
Fix MIMO data for use_binary_storage_method to be one of the valid oneOf values.


<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->

Closes #1321

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
