### PR TITLE
Update lychee toml file

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -2,6 +2,8 @@ exclude = [
   "@ref",
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://code.visualstudio.com",
+  "https://resolver.tudelft.nl/uuid:0e87f306-1c92-4eec-805f-72377ed57fb2",
+  "https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593",
 ]
 
 exclude_path = [


### PR DESCRIPTION
Adding "https://resolver.tudelft.nl/uuid:0e87f306-1c92-4eec-805f-72377ed57fb2" and "https://blog.esciencecenter.nl/the-utopic-git-history-d44b81c09593" to the `exclude` list in `.lychee.toml` to skip them during link checking.

## Related issues

Closes #1341

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
