### PR TITLE
Modify exporting to CSV to use only connection

### DIFF
--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -36,12 +36,7 @@ end
         TulipaEnergyModel.solve_model(model)
         TulipaEnergyModel.save_solution!(connection, model, variables, constraints)
         output_dir = mktempdir()
-        TulipaEnergyModel.export_solution_to_csv_files(
-            output_dir,
-            connection,
-            variables,
-            constraints,
-        )
+        TulipaEnergyModel.export_solution_to_csv_files(output_dir, connection)
         return true
     end
 end


### PR DESCRIPTION
This is more general because it avoids the specific variables and constraints objects and uses the connection instead. It's necessary for rolling horizon, for instance.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1368

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
