### PR TITLE
[Small-doc-update] Update documentation on pre-commit

### DIFF
--- a/docs/src/90-contributing/91-developer.md
+++ b/docs/src/90-contributing/91-developer.md
@@ -39,7 +39,7 @@ To contribute to TulipaEnergyModel.jl, you need the following:
    You can install `pre-commit` globally using
 
    ```bash
-   pip install --user pre-commit
+   pip install pre-commit
    ```
 
    If you prefer to create a local environment with it, do the following:
@@ -55,13 +55,6 @@ To contribute to TulipaEnergyModel.jl, you need the following:
    . env/bin/activate
 
    pip install --upgrade pip setuptools pre-commit
-   ```
-
-   For every subsequent use, you don't have to install, just activate the environment:
-
-   ```bash
-   source env/Scripts/activate # in bash
-   env/Scripts/Activate.ps1 # in powershell
    ```
 
 1. [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) for code


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

Our new MSc student has tried our developer documentation, but had errors when doing the pre-commit part. Therefore, I made the following fixes:
- Pre-commit should be installed globally without the "--user" tag.
- The part regarding activating the environment only applies if a virtual environment has been created, not when it has not been created, so it is confusing. Furthermore, I think the information is also redundant, as the commands for activating the virtual environment are given already. 

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
There is no related issue.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
