### PR TITLE
Modify storage constraint to compute inflows using _profile_aggregate

### DIFF
--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -156,6 +156,14 @@ function add_storage_constraints!(connection, model, variables, expressions, con
                     storage_charging_efficiency = row.storage_charging_efficiency::Float64
                     storage_discharging_efficiency = row.storage_discharging_efficiency::Float64
 
+                    inflows_agg = _profile_aggregate(
+                        profiles.over_clustered_year,
+                        (row.inflows_profile_name, row.year),
+                        row.period_block_start:row.period_block_end,
+                        sum,
+                        0.0,
+                    )
+
                     if row.period_block_start == 1 && !ismissing(initial_storage_level)
                         # Initial storage is a Float64
                         @constraint(
@@ -199,12 +207,8 @@ function add_storage_constraints!(connection, model, variables, expressions, con
                             base_name = "$table_name[$(row.asset),$(row.year),$(row.period_block_start):$(row.period_block_end)]"
                         )
                     end
-                end for (row, incoming_flow, outgoing_flow, inflows_agg) in zip(
-                    indices,
-                    cons.expressions[:incoming],
-                    cons.expressions[:outgoing],
-                    cons.coefficients[:inflows_profile_aggregation],
-                )
+                end for (row, incoming_flow, outgoing_flow) in
+                zip(indices, cons.expressions[:incoming], cons.expressions[:outgoing])
             ],
         )
 


### PR DESCRIPTION
This ensures that all profile aggregation is done through that function, which is a requirement for rolling horizon.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1370

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
