### PR TITLE
Compute and save dual variables during rolling horizon

### DIFF
--- a/test/io-outputs/energy-problem-model-solved.txt
+++ b/test/io-outputs/energy-problem-model-solved.txt
@@ -5,4 +5,4 @@ EnergyProblem:
     - Number of structural constraints: 432
   - Model solved!
     - Termination status: OPTIMAL
-    - Objective value: 269238.4382415647
+    - Objective value: 269238.4382415648


### PR DESCRIPTION
Add an argument compute_duals to run_rolling_horizon that is passed to
save_solution.
Save the cons_% tables as full_cons_% during rolling horizon.
If the duals are computed, create a column dual_% in the full_cons_%
table and copy the internal dual_% value from the cons_% table in the
window to the corresponding full_cons_% table.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1395
<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
