### PR TITLE
Prevent dependabot from trying to comment on PR

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -65,7 +65,7 @@ jobs:
           comment-author: "github-actions[bot]"
           body-includes: Check the documentation preview
       - name: Comment on PR
-        if: github.event.pull_request.head.repo.full_name == github.repository && steps.docpreview.outputs.comment-id == 0
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && steps.docpreview.outputs.comment-id == 0
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.docpreview.outputs.comment-id }}


### PR DESCRIPTION
Also, dependabot shouldn't try to comment on PR.

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Related to #1509 and #1504

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
