### PR TITLE
Change rep_period profiles to handle rolling horizon

### DIFF
--- a/src/TulipaEnergyModel.jl
+++ b/src/TulipaEnergyModel.jl
@@ -25,10 +25,10 @@ using TimerOutputs: TimerOutput, @timeit
 const to = TimerOutput()
 
 # Definitions and auxiliary files
-include("utils.jl")
 include("run-scenario.jl")
 include("model-parameters.jl")
 include("structures.jl")
+include("utils.jl")
 
 # Data
 include("input-schemas.jl")

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -618,19 +618,22 @@ function add_expressions_to_constraints!(connection, variables, constraints)
 end
 
 function prepare_profiles_structure(connection)
+    # Independent of being rolling horizon or not, these are complete
     rep_period = Dict(
-        (row.profile_name, row.year, row.rep_period) => [
-            row.value for row in DuckDB.query(
-                connection,
-                "SELECT profile.value
-                FROM profiles_rep_periods AS profile
-                WHERE
-                    profile.profile_name = '$(row.profile_name)'
-                    AND profile.year = $(row.year)
-                    AND profile.rep_period = $(row.rep_period)
-                ",
-            )
-        ] for row in DuckDB.query(
+        (row.profile_name, row.year, row.rep_period) => ProfileWithRollingHorizon(
+            Float64[
+                row.value for row in DuckDB.query(
+                    connection,
+                    "SELECT profile.value
+                    FROM profiles_rep_periods AS profile
+                    WHERE
+                        profile.profile_name = '$(row.profile_name)'
+                        AND profile.year = $(row.year)
+                        AND profile.rep_period = $(row.rep_period)
+                    ",
+                )
+            ],
+        ) for row in DuckDB.query(
             connection,
             "SELECT DISTINCT
                 profiles.profile_name,
@@ -642,7 +645,7 @@ function prepare_profiles_structure(connection)
     )
 
     over_clustered_year = Dict(
-        (row.profile_name, row.year) => [
+        (row.profile_name, row.year) => Float64[
             row.value for row in DuckDB.query(
                 connection,
                 "SELECT profile.value

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -209,14 +209,21 @@ function attach_coefficient!(cons::TulipaConstraint, name::Symbol, container)
     return nothing
 end
 
+mutable struct ProfileWithRollingHorizon
+    values::Vector{Float64}
+    rolling_horizon_variables::Vector{JuMP.VariableRef}
+
+    ProfileWithRollingHorizon(values::Vector{Float64}) = new(values, JuMP.VariableRef[])
+end
+
 """
 Structure to hold the dictionaries of profiles.
 """
 mutable struct ProfileLookup
     # The integers here are Int32 because they are obtained directly from DuckDB
-    #
+
     # rep_period[(asset, year, rep_period)]
-    rep_period::Dict{Tuple{String,Int32,Int32},Vector{Float64}}
+    rep_period::Dict{Tuple{String,Int32,Int32},ProfileWithRollingHorizon}
 
     # over_clustered_year[(asset, year)]
     over_clustered_year::Dict{Tuple{String,Int32},Vector{Float64}}


### PR DESCRIPTION
- Implement ProfileWithRollingHorizon and make profiles.rep_period use that instead of Vector{Float64}.
- Change _profile_aggregate to dispatch on Vector{Float64} and ProfileWithRollingHorizon.
- These should allow the rolling horizon variables to be aggregated the same way as the normal profiles.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Part of #1365
Closes #1374

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
