### PR TITLE
[Fix]: Disable rule MD060 for md files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -9,5 +9,6 @@
   },
   "MD033": false,
   "MD041": false,
+  "MD060": false,
   "default": true
 }


### PR DESCRIPTION
With the pre-commit update there is a MD060 in the markdown files. The error occurs when Markdown tables don't follow consistent column alignment styles.

The MD060 rule is detection-only - markdownlint can identify misaligned table columns but cannot auto-fix them. So, it can't change them to follow the rule.

To fully follow the rule markdown tables must to be, either:

"aligned": Pipes align with the header separator
"compact": No extra spaces around pipes

Transform tables from this (misaligned):

```text
| Header 1 | Header 2 | Header 3|
|----------|----------|---------|
| Value 1|Value 2  | Value 3 |
```

To this (aligned):

```text
| Header 1 | Header 2 | Header 3 |
|----------|----------|----------|
| Value 1  | Value 2  | Value 3  |
```

Or this (compact):

```text
|Header 1|Header 2|Header 3|
|--------|--------|--------|
|Value 1|Value 2|Value 3|
```

So, disable the rule for now, but I have created an issue #1435 for the long-term solution.

## Related issues

There is no related issue.

## Checklist

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
