### PR TITLE
Fix mixed case of commodity_price profiles

### DIFF
--- a/test/test-objective-profiles.jl
+++ b/test/test-objective-profiles.jl
@@ -99,3 +99,88 @@
 
     @test expected == observed
 end
+
+@testitem "Commodity price part of flows_operational_cost when one flow has profiles and the other doesn't" tags =
+    [:unit, :objective] setup = [CommonSetup] begin
+    using DuckDB: DuckDB
+    using TulipaBuilder: TulipaBuilder as TB
+    using TulipaClustering: TulipaClustering as TC
+    using Statistics
+
+    commodity_price = [3.14, 1.23]
+    producer_efficiency = [0.95, 0.99]
+    operational_cost = [6.66, 9.11]
+    commodity_price_profile = collect(1.0:6.0)
+
+    function full_run()
+        tulipa = TB.TulipaData()
+        TB.add_asset!(tulipa, "Consumer", :consumer)
+        for i in 1:2
+            producer_name = "Producer$i"
+            TB.add_asset!(tulipa, producer_name, :producer)
+            TB.add_flow!(
+                tulipa,
+                producer_name,
+                "Consumer";
+                commodity_price = commodity_price[i],
+                producer_efficiency = producer_efficiency[i],
+                operational_cost = operational_cost[i],
+            )
+        end
+        # (Producer1,Consumer) doesn't have a commidity_price profile
+        TB.attach_profile!(
+            tulipa,
+            "Producer2",
+            "Consumer",
+            :commodity_price,
+            2030,
+            commodity_price_profile,
+        )
+        TB.set_partition!(tulipa, "Producer1", "Consumer", 2030, 1, "explicit", "1;2;3")
+        TB.set_partition!(tulipa, "Producer2", "Consumer", 2030, 1, "explicit", "3;1;2")
+
+        connection = TB.create_connection(tulipa)
+        TC.dummy_cluster!(connection)
+        TEM.populate_with_defaults!(connection)
+        energy_problem = TEM.EnergyProblem(connection)
+        TEM.create_model!(energy_problem)
+
+        var_flow = energy_problem.variables[:flow]
+        partitions = [
+            Dict(
+                row.id => row.time_block_start:row.time_block_end for
+                row in var_flow.indices if row.from_asset == "Producer$producer"
+            ) for producer in 1:2
+        ]
+        flow_lookup = [
+            Dict(
+                row.id => var_flow.container[row.id] for
+                row in var_flow.indices if row.from_asset == "Producer$producer"
+            ) for producer in 1:2
+        ]
+        observed = energy_problem.model[:flows_operational_cost]
+
+        return energy_problem, var_flow, partitions, flow_lookup, observed
+    end
+
+    energy_problem, var_flow, partitions, flow_lookup, observed = full_run()
+
+    expected1 = sum(
+        flow_lookup[1][i] *
+        length(partitions[1][i]) *
+        (commodity_price[1] / producer_efficiency[1] + operational_cost[1]) for
+        i in keys(partitions[1])
+    )
+    commodity_price_agg = Dict(
+        i => commodity_price[2] * Statistics.mean(commodity_price_profile[p]) for
+        (i, p) in partitions[2]
+    )
+    expected2 = sum(
+        flow_lookup[2][i] *
+        length(partitions[2][i]) *
+        (commodity_price_agg[i] / producer_efficiency[2] + operational_cost[2]) for
+        i in keys(partitions[2])
+    )
+
+    @test expected1 + expected2 == observed
+end


### PR DESCRIPTION
Allow commodity_price profiles to be set for one flow and unset for another.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Fixes #1489

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
