### PR TITLE
Fix issue #1531: Update the working example of checking infeasibility through JuMP IIS functionality. 

### DIFF
--- a/docs/src/20-user-guide/20-how-to-use.md
+++ b/docs/src/20-user-guide/20-how-to-use.md
@@ -127,10 +127,13 @@ If your model is infeasible, you can try exploring the infeasibility with [JuMP.
 Use `energy_problem.model` for the model argument. For instance:
 
 ```julia
-if energy_problem.termination_status == INFEASIBLE
-  compute_conflict!(energy_problem.model)
-  iis_model, reference_map = copy_conflict(energy_problem.model)
-  print(iis_model)
+import MathOptInterface as MOI
+using JuMP
+
+if JuMP.termination_status(energy_problem.model) == MOI.INFEASIBLE
+    JuMP.compute_conflict!(energy_problem.model)
+    iis_model, reference_map = JuMP.copy_conflict(energy_problem.model)
+    print(iis_model)
 end
 ```
 


### PR DESCRIPTION
The old description in the documentation for exploring infeasibility resulted in error if the user had not explicitly called JuMP before. The new working example makes use of explicitly importing MathOptInterface and using JuMP to prevent any error. As long as there is an energy problem, the code should work. 

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1531 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
