### PR TITLE
[Multi-year Part II] Validate consistency between `asset_both` and `flow_commission`

### DIFF
--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -575,24 +575,24 @@ function _validate_flow_commission_and_asset_both_consistency!(connection)
         )
     end
 
-    # for row in DuckDB.query(
-    #     connection,
-    #     "SELECT flow_commission.from_asset, asset_both.commission_year
-    #     FROM flow_commission
-    #     LEFT JOIN asset_both
-    #         ON flow_commission.from_asset = asset_both.asset
-    #         AND flow_commission.commission_year = asset_both.commission_year
-    #     LEFT JOIN asset
-    #         ON asset_both.asset = asset.asset
-    #     WHERE asset.investment_method = 'semi-compact'
-    #         AND flow_commission.commission_year IS NULL
-    #     ",
-    # )
-    #     push!(
-    #         error_messages,
-    #         "Unexpected commission_year = $(row.commission_year) for the outgoing flow of asset '$(row.asset)' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
-    #     )
-    # end
+    for row in DuckDB.query(
+        connection,
+        "SELECT flow_commission.from_asset, flow_commission.commission_year
+        FROM flow_commission
+        LEFT JOIN asset_both
+            ON flow_commission.from_asset = asset_both.asset
+            AND flow_commission.commission_year = asset_both.commission_year
+        LEFT JOIN asset
+            ON flow_commission.from_asset = asset.asset
+        WHERE asset.investment_method = 'semi-compact'
+            AND asset_both.commission_year IS NULL
+        ",
+    )
+        push!(
+            error_messages,
+            "Unexpected commission_year = $(row.commission_year) for the outgoing flow of asset '$(row.from_asset)' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
+        )
+    end
 
     return error_messages
 end

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -647,6 +647,7 @@ end
     error_messages = TEM._validate_flow_commission_and_asset_both_consistency!(connection)
     @test error_messages == [
         "Missing commission_year = 2030 for the outgoing flow of asset 'wind' in 'flow_commission' given (asset 'wind', milestone_year = 2030, commission_year = 2030) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
+        "Unexpected commission_year = 0 for the outgoing flow of asset 'wind' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
     ]
 end
 

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -630,7 +630,7 @@ end
     error_messages = TEM._validate_flow_commission_and_asset_both_consistency!(connection)
     @test error_messages == [
         "Missing commission_year = 0 for the outgoing flow of asset 'A' in 'flow_commission' given (asset 'A', milestone_year = 1, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
-        # "Unexpected commission_year = -1 for the outgoing flow of asset 'B' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
+        "Unexpected commission_year = -1 for the outgoing flow of asset 'B' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
     ]
 end
 


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

This validation ensures when you use `semi-compact` method, the data is available in the `flow_commission` that corresponds to `asset_both`. This is needed to generate capacity constraints.

This validation is similar to #1313 which checks consistency between `asset_both` and `asset_commission` because the model needs to have the fixed costs from the corresponding `commission_year`.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1345 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
