### PR TITLE
Mark remaining t_% tables as TEMP and remove t_grouped_% tables on model creation

### DIFF
--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -82,6 +82,14 @@ function create_model(
 
     JuMP.set_string_names_on_creation(model, enable_names)
 
+    # Cleanup temporary t_grouped_% tables so they don't conflict with future ones
+    # t_grouped_% are special because they are created inside the `add_expression_terms_rep_period_constraints`
+    # and reused if they exist. It's easier to delete them if they exist,
+    # instead of keeping track of their existence in a possible exception state.
+    for row in DuckDB.query(connection, "FROM duckdb_tables() WHERE table_name LIKE 't_grouped_%'")
+        DuckDB.query(connection, "DROP TABLE $(row.table_name)")
+    end
+
     ## Variables
     @timeit to "add_flow_variables!" add_flow_variables!(connection, model, variables)
     @timeit to "add_vintage_flow_variables!" add_vintage_flow_variables!(

--- a/src/data-preparation.jl
+++ b/src/data-preparation.jl
@@ -248,7 +248,7 @@ blocks, and are replaced by columns `time_block_start` and `time_block_end`.
 function create_unrolled_partition_tables!(connection)
     DBInterface.execute(
         connection,
-        "CREATE OR REPLACE TABLE t_explicit_assets_rep_periods_partitions AS
+        "CREATE OR REPLACE TEMP TABLE t_explicit_assets_rep_periods_partitions AS
         SELECT
             asset.asset,
             rep_periods_data.year,
@@ -268,7 +268,7 @@ function create_unrolled_partition_tables!(connection)
 
     DBInterface.execute(
         connection,
-        "CREATE OR REPLACE TABLE t_explicit_flows_rep_periods_partitions AS
+        "CREATE OR REPLACE TEMP TABLE t_explicit_flows_rep_periods_partitions AS
         SELECT
             flow.from_asset,
             flow.to_asset,
@@ -347,7 +347,7 @@ function create_unrolled_partition_tables!(connection)
 
     DBInterface.execute(
         connection,
-        "CREATE OR REPLACE TABLE t_explicit_assets_timeframe_partitions AS
+        "CREATE OR REPLACE TEMP TABLE t_explicit_assets_timeframe_partitions AS
         WITH t_relevant_assets AS (
             SELECT DISTINCT
                 asset.asset,
@@ -485,7 +485,7 @@ function create_lowest_resolution_table!(connection)
         table_name = replace(merged_table, "merged" => "t_lowest")
         DuckDB.execute(
             connection,
-            "CREATE OR REPLACE TABLE $table_name(
+            "CREATE OR REPLACE TEMP TABLE $table_name(
                 asset STRING,
                 year INT,
                 rep_period INT,
@@ -559,7 +559,7 @@ function create_highest_resolution_table!(connection)
         table_name = replace(merged_table, "merged" => "t_highest")
         DuckDB.execute(
             connection,
-            "CREATE OR REPLACE TABLE $table_name AS
+            "CREATE OR REPLACE TEMP TABLE $table_name AS
             SELECT
                 merged.asset,
                 merged.year,


### PR DESCRIPTION
Some t_% tables were not marked as TEMP yet. This fixes it.
The t_grouped_% tables are reused in the model creation. However, if the model is created with a connection that already has t_grouped_% tables, they were not
being removed. This commit removes existing t_grouped_% tables before
creating them again. This became evident when dealing with rolling horizon,
since the tables were being reused between windows.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Part of #1365
Closes #1376

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
