### PR TITLE
Add Julia MCP testing instructions to AGENTS.md and developer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,8 @@ Branch naming: `feature/description` or `fix/description`
 
 **CRITICAL:** Use the testing filters to avoid running too many tests at once.
 
-**Run all tests:** `julia --project=test test/runtests.jl`
+**Run tests (MCP preferred):** Use `julia_eval` with `env_path = "test/"` and `@run_package_tests` — see [Julia MCP](#julia-mcp-preferred) below.
+**Run all tests (CLI):** `julia --project=test test/runtests.jl`
 **Run specific file:** `julia --project=test test/runtests.jl --file test-model`
 **Run fast tests only:** `julia --project=test test/runtests.jl --tags fast --exclude slow`
 **List available tags:** `julia --project=test test/runtests.jl --list-tags`
@@ -179,7 +180,26 @@ Branch naming: `feature/description` or `fix/description`
 Uses [TestItemRunner.jl](https://github.com/julia-vscode/TestItemRunner.jl) with `@testitem`, `@testsnippet`, `@testmodule` — **not** standard `@testset`.
  Test inputs are in `test/inputs/`.
 
-Never run the full test suite unless you are explicitly asked to. Instead, run only the tests you created or modified; for example, for `test-model.jl` run `julia --project=test test/runtests.jl --file test-model`.
+Never run the full test suite unless you are explicitly asked to. Instead, run only the tests you created or modified.
+
+### Julia MCP (Preferred)
+
+**When `julia_eval` (Julia MCP) is available, use it instead of the CLI** — it maintains a warm session and avoids recompilation on every run.
+
+Use `env_path = "test/"` (has its own `Project.toml` with the package as a path source). Call `@run_package_tests` directly — `runtests.jl` reads `ARGS` and won't work in a REPL:
+
+```julia
+# Filter by file (most common)
+@run_package_tests verbose=true filter = ti -> contains(ti.filename, "test-model")
+
+# Filter by tags (AND logic)
+@run_package_tests verbose=true filter = ti -> all(tag in ti.tags for tag in [:unit, :fast])
+
+# Exclude slow tests
+@run_package_tests verbose=true filter = ti -> !any(tag in ti.tags for tag in [:slow])
+```
+
+`ti` fields: `.filename`, `.name`, `.tags` — same semantics as the CLI flags below.
 
 ### Shared Setup (in `test/utils.jl`)
 

--- a/docs/src/90-contributing/91-developer.md
+++ b/docs/src/90-contributing/91-developer.md
@@ -221,6 +221,12 @@ Example (Claude):
 1. Include: `ALWAYS READ AGENTS.md`.
 1. Keep the rule together with your other persistent coding instructions.
 
+### Julia MCP
+
+[Julia MCP](https://github.com/aplavin/julia-mcp) lets AI agents run Julia code in a persistent REPL session via the Model Context Protocol. This avoids recompilation on every test run, making iterative development significantly faster.
+
+**Install it** by following the instructions at [github.com/aplavin/julia-mcp](https://github.com/aplavin/julia-mcp) for your AI tool (Claude Code, Cursor, etc.). Once installed, agents can run tests using `@run_package_tests` with `env_path = "test/"` — see `AGENTS.md` for filter examples.
+
 ## Code format and guidelines
 
 This section will list the guidelines for code formatting **not enforced** by JuliaFormatter.


### PR DESCRIPTION
Documents using julia_eval (Julia MCP) as the preferred way to run
tests — warm session avoids recompilation overhead. Adds filter
examples using @run_package_tests with .filename, .tags, .name fields.
Points developers to <https://github.com/aplavin/julia-mcp> to install.

Co-authored-by: Claude Code (claude-opus-4-6) <noreply@anthropic.com>

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
