### PR TITLE
Add compact start-up and shut-down constraints

### DIFF
--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -37,6 +37,7 @@ In addition, the following asset sets represent methods for incorporating additi
 | $\mathcal{A}^{\text{uc}}_y$               | Energy assets with unit commitment method at year $y$         |          | $\mathcal{A}^{\text{uc}}_y  \subseteq \mathcal{A}^{\text{cv}} \cup \mathcal{A}^{\text{p}}$       | This set contains conversion and production assets that have a unit commitment method. Please visit the [how-to section](@ref unit-commitment-setup) to learn how to set up this feature.                                                                       |
 | $\mathcal{A}^{\text{uc basic}}_y$         | Energy assets with a basic unit commitment method at year $y$ |          | $\mathcal{A}^{\text{uc basic}}_y \subseteq \mathcal{A}^{\text{uc}}_y$                            | This set contains the assets that have a basic unit commitment method that uses only the units on variable. Please visit the [how-to section](@ref unit-commitment-setup) to learn how to set up this feature.                                                                                       |
 | $\mathcal{A}^{\text{uc 3var}}_y$          | Energy assets with a 3var unit commitment method at year $y$  |          | $\mathcal{A}^{\text{uc 3var}}_y \subseteq \mathcal{A}^{\text{uc}}_y$                             | This set contains the assets that have a unit commitment method using three variables: units on, start-up, and shut-down. Please visit the [how-to section](@ref unit-commitment-setup) to learn how to set up this feature.                                                                                       |
+| $\mathcal{A}^{\text{su-sd compact}}_y$    | Energy assets with compact start-up and shut-down constraints at year $y$  |     | $\mathcal{A}^{\text{su-sd compact}}_y \subseteq \mathcal{A}^{\text{uc}}_y$               | This set contains the assets that have a unit commitment method using three variables: units on, start-up, and shut-down, along with a compact set of logical constraints. Please visit the [how-to section](@ref unit-commitment-setup) to learn how to set up this feature. |
 | $\mathcal{A}^{\text{ramp}}_y$             | Energy assets with ramping method at year $y$                 |          | $\mathcal{A}^{\text{ramp}}_y  \subseteq \mathcal{A}^{\text{cv}} \cup \mathcal{A}^{\text{p}}$     | This set contains conversion and production assets that have a ramping method. Please visit the [how-to section](@ref ramping-setup) to learn how to set up this feature.                                                                                       |
 | $\mathcal{A}^{\text{dc-opf}}_y$           | Energy assets with a DC power flow method at year $y$         |          | $\mathcal{A}^{\text{dc-opf}}_y \subseteq \mathcal{A}$                                            | This set contains the assets that have that use the dc-opf method.                                                                                                                                                                                              |
 
@@ -558,6 +559,17 @@ v^{\text{on}}_{a, k_y, b_{k_y}} - v^{\text{on}}_{a, k_y, (b_{k_y} - 1)} = v^{\te
 \\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
 \\ v^{\text{shut down}}_{a, k_y, b_{k_y}} \leq v^{\text{available units}}_{a,y} - v^{\text{on}}_{a, k_y, b_{k_y}} \quad
 \\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
+```
+
+#### Compact logical constraints for start-up and shut-down variables
+
+This set of logical constraints defines the behaviour of the start-up and shut-down variables, and is more compact than the tight logical constraints defined above. The constraints are tight in the direction of the objective function.
+
+```math
+v^{\text{start up}}_{a, k_y, b_{k_y}} \geq v^{\text{on}}_{a, k_y, b_{k_y}} - v^{\text{on}}_{a, k_y, (b_{k_y} - 1)} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{su-sd compact}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}^{\text{su}}_{k_y}
+\\ v^{\text{shut down}}_{a, k_y, b_{k_y}} \geq v^{\text{on}}_{a, k_y, (b_{k_y} - 1)} - v^{\text{on}}_{a, k_y, b_{k_y}} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{su-sd compact}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}^{\text{sd}}_{k_y}
 ```
 
 ### [Ramping Constraints](@id ramp-constraints)

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -41,6 +41,8 @@ function compute_constraints_indices(connection)
             :shut_down_upper_bound_simple_investment,
             :shut_down_upper_bound_compact_investment,
             :unit_commitment_logic,
+            :start_up_lower_bound,
+            :shut_down_lower_bound,
         )
     )
 

--- a/src/constraints/unit-commitment-shut-down-lower-bound.jl
+++ b/src/constraints/unit-commitment-shut-down-lower-bound.jl
@@ -1,0 +1,41 @@
+export add_shut_down_lower_bound_constraints!
+
+"""
+    add_shut_down_lower_bound_constraints!(connection, model, variables, expressions, constraints)
+
+Adds the compact shut down constraints to the model.
+"""
+function add_shut_down_lower_bound_constraints!(
+    connection,
+    model,
+    variables,
+    expressions,
+    constraints,
+)
+    let table_name = :shut_down_lower_bound, cons = constraints[table_name]
+        units_on = variables[:units_on].container
+        shut_down = variables[:shut_down].container
+
+        indices = _append_variable_ids(connection, table_name, ["units_on", "shut_down"])
+
+        attach_constraint!(
+            model,
+            cons,
+            table_name,
+            [
+                begin
+                    if row.time_block_start == 1
+                        @constraint(model, 0 == 0)
+                    else
+                        @constraint(
+                            model,
+                            units_on[row.units_on_id-1] - units_on[row.units_on_id] <=
+                            shut_down[row.shut_down_id],
+                            base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+                        )
+                    end
+                end for row in indices
+            ],
+        )
+    end
+end

--- a/src/constraints/unit-commitment-start-up-lower-bound.jl
+++ b/src/constraints/unit-commitment-start-up-lower-bound.jl
@@ -1,0 +1,41 @@
+export add_start_up_lower_bound_constraints!
+
+"""
+    add_start_up_lower_bound_constraints!(connection, model, variables, expressions, constraints)
+
+Adds the compact start up constraints to the model.
+"""
+function add_start_up_lower_bound_constraints!(
+    connection,
+    model,
+    variables,
+    expressions,
+    constraints,
+)
+    let table_name = :start_up_lower_bound, cons = constraints[table_name]
+        units_on = variables[:units_on].container
+        start_up = variables[:start_up].container
+
+        indices = _append_variable_ids(connection, table_name, ["units_on", "start_up"])
+
+        attach_constraint!(
+            model,
+            cons,
+            table_name,
+            [
+                begin
+                    if row.time_block_start == 1
+                        @constraint(model, 0 == 0)
+                    else
+                        @constraint(
+                            model,
+                            units_on[row.units_on_id] - units_on[row.units_on_id-1] <=
+                            start_up[row.start_up_id],
+                            base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+                        )
+                    end
+                end for row in indices
+            ],
+        )
+    end
+end

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -239,6 +239,22 @@ function create_model(
         constraints,
     )
 
+    @timeit to "add_start_up_lower_bound_constraints!" add_start_up_lower_bound_constraints!(
+        connection,
+        model,
+        variables,
+        expressions,
+        constraints,
+    )
+
+    @timeit to "add_shut_down_lower_bound_constraints!" add_shut_down_lower_bound_constraints!(
+        connection,
+        model,
+        variables,
+        expressions,
+        constraints,
+    )
+
     if model_file_name != ""
         @timeit to "save model file" JuMP.write_to_file(model, model_file_name)
     end

--- a/src/input-schemas.json
+++ b/src/input-schemas.json
@@ -169,7 +169,8 @@
         "oneOf": [
           null,
           "basic",
-          "3var"
+          "3var",
+          "SU-SD-compact"
         ]
       },
       "default": null,

--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -947,3 +947,99 @@ from (
 
 drop sequence id
 ;
+
+create sequence id start 1
+;
+
+drop table if exists cons_start_up_lower_bound
+;
+
+create table cons_start_up_lower_bound as
+with sorted as (
+    select distinct
+        t_high.asset,
+        t_high.year,
+        t_high.rep_period,
+        t_high.time_block_start,
+        t_high.time_block_end,
+    from
+        asset_time_resolution_rep_period as atr
+        join t_highest_assets_and_out_flows as t_high
+            on atr.asset = t_high.asset
+            and atr.time_block_start = t_high.time_block_start and
+            atr.rep_period = t_high.rep_period and
+            atr.year = t_high.year
+        join asset
+            on asset.asset = t_high.asset
+    where
+        asset.type in ('producer', 'conversion')
+        and asset.unit_commitment = true
+        and asset.unit_commitment_method = 'SU-SD-compact'
+    order by
+        t_high.asset,
+        t_high.year,
+        t_high.rep_period,
+        t_high.time_block_start
+)
+select
+    nextval('id') as id,
+    sorted.*
+from
+    sorted
+order by
+    sorted.asset,
+    sorted.year,
+    sorted.rep_period,
+    sorted.time_block_start
+;
+
+drop sequence id
+;
+
+create sequence id start 1
+;
+
+drop table if exists cons_shut_down_lower_bound
+;
+
+create table cons_shut_down_lower_bound as
+with sorted as (
+    select distinct
+        t_high.asset,
+        t_high.year,
+        t_high.rep_period,
+        t_high.time_block_start,
+        t_high.time_block_end,
+    from
+        asset_time_resolution_rep_period as atr
+        join t_highest_assets_and_out_flows as t_high
+            on atr.asset = t_high.asset
+            and atr.time_block_start = t_high.time_block_start and
+            atr.rep_period = t_high.rep_period and
+            atr.year = t_high.year
+        join asset
+            on asset.asset = t_high.asset
+    where
+        asset.type in ('producer', 'conversion')
+        and asset.unit_commitment = true
+        and asset.unit_commitment_method = 'SU-SD-compact'
+    order by
+        t_high.asset,
+        t_high.year,
+        t_high.rep_period,
+        t_high.time_block_start
+)
+select
+    nextval('id') as id,
+    sorted.*
+from
+    sorted
+order by
+    sorted.asset,
+    sorted.year,
+    sorted.rep_period,
+    sorted.time_block_start
+;
+
+drop sequence id
+;

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -126,7 +126,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var%'
+        and (asset.unit_commitment_method LIKE '3var-%' or asset.unit_commitment_method = 'SU-SD-compact')
     order by
         atr.asset,
         atr.year,
@@ -168,7 +168,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var%'
+        and (asset.unit_commitment_method LIKE '3var-%' or asset.unit_commitment_method = 'SU-SD-compact')
     order by
         atr.asset,
         atr.year,

--- a/test/test-constraints-SUSD-compact.jl
+++ b/test/test-constraints-SUSD-compact.jl
@@ -1,0 +1,167 @@
+using JuMP
+
+@testitem "Test compact SUSD constraints" setup = [CommonSetup] tags = [:unit, :validation, :fast] begin
+    # Setup a temporary DuckDB connection and model
+    connection = DBInterface.connect(DuckDB.DB)
+    model = JuMP.Model()
+
+    table_name = "asset"
+    table_rows = [
+        ("input_1", "simple", true, "SU-SD-compact", "conversion", 15),
+        ("input_2", "compact", true, "SU-SD-compact", "conversion", 15),
+        ("death_star", "simple", true, "SU-SD-compact", "conversion", 15),
+    ]
+    columns = [
+        :asset,
+        :investment_method,
+        :unit_commitment,
+        :unit_commitment_method,
+        :type,
+        :technical_lifetime,
+    ]
+    _create_table_for_tests(connection, table_name, table_rows, columns)
+
+    table_name = "var_units_on"
+    table_rows = [
+        (1, "input_1", 2050, 1, 1, 3, true),
+        (2, "input_1", 2050, 1, 4, 7, true),
+        (3, "input_2", 2050, 1, 1, 3, true),
+        (4, "input_2", 2050, 1, 4, 7, true),
+        (5, "death_star", 2050, 1, 1, 3, true),
+        (6, "death_star", 2050, 1, 4, 7, true),
+    ]
+    columns = [
+        :id,
+        :asset,
+        :year,
+        :rep_period,
+        :time_block_start,
+        :time_block_end,
+        :unit_commitment_integer,
+    ]
+    _create_table_for_tests(connection, table_name, table_rows, columns)
+
+    table_name = "var_start_up"
+    table_rows = [
+        (1, "input_1", 2050, 1, 1, 2, true),
+        (2, "input_1", 2050, 1, 4, 4, true),
+        (3, "input_2", 2050, 1, 1, 2, true),
+        (4, "input_2", 2050, 1, 4, 4, true),
+        (5, "death_star", 2050, 1, 1, 2, true),
+        (6, "death_star", 2050, 1, 4, 4, true),
+    ]
+    columns = [
+        :id,
+        :asset,
+        :year,
+        :rep_period,
+        :time_block_start,
+        :time_block_end,
+        :unit_commitment_integer,
+    ]
+    _create_table_for_tests(connection, table_name, table_rows, columns)
+
+    table_name = "var_shut_down"
+    table_rows = [
+        (1, "input_1", 2050, 1, 1, 2, true),
+        (2, "input_1", 2050, 1, 4, 4, true),
+        (3, "input_2", 2050, 1, 1, 2, true),
+        (4, "input_2", 2050, 1, 4, 4, true),
+        (5, "death_star", 2050, 1, 1, 2, true),
+        (6, "death_star", 2050, 1, 4, 4, true),
+    ]
+    columns = [
+        :id,
+        :asset,
+        :year,
+        :rep_period,
+        :time_block_start,
+        :time_block_end,
+        :unit_commitment_integer,
+    ]
+    _create_table_for_tests(connection, table_name, table_rows, columns)
+
+    variables = Dict{Symbol,TulipaEnergyModel.TulipaVariable}(
+        key => TulipaEnergyModel.TulipaVariable(connection, "var_$key") for
+        key in (:units_on, :start_up, :shut_down)
+    )
+    TulipaEnergyModel.add_unit_commitment_variables!(model, variables)
+    TulipaEnergyModel.add_start_up_and_shut_down_variables!(model, variables)
+
+    table_name = "cons_start_up_lower_bound"
+    table_rows = [
+        (1, "input_1", 2050, 1, 1, 2),
+        (2, "input_1", 2050, 1, 4, 4),
+        (3, "input_2", 2050, 1, 1, 2),
+        (4, "input_2", 2050, 1, 4, 4),
+        (5, "death_star", 2050, 1, 1, 2),
+        (6, "death_star", 2050, 1, 4, 4),
+    ]
+    columns = [:id, :asset, :year, :rep_period, :time_block_start, :time_block_end]
+    _create_table_for_tests(connection, table_name, table_rows, columns)
+
+    table_name = "cons_shut_down_lower_bound"
+    table_rows = [
+        (1, "input_1", 2050, 1, 1, 2),
+        (2, "input_1", 2050, 1, 4, 4),
+        (3, "input_2", 2050, 1, 1, 2),
+        (4, "input_2", 2050, 1, 4, 4),
+        (5, "death_star", 2050, 1, 1, 2),
+        (6, "death_star", 2050, 1, 4, 4),
+    ]
+    columns = [:id, :asset, :year, :rep_period, :time_block_start, :time_block_end]
+    _create_table_for_tests(connection, table_name, table_rows, columns)
+
+    constraints = Dict{Symbol,TulipaEnergyModel.TulipaConstraint}(
+        key => TulipaEnergyModel.TulipaConstraint(connection, "cons_$key") for
+        key in (:start_up_lower_bound, :shut_down_lower_bound)
+    )
+
+    expressions = Dict{Symbol,TulipaEnergyModel.TulipaExpression}()
+
+    TulipaEnergyModel.add_start_up_lower_bound_constraints!(
+        connection,
+        model,
+        variables,
+        expressions,
+        constraints,
+    )
+
+    TulipaEnergyModel.add_shut_down_lower_bound_constraints!(
+        connection,
+        model,
+        variables,
+        expressions,
+        constraints,
+    )
+
+    JuMP.@variable(model, dummy)
+
+    var_units_on = variables[:units_on].container
+    var_start_up = variables[:start_up].container
+    var_shut_down = variables[:shut_down].container
+
+    # test start-up lower bound constraint
+    expected_cons = [
+        JuMP.@build_constraint(0 * dummy == 0),
+        JuMP.@build_constraint(var_units_on[2] - var_units_on[1] <= var_start_up[2]),
+        JuMP.@build_constraint(0 * dummy == 0),
+        JuMP.@build_constraint(var_units_on[4] - var_units_on[3] <= var_start_up[4]),
+        JuMP.@build_constraint(0 * dummy == 0),
+        JuMP.@build_constraint(var_units_on[6] - var_units_on[5] <= var_start_up[6]),
+    ]
+    observed_cons = _get_cons_object(model, :start_up_lower_bound)
+    @test _is_constraint_equal(expected_cons, observed_cons)
+
+    # test shut-down lower bound constraint
+    expected_cons = [
+        JuMP.@build_constraint(0 * dummy == 0),
+        JuMP.@build_constraint(var_units_on[1] - var_units_on[2] <= var_shut_down[2]),
+        JuMP.@build_constraint(0 * dummy == 0),
+        JuMP.@build_constraint(var_units_on[3] - var_units_on[4] <= var_shut_down[4]),
+        JuMP.@build_constraint(0 * dummy == 0),
+        JuMP.@build_constraint(var_units_on[5] - var_units_on[6] <= var_shut_down[6]),
+    ]
+    observed_cons = _get_cons_object(model, :shut_down_lower_bound)
+    @test _is_constraint_equal(expected_cons, observed_cons)
+end


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
There is no related issue.

## Changes Introduced
The compact set of start-up and shut-down constraints has been added, along with their documentation and tests. Note that these constraints should not be used in combination with the previously added tight start-up and shut-down constraints, nor should they be used with future 3-var constraints such as minimum up/down times or start-up and shut-down ramping. Therefore, the `unit_commitment_method` for this constraint set is `SU-SD-compact`, and not of the form `3var*`. The formulation of these constraints can be found in equations (9a) and (9b) in the document shared by email.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
