### PR TITLE
Data validation refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,15 @@ Prefer `@testsnippet` when tests mutate the data; prefer `@testmodule` when setu
 
 New tags must be added to `TAGS_DATA` in `test/runtests.jl`. Target: 100% test coverage.
 
+### Adding a Data Validator
+
+1. Write `_validate_<description>!(error_messages, connection)` in `src/data-validation.jl`.
+   Push error strings into `error_messages` directly; return `error_messages` at the end.
+2. Register it in the tuple in `validate_data!` with a log message and `fail_fast = false`
+   (use `true` only if later validators would crash without this one passing).
+3. Add tests in `test/test-data-validation.jl` tagged `[:unit, :data_validation, :fast]`.
+   Call the validator as `TEM._validate_foo!(String[], connection)` and assert on the result.
+
 ### MPS Regression Testing
 
 MPS files in `benchmark/model-mps-folder/` serve as regression tests for the optimization model. The `CompareMPS.yml` workflow runs automatically on PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ Never run the full test suite unless you are explicitly asked to. Instead, run o
 
 **When `julia_eval` (Julia MCP) is available, use it instead of the CLI** — it maintains a warm session and avoids recompilation on every run.
 
-Use `env_path = "test/"` (has its own `Project.toml` with the package as a path source). Always import `TestItemRunner` first, then call `@run_package_tests` — `runtests.jl` reads `ARGS` and won't work in a REPL:
+Use `env_path` with the **absolute path** to the `test/` directory (e.g., `/full/path/to/TulipaEnergyModel.jl/test/`) — relative paths resolve from the MCP server's directory, not the project root. The test env has its own `Project.toml` with the package as a path source. Always import `TestItemRunner` first, then call `@run_package_tests` — `runtests.jl` reads `ARGS` and won't work in a REPL:
 
 ```julia
 using TestItemRunner

--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -86,10 +86,7 @@ function validate_data!(connection)
             false,
         ),
     )
-        @timeit to "$log_msg" append!(
-            error_messages,
-            validation_function(connection)::Vector{String},
-        )
+        @timeit to "$log_msg" validation_function(error_messages, connection)
         if fail_fast && length(error_messages) > 0
             break
         end
@@ -102,8 +99,7 @@ function validate_data!(connection)
     return
 end
 
-function _validate_has_all_tables_and_columns!(connection)
-    error_messages = String[]
+function _validate_has_all_tables_and_columns!(error_messages, connection)
     for (table_name, table) in TulipaEnergyModel.schema_per_table_name
         columns_from_connection = [
             row.column_name::String for row in DuckDB.query(
@@ -132,10 +128,9 @@ function _validate_has_all_tables_and_columns!(connection)
     return error_messages
 end
 
-function _validate_no_duplicate_rows!(connection)
+function _validate_no_duplicate_rows!(error_messages, connection)
     # It should be possible to add a primary key to the tables below to avoid this validation.
     # However, where to add this, and how to ensure it was added is not clear.
-    duplicates = String[]
     for (table, primary_keys) in (
         ("asset", [:asset]),
         ("asset_both", [:asset, :milestone_year, :commission_year]),
@@ -159,28 +154,26 @@ function _validate_no_duplicate_rows!(connection)
         ("stochastic_scenario", [:scenario]),
         ("timeframe_data", [:milestone_year, :period]),
     )
-        append!(duplicates, _validate_no_duplicate_rows!(connection, table, primary_keys))
+        _validate_no_duplicate_rows!(error_messages, connection, table, primary_keys)
     end
 
-    return duplicates
+    return error_messages
 end
 
-function _validate_no_duplicate_rows!(connection, table, primary_keys)
+function _validate_no_duplicate_rows!(error_messages, connection, table, primary_keys)
     keys_as_string = join(primary_keys, ", ")
-    duplicates = String[]
     for row in DuckDB.query(
         connection,
         "SELECT $keys_as_string, COUNT(*) FROM $table GROUP BY $keys_as_string HAVING COUNT(*) > 1",
     )
         values = join(["$k=$(row[k])" for k in primary_keys], ", ")
-        push!(duplicates, "Table $table has duplicate entries for ($values)")
+        push!(error_messages, "Table $table has duplicate entries for ($values)")
     end
 
-    return duplicates
+    return error_messages
 end
 
-function _validate_schema_one_of_constraints!(connection)
-    error_messages = String[]
+function _validate_schema_one_of_constraints!(error_messages, connection)
     for (table_name, table) in TulipaEnergyModel.schema, (col, attr) in table
         if haskey(attr, "constraints") && haskey(attr["constraints"], "oneOf")
             valid_types = attr["constraints"]["oneOf"]
@@ -204,9 +197,7 @@ function _validate_schema_one_of_constraints!(connection)
     return error_messages
 end
 
-function _validate_only_transport_flows_are_investable!(connection)
-    error_messages = String[]
-
+function _validate_only_transport_flows_are_investable!(error_messages, connection)
     for row in DuckDB.query(
         connection,
         "SELECT flow.from_asset, flow.to_asset,
@@ -227,11 +218,9 @@ function _validate_only_transport_flows_are_investable!(connection)
     return error_messages
 end
 
-function _validate_flow_both_table_does_not_contain_non_transport_flows!(connection)
+function _validate_flow_both_table_does_not_contain_non_transport_flows!(error_messages, connection)
     # In principle, we should also check all transport flows are covered.
     # But that is tested elsewhere, i.e., in _validate_simple_method_data_consistency!()
-    error_messages = String[]
-
     for row in DuckDB.query(
         connection,
         "SELECT flow_both.from_asset, flow_both.to_asset, flow_both.milestone_year, flow_both.commission_year
@@ -252,6 +241,7 @@ function _validate_flow_both_table_does_not_contain_non_transport_flows!(connect
 end
 
 function _validate_foreign_key!(
+    error_messages,
     connection,
     table_name,
     column::Symbol,
@@ -259,7 +249,6 @@ function _validate_foreign_key!(
     foreign_key::Symbol;
     allow_missing = true,
 )
-    error_messages = String[]
     query = "SELECT main.$column
         FROM $table_name AS main
         ANTI JOIN $foreign_table_name AS other
@@ -279,7 +268,7 @@ function _validate_foreign_key!(
     return error_messages
 end
 
-function _validate_assets_in_investment_groups_are_investable!(connection)
+function _validate_assets_in_investment_groups_are_investable!(error_messages, connection)
     query = """
     SELECT
         group_asset_membership.group_name,
@@ -293,33 +282,35 @@ function _validate_assets_in_investment_groups_are_investable!(connection)
         AND group_asset.milestone_year = asset_milestone.milestone_year
     WHERE NOT asset_milestone.investable
     """
-    error_messages = [
-        "Asset '$(row.asset)' is in investment group '$(row.group_name)' for milestone_year '$(row.milestone_year)' but it is not 'asset_milestone.investable'"
-        for row in DuckDB.query(connection, query)
-    ]
+    for row in DuckDB.query(connection, query)
+        push!(
+            error_messages,
+            "Asset '$(row.asset)' is in investment group '$(row.group_name)' for milestone_year '$(row.milestone_year)' but it is not 'asset_milestone.investable'",
+        )
+    end
 
     return error_messages
 end
 
-function _validate_group_consistency!(connection)
-    error_messages = String[]
-
+function _validate_group_consistency!(error_messages, connection)
     # Check the values in the table `group_asset_membership`:
     # - `group_name` comes from `group_asset.name`
     # - `asset` comes from `asset.asset`
-    append!(
+    _validate_foreign_key!(
         error_messages,
-        _validate_foreign_key!(
-            connection,
-            "group_asset_membership",
-            :group_name,
-            "group_asset",
-            :name,
-        ),
+        connection,
+        "group_asset_membership",
+        :group_name,
+        "group_asset",
+        :name,
     )
-    append!(
+    _validate_foreign_key!(
         error_messages,
-        _validate_foreign_key!(connection, "group_asset_membership", :asset, "asset", :asset),
+        connection,
+        "group_asset_membership",
+        :asset,
+        "asset",
+        :asset,
     )
 
     # Check that the groups created in `group_asset` have at least one entry in `group_asset_membership`
@@ -339,14 +330,16 @@ function _validate_group_consistency!(connection)
         )
     end
 
-    append!(error_messages, _validate_assets_in_investment_groups_are_investable!(connection))
+    _validate_assets_in_investment_groups_are_investable!(error_messages, connection)
 
     return error_messages
 end
 
-function _validate_stochastic_scenario_probabilities_sum_to_one!(connection; tolerance = 1e-3)
-    error_messages = String[]
-
+function _validate_stochastic_scenario_probabilities_sum_to_one!(
+    error_messages,
+    connection;
+    tolerance = 1e-3,
+)
     # Check if table is not empty
     row_count = count_rows_from(connection, "stochastic_scenario")
     if row_count == 0
@@ -368,8 +361,7 @@ function _validate_stochastic_scenario_probabilities_sum_to_one!(connection; tol
     return error_messages
 end
 
-function _validate_simple_method_data_consistency!(connection)
-    error_messages = String[]
+function _validate_simple_method_data_consistency!(error_messages, connection)
     _validate_simple_method_has_only_matching_years!(error_messages, connection)
     _validate_simple_method_all_milestone_years_are_covered!(error_messages, connection)
 
@@ -467,9 +459,7 @@ function _validate_simple_method_all_milestone_years_are_covered!(error_messages
     return error_messages
 end
 
-function _validate_use_binary_storage_method_has_investment_limit!(connection)
-    error_messages = String[]
-
+function _validate_use_binary_storage_method_has_investment_limit!(error_messages, connection)
     for row in DuckDB.query(
         connection,
         "SELECT asset.asset, asset.use_binary_storage_method, asset_milestone.milestone_year, asset_commission.commission_year, asset_commission.investment_limit
@@ -494,8 +484,7 @@ function _validate_use_binary_storage_method_has_investment_limit!(connection)
     return error_messages
 end
 
-function _validate_dc_opf_data!(connection)
-    error_messages = String[]
+function _validate_dc_opf_data!(error_messages, connection)
     _validate_reactance_must_be_greater_than_zero!(error_messages, connection)
     _validate_dc_opf_only_apply_to_non_investable_transport_flows!(error_messages, connection)
 
@@ -540,9 +529,10 @@ function _validate_dc_opf_only_apply_to_non_investable_transport_flows!(error_me
     return error_messages
 end
 
-function _validate_certain_asset_types_can_only_have_none_investment_methods!(connection)
-    error_messages = String[]
-
+function _validate_certain_asset_types_can_only_have_none_investment_methods!(
+    error_messages,
+    connection,
+)
     for row in DuckDB.query(
         connection,
         "SELECT asset.asset, asset.investment_method, asset.type
@@ -560,8 +550,7 @@ function _validate_certain_asset_types_can_only_have_none_investment_methods!(co
     return error_messages
 end
 
-function _validate_asset_commission_and_asset_both_consistency!(connection)
-    error_messages = String[]
+function _validate_asset_commission_and_asset_both_consistency!(error_messages, connection)
     for row in DuckDB.query(
         connection,
         "SELECT asset_both.asset, asset_both.milestone_year, asset_both.commission_year
@@ -597,8 +586,7 @@ function _validate_asset_commission_and_asset_both_consistency!(connection)
     return error_messages
 end
 
-function _validate_flow_commission_and_asset_both_consistency!(connection)
-    error_messages = String[]
+function _validate_flow_commission_and_asset_both_consistency!(error_messages, connection)
     for row in DuckDB.query(
         connection,
         "SELECT asset_both.asset, asset_both.milestone_year, asset_both.commission_year
@@ -640,8 +628,7 @@ function _validate_flow_commission_and_asset_both_consistency!(connection)
     return error_messages
 end
 
-function _validate_bid_related_data!(connection)
-    error_messages = String[]
+function _validate_bid_related_data!(error_messages, connection)
 
     #= Testing strategy:
     # - For a given `asset`, there are necessary and sufficient conditions that
@@ -898,8 +885,7 @@ function _validate_bid_related_data!(connection)
     return error_messages
 end
 
-function _validate_commodity_price_consistency!(connection)
-    error_messages = String[]
+function _validate_commodity_price_consistency!(error_messages, connection)
     if !_check_if_table_exists(connection, "flows_profiles")
         return error_messages
     end
@@ -934,9 +920,7 @@ function _validate_commodity_price_consistency!(connection)
     return error_messages
 end
 
-function _validate_investable_and_asset_both_consistency!(connection)
-    error_messages = String[]
-
+function _validate_investable_and_asset_both_consistency!(error_messages, connection)
     for row in DuckDB.query(
         connection,
         "SELECT asset_milestone.asset, asset_milestone.milestone_year

--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -890,26 +890,23 @@ function _validate_commodity_price_consistency!(error_messages, connection)
         return error_messages
     end
     # All flows associated with a 'commodity_price' profile
-    rows = [
-        row for row in DuckDB.query(
-            connection,
-            """
-            SELECT
-                flow_milestone.from_asset,
-                flow_milestone.to_asset,
-                flows_profiles.profile_type,
-                flow_milestone.commodity_price,
-            FROM flows_profiles
-            LEFT JOIN flow_milestone
-                ON flow_milestone.from_asset = flows_profiles.from_asset
-                AND flow_milestone.to_asset = flows_profiles.to_asset
-            WHERE
-                flows_profiles.profile_type = 'commodity_price'
-                AND flow_milestone.commodity_price <= 0
-            """,
-        )
-    ]
-    for row in rows
+    for row in DuckDB.query(
+        connection,
+        """
+        SELECT
+            flow_milestone.from_asset,
+            flow_milestone.to_asset,
+            flows_profiles.profile_type,
+            flow_milestone.commodity_price,
+        FROM flows_profiles
+        LEFT JOIN flow_milestone
+            ON flow_milestone.from_asset = flows_profiles.from_asset
+            AND flow_milestone.to_asset = flows_profiles.to_asset
+        WHERE
+            flows_profiles.profile_type = 'commodity_price'
+            AND flow_milestone.commodity_price <= 0
+        """,
+    )
         from, to, commodity_price = row.from_asset, row.to_asset, row.commodity_price
         push!(
             error_messages,

--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -851,10 +851,10 @@ function _validate_bid_related_data!(connection)
                 )
             end
             if !unit_commitment_integer
-                push!(error_messages, "have asset.unit_commitment_integer = true")
+                push!(error_messages, "$prefix_msg have asset.unit_commitment_integer = true")
             end
             if unit_commitment_method != "basic"
-                push!(error_messages, "have asset.unit_commitment_method = \"basic\"")
+                push!(error_messages, "$prefix_msg have asset.unit_commitment_method = \"basic\"")
             end
             if consumer_balance_sense != "=="
                 push!(

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -13,7 +13,7 @@ end
     end
 
     DuckDB.query(connection, "DROP TABLE asset")
-    @test TEM._validate_has_all_tables_and_columns!(connection) ==
+    @test TEM._validate_has_all_tables_and_columns!(String[], connection) ==
           ["Table 'asset' expected but not found"]
 end
 
@@ -25,7 +25,7 @@ end
     end
 
     DuckDB.query(connection, "ALTER TABLE asset DROP COLUMN type")
-    @test TEM._validate_has_all_tables_and_columns!(connection) ==
+    @test TEM._validate_has_all_tables_and_columns!(String[], connection) ==
           ["Column 'type' is missing from table 'asset'"]
 end
 
@@ -38,8 +38,8 @@ end
     )
     connection = DBInterface.connect(DuckDB.DB)
     DuckDB.register_data_frame(connection, bad_data, "bad_data")
-    @test TEM._validate_no_duplicate_rows!(connection, "bad_data", [:asset, :year]) == []
-    @test TEM._validate_no_duplicate_rows!(connection, "bad_data", [:asset]) |> sort == [
+    @test TEM._validate_no_duplicate_rows!(String[], connection, "bad_data", [:asset, :year]) == []
+    @test TEM._validate_no_duplicate_rows!(String[], connection, "bad_data", [:asset]) |> sort == [
         "Table bad_data has duplicate entries for (asset=ccgt)",
         "Table bad_data has duplicate entries for (asset=demand)",
     ]
@@ -53,7 +53,7 @@ end
         DuckDB.query(connection, "INSERT INTO $table (FROM $table ORDER BY RANDOM() LIMIT 1)")
     end
     @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
-    error_messages = TEM._validate_no_duplicate_rows!(connection)
+    error_messages = TEM._validate_no_duplicate_rows!(String[], connection)
     @test length(error_messages) == 2
     # These tests assume an order in the validation of the tables
     @test occursin("Table asset has duplicate entries", error_messages[1])
@@ -66,7 +66,7 @@ end
     # Change the table to force an error
     DuckDB.query(connection, "UPDATE asset SET type = 'badtype' WHERE asset = 'ccgt'")
     @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
-    error_messages = TEM._validate_schema_one_of_constraints!(connection)
+    error_messages = TEM._validate_schema_one_of_constraints!(String[], connection)
     @test error_messages == ["Table 'asset' has bad value for column 'type': 'badtype'"]
 end
 
@@ -79,7 +79,7 @@ end
         "UPDATE asset SET consumer_balance_sense = '<>' WHERE asset = 'demand'",
     )
     @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
-    error_messages = TEM._validate_schema_one_of_constraints!(connection)
+    error_messages = TEM._validate_schema_one_of_constraints!(String[], connection)
     @test error_messages ==
           ["Table 'asset' has bad value for column 'consumer_balance_sense': '<>'"]
 end
@@ -93,7 +93,7 @@ end
         "UPDATE asset SET unit_commitment_method = 'bad' WHERE asset = 'demand'",
     )
     @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
-    error_messages = TEM._validate_schema_one_of_constraints!(connection)
+    error_messages = TEM._validate_schema_one_of_constraints!(String[], connection)
     @test error_messages ==
           ["Table 'asset' has bad value for column 'unit_commitment_method': 'bad'"]
 end
@@ -113,7 +113,7 @@ end
             AND rep_period = 1",
     )
     @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
-    error_messages = TEM._validate_schema_one_of_constraints!(connection)
+    error_messages = TEM._validate_schema_one_of_constraints!(String[], connection)
     @test error_messages ==
           ["Table 'flows_rep_periods_partitions' has bad value for column 'specification': 'bad'"]
 end
@@ -135,7 +135,7 @@ end
     DuckDB.register_data_frame(connection, flow, "flow")
     DuckDB.register_data_frame(connection, flow_milestone, "flow_milestone")
 
-    error_messages = TEM._validate_only_transport_flows_are_investable!(connection)
+    error_messages = TEM._validate_only_transport_flows_are_investable!(String[], connection)
     @test error_messages == ["Flow ('A1', 'B') is investable but is not a transport flow"]
 end
 
@@ -154,7 +154,7 @@ end
         "UPDATE flow_milestone SET investable = TRUE WHERE from_asset in ('wind','ocgt')",
     )
     @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
-    error_messages = TEM._validate_only_transport_flows_are_investable!(connection)
+    error_messages = TEM._validate_only_transport_flows_are_investable!(String[], connection)
     @test error_messages == ["Flow ('wind', 'demand') is investable but is not a transport flow"]
 end
 
@@ -175,7 +175,8 @@ end
     DuckDB.register_data_frame(connection, flow, "flow")
     DuckDB.register_data_frame(connection, flow_both, "flow_both")
 
-    error_messages = TEM._validate_flow_both_table_does_not_contain_non_transport_flows!(connection)
+    error_messages =
+        TEM._validate_flow_both_table_does_not_contain_non_transport_flows!(String[], connection)
     @test error_messages == [
         "Unexpected (flow=('A1', 'B'), milestone_year=1, commission_year=1) in 'flow_both' because 'flow_both' should only contain transport flows.",
     ]
@@ -192,7 +193,8 @@ end
         """,
     )
 
-    error_messages = TEM._validate_flow_both_table_does_not_contain_non_transport_flows!(connection)
+    error_messages =
+        TEM._validate_flow_both_table_does_not_contain_non_transport_flows!(String[], connection)
     @test error_messages == [
         "Unexpected (flow=('wind', 'demand'), milestone_year=2030, commission_year=2030) in 'flow_both' because 'flow_both' should only contain transport flows.",
     ]
@@ -213,6 +215,7 @@ end
     DuckDB.register_data_frame(connection, foreign_table, "foreign_table")
 
     error_messages = TEM._validate_foreign_key!(
+        String[],
         connection,
         "main_table",
         :cat1,
@@ -240,6 +243,7 @@ end
     DuckDB.register_data_frame(connection, foreign_table, "foreign_table")
 
     error_messages = TEM._validate_foreign_key!(
+        String[],
         connection,
         "main_table",
         :cat2,
@@ -250,6 +254,7 @@ end
     @test error_messages == String[]
 
     error_messages = TEM._validate_foreign_key!(
+        String[],
         connection,
         "main_table",
         :cat2,
@@ -292,7 +297,7 @@ end
         """,
     )
 
-    error_messages = TEM._validate_group_consistency!(connection)
+    error_messages = TEM._validate_group_consistency!(String[], connection)
     @test Set(error_messages) == Set([
         "Table 'group_asset_membership' column 'asset' has invalid value 'bad_asset'. Valid values should be among column 'asset' of 'asset'",
         "Table 'group_asset_membership' column 'group_name' has invalid value 'bad_group'. Valid values should be among column 'name' of 'group_asset'",
@@ -313,7 +318,7 @@ end
     DuckDB.register_data_frame(connection, group_asset, "group_asset")
     DuckDB.register_data_frame(connection, group_asset_membership, "group_asset_membership")
 
-    error_messages = TEM._validate_group_consistency!(connection)
+    error_messages = TEM._validate_group_consistency!(String[], connection)
     @test error_messages ==
           ["Group 'bad_group' in 'group_asset' has no members in 'group_asset_membership'"]
 end
@@ -350,7 +355,7 @@ end
     DuckDB.register_data_frame(connection, group_asset, "group_asset")
     DuckDB.register_data_frame(connection, group_asset_membership, "group_asset_membership")
 
-    error_messages = TEM._validate_group_consistency!(connection)
+    error_messages = TEM._validate_group_consistency!(String[], connection)
     @test Set(error_messages) == Set([
         "Asset 'A1' is in investment group 'group1' for milestone_year '2030' but it is not 'asset_milestone.investable'",
         "Asset 'A1' is in investment group 'group1' for milestone_year '2050' but it is not 'asset_milestone.investable'",
@@ -502,7 +507,8 @@ end
     DuckDB.register_data_frame(connection, asset, "asset")
     DuckDB.register_data_frame(connection, asset_milestone, "asset_milestone")
     DuckDB.register_data_frame(connection, asset_commission, "asset_commission")
-    error_messages = TEM._validate_use_binary_storage_method_has_investment_limit!(connection)
+    error_messages =
+        TEM._validate_use_binary_storage_method_has_investment_limit!(String[], connection)
     @test error_messages == [
         "Incorrect investment_limit = missing for investable storage asset 'storage_1' with use_binary_storage_method = 'binary' for milestone_year 1. The investment_limit at commission_year 1 should be greater than 0 in 'asset_commission'.",
         "Incorrect investment_limit = 0 for investable storage asset 'storage_2' with use_binary_storage_method = 'binary' for milestone_year 1. The investment_limit at commission_year 1 should be greater than 0 in 'asset_commission'.",
@@ -519,7 +525,8 @@ end
         UPDATE asset_milestone SET investable = TRUE WHERE asset in ('battery', 'phs');
         """,
     )
-    error_messages = TEM._validate_use_binary_storage_method_has_investment_limit!(connection)
+    error_messages =
+        TEM._validate_use_binary_storage_method_has_investment_limit!(String[], connection)
     @test error_messages == [
         "Incorrect investment_limit = missing for investable storage asset 'battery' with use_binary_storage_method = 'binary' for milestone_year 2030. The investment_limit at commission_year 2030 should be greater than 0 in 'asset_commission'.",
     ]
@@ -620,8 +627,10 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     DuckDB.register_data_frame(connection, asset, "asset")
 
-    error_messages =
-        TEM._validate_certain_asset_types_can_only_have_none_investment_methods!(connection)
+    error_messages = TEM._validate_certain_asset_types_can_only_have_none_investment_methods!(
+        String[],
+        connection,
+    )
     @test error_messages == [
         "Incorrect use of investment method 'simple' for asset 'A4' of type 'consumer'. Consumer assets can only have 'none' investment method.",
         "Incorrect use of investment method 'compact' for asset 'A5' of type 'consumer'. Consumer assets can only have 'none' investment method.",
@@ -632,8 +641,10 @@ end
     [CommonSetup] tags = [:unit, :data_validation, :fast] begin
     connection = _tiny_fixture()
     DuckDB.query(connection, "UPDATE asset SET investment_method = 'simple' WHERE asset = 'demand'")
-    error_messages =
-        TEM._validate_certain_asset_types_can_only_have_none_investment_methods!(connection)
+    error_messages = TEM._validate_certain_asset_types_can_only_have_none_investment_methods!(
+        String[],
+        connection,
+    )
     @test error_messages == [
         "Incorrect use of investment method 'simple' for asset 'demand' of type 'consumer'. Consumer assets can only have 'none' investment method.",
     ]
@@ -649,7 +660,8 @@ end
     asset_commission = DataFrame(:asset => ["A", "A"], :commission_year => [-1, 1])
     DuckDB.register_data_frame(connection, asset_commission, "asset_commission")
 
-    error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+    error_messages =
+        TEM._validate_asset_commission_and_asset_both_consistency!(String[], connection)
     @test error_messages == [
         "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 1, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
         "Missing commission_year = 0 for asset 'A' in 'asset_commission' given (asset 'A', milestone_year = 2, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
@@ -661,7 +673,8 @@ end
     [CommonSetup] tags = [:unit, :data_validation, :fast] begin
     connection = _tiny_fixture()
     DuckDB.query(connection, "UPDATE asset_commission SET commission_year = 0 WHERE asset = 'wind'")
-    error_messages = TEM._validate_asset_commission_and_asset_both_consistency!(connection)
+    error_messages =
+        TEM._validate_asset_commission_and_asset_both_consistency!(String[], connection)
     @test error_messages == [
         "Missing commission_year = 2030 for asset 'wind' in 'asset_commission' given (asset 'wind', milestone_year = 2030, commission_year = 2030) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
         "Unexpected commission_year = 0 for asset 'wind' in 'asset_commission'. The commission_year should match the one in 'asset_both'.",
@@ -688,7 +701,7 @@ end
     asset = DataFrame(:asset => ["A", "B"], :investment_method => ["semi-compact", "semi-compact"])
     DuckDB.register_data_frame(connection, asset, "asset")
 
-    error_messages = TEM._validate_flow_commission_and_asset_both_consistency!(connection)
+    error_messages = TEM._validate_flow_commission_and_asset_both_consistency!(String[], connection)
     @test error_messages == [
         "Missing commission_year = 0 for the outgoing flow of asset 'A' in 'flow_commission' given (asset 'A', milestone_year = 1, commission_year = 0) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
         "Unexpected commission_year = -1 for the outgoing flow of asset 'B' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
@@ -705,7 +718,7 @@ end
         UPDATE asset SET investment_method = 'semi-compact' WHERE asset = 'wind';
         """,
     )
-    error_messages = TEM._validate_flow_commission_and_asset_both_consistency!(connection)
+    error_messages = TEM._validate_flow_commission_and_asset_both_consistency!(String[], connection)
     @test error_messages == [
         "Missing commission_year = 2030 for the outgoing flow of asset 'wind' in 'flow_commission' given (asset 'wind', milestone_year = 2030, commission_year = 2030) in 'asset_both'. The commission_year should match the one in 'asset_both'.",
         "Unexpected commission_year = 0 for the outgoing flow of asset 'wind' in 'flow_commission'. The commission_year should match the one in 'asset_both'.",
@@ -718,7 +731,8 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     DuckDB.register_data_frame(connection, stochastic_scenario, "stochastic_scenario")
 
-    error_messages = TEM._validate_stochastic_scenario_probabilities_sum_to_one!(connection)
+    error_messages =
+        TEM._validate_stochastic_scenario_probabilities_sum_to_one!(String[], connection)
     @test error_messages == []
 end
 
@@ -729,6 +743,7 @@ end
     DuckDB.register_data_frame(connection, stochastic_scenario, "stochastic_scenario")
 
     error_messages = TEM._validate_stochastic_scenario_probabilities_sum_to_one!(
+        String[],
         connection;
         tolerance = 1e-5, # testing passing a tolerance different from default
     )
@@ -849,7 +864,7 @@ end
         add_new_bid!(tulipa, "bid1"; price = 1.0, quantity = Dict(3 => 30.0, 4 => 50.0))
         connection = create_connection_and_prepare(tulipa)
 
-        error_messages = TEM._validate_bid_related_data!(connection)
+        error_messages = TEM._validate_bid_related_data!(String[], connection)
         @test length(error_messages) == 0
     end
 
@@ -885,7 +900,7 @@ end
             )
         end
 
-        error_messages = TEM._validate_bid_related_data!(connection)
+        error_messages = TEM._validate_bid_related_data!(String[], connection)
         return error_messages
     end
 
@@ -969,12 +984,12 @@ end
         WHERE from_asset = 'wind' AND to_asset = 'demand'
         """,
     )
-    @test TEM._validate_commodity_price_consistency!(connection) == String[]
+    @test TEM._validate_commodity_price_consistency!(String[], connection) == String[]
 
     # If the flows_profiles table does not exist, no more error (this is mostly here to incrase coverage)
     connection = _tiny_fixture()
     DuckDB.query(connection, "DROP TABLE flows_profiles")
-    @test TEM._validate_commodity_price_consistency!(connection) == String[]
+    @test TEM._validate_commodity_price_consistency!(String[], connection) == String[]
 end
 
 @testitem "Check consistency between investable and asset_both - using fake data" setup =
@@ -991,7 +1006,7 @@ end
     DuckDB.register_data_frame(connection, asset_milestone, "asset_milestone")
     DuckDB.register_data_frame(connection, asset_both, "asset_both")
 
-    error_messages = TEM._validate_investable_and_asset_both_consistency!(connection)
+    error_messages = TEM._validate_investable_and_asset_both_consistency!(String[], connection)
     @test error_messages == [
         "Investable asset 'A' with milestone_year=1 in 'asset_milestone' does not have a corresponding entry (asset='A', milestone_year=1, commission_year=1) in 'asset_both'.",
     ]
@@ -1006,7 +1021,7 @@ end
         connection,
         "DELETE FROM asset_both WHERE asset = 'wind' AND milestone_year = 2030 AND commission_year = 2030",
     )
-    error_messages = TEM._validate_investable_and_asset_both_consistency!(connection)
+    error_messages = TEM._validate_investable_and_asset_both_consistency!(String[], connection)
     @test error_messages == [
         "Investable asset 'wind' with milestone_year=2030 in 'asset_milestone' does not have a corresponding entry (asset='wind', milestone_year=2030, commission_year=2030) in 'asset_both'.",
     ]


### PR DESCRIPTION
I want to try create a validator with the agent, so I did a small refactor and created docs for it.
PS. Also testing sending the PR with the agent :robot: :smile: :bug:
PPS. Changed branch to run benchmark

## Related issues

There is no related issue.

## Summary

- Fix missing `$prefix_msg` prefix in two bid validator error messages — asset name and reason were absent from the output
- Standardise all 16 validators to the mutation pattern `(error_messages, connection)`, replacing the inconsistent mix of mutating and return-based signatures
- Remove unnecessary intermediate array materialisation in `_validate_commodity_price_consistency!`
- Add "Adding a Data Validator" recipe to `AGENTS.md` documenting the convention, registration steps, and test tagging

## Checklist

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing