### PR TITLE
More robust test of printed EnergyProblem

### DIFF
--- a/test/test-io.jl
+++ b/test/test-io.jl
@@ -60,6 +60,12 @@ end
     io = IOBuffer()
     TulipaEnergyModel.solve_model!(energy_problem)
     print(io, energy_problem)
-    @test split(String(take!(io))) ==
-          split(read("io-outputs/energy-problem-model-solved.txt", String))
+    expected_output = split(read("io-outputs/energy-problem-model-solved.txt", String))
+    actual_output = split(String(take!(io)))
+    # To make the comparison more robust, the only look at the the first
+    # 9 significant digits of the solution (+ '.')
+    expected_output[end] = expected_output[end][1:10]
+    actual_output[end] = actual_output[end][1:10]
+
+    @test expected_output == actual_output
 end


### PR DESCRIPTION
The objective value at the solution can change slightly because of our dependencies,
so we compare only the first 9 significant digits. Since this is done in the text
level, it looks odd, but it is similar to the case studies.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1408

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
