### PR TITLE
Update CompareMPS to not comment on PR when run by dependabot

### DIFF
--- a/.github/workflows/CompareMPS.yml
+++ b/.github/workflows/CompareMPS.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find older comment (to avoid multiple comments)
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: peter-evans/find-comment@v4
         id: find-old-comment
         with:
@@ -30,7 +30,7 @@ jobs:
           comment-author: "github-actions[bot]"
           body-includes: CompareMPS report
       - name: Comment on PR with CompareMPS
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-old-comment.outputs.comment-id }}
@@ -80,7 +80,11 @@ jobs:
           <details>
 
           ```plaintext' > body.md
-          cat mps-logfile.txt >> body.md
+          if [ -f mps-logfile.txt]; then
+            cat mps-logfile.txt >> body.md
+          else
+            echo "mps-logfile.txt was not created" >> body.md
+          fi
           echo '```
 
           </details>
@@ -89,7 +93,7 @@ jobs:
           ' >> body.md
           echo "::warning title=MPS files are different::$(cat body.md)"
       - name: Find Comment
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
@@ -97,7 +101,7 @@ jobs:
           comment-author: "github-actions[bot]"
           body-includes: CompareMPS report
       - name: Comment on PR with log if failed
-        if: failure() && github.event.pull_request.head.repo.full_name == github.repository
+        if: failure() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -105,7 +109,7 @@ jobs:
           body-path: body.md
           edit-mode: replace
       - name: Comment on PR with CompareMPS
-        if: success() && github.event.pull_request.head.repo.full_name == github.repository
+        if: success() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
Dependabot doesn't have permissions to create pull request comments, so
we skip these steps in CompareMPS when the actor is dependabot.
Verify that mps-logfile.txt exists, just in case something else creates
the same kind of issue.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Related to the failure in #1466

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
