### PR TITLE
[Validation] Add validator for investable and investment_method consistency

### DIFF
--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -85,6 +85,11 @@ function validate_data!(connection)
             _validate_commodity_price_consistency!,
             false,
         ),
+        (
+            "consistency between investable and investment_method",
+            _validate_investable_and_investment_method_consistency!,
+            false,
+        ),
     )
         @timeit to "$log_msg" validation_function(error_messages, connection)
         if fail_fast && length(error_messages) > 0
@@ -933,6 +938,40 @@ function _validate_investable_and_asset_both_consistency!(error_messages, connec
         push!(
             error_messages,
             "Investable asset '$(row.asset)' with milestone_year=$(row.milestone_year) in 'asset_milestone' does not have a corresponding entry (asset='$(row.asset)', milestone_year=$(row.milestone_year), commission_year=$(row.milestone_year)) in 'asset_both'.",
+        )
+    end
+
+    return error_messages
+end
+
+function _validate_investable_and_investment_method_consistency!(error_messages, connection)
+    for row in DuckDB.query(
+        connection,
+        "SELECT asset_milestone.asset, asset_milestone.milestone_year
+        FROM asset_milestone
+        JOIN asset ON asset_milestone.asset = asset.asset
+        WHERE asset_milestone.investable
+            AND asset.investment_method = 'none'
+        ",
+    )
+        push!(
+            error_messages,
+            "Asset '$(row.asset)' is investable in 'asset_milestone' for milestone_year=$(row.milestone_year), but 'asset.investment_method' is 'none'. An asset is investable if and only if its investment_method is not 'none'.",
+        )
+    end
+
+    for row in DuckDB.query(
+        connection,
+        "SELECT asset_milestone.asset, asset_milestone.milestone_year, asset.investment_method
+        FROM asset_milestone
+        JOIN asset ON asset_milestone.asset = asset.asset
+        WHERE NOT asset_milestone.investable
+            AND asset.investment_method != 'none'
+        ",
+    )
+        push!(
+            error_messages,
+            "Asset '$(row.asset)' is not investable in 'asset_milestone' for milestone_year=$(row.milestone_year), but 'asset.investment_method' is '$(row.investment_method)'. An asset is investable if and only if its investment_method is not 'none'.",
         )
     end
 

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -1026,3 +1026,45 @@ end
         "Investable asset 'wind' with milestone_year=2030 in 'asset_milestone' does not have a corresponding entry (asset='wind', milestone_year=2030, commission_year=2030) in 'asset_both'.",
     ]
 end
+
+@testitem "Check consistency between investable and investment_method - using fake data" setup =
+    [CommonSetup] tags = [:unit, :data_validation, :fast] begin
+    asset = DataFrame(:asset => ["A", "B", "C"], :investment_method => ["none", "simple", "none"])
+    asset_milestone = DataFrame(
+        :asset => ["A", "B", "C"],
+        :milestone_year => [1, 1, 1],
+        :investable => [true, false, false],
+    )
+    connection = DBInterface.connect(DuckDB.DB)
+    DuckDB.register_data_frame(connection, asset, "asset")
+    DuckDB.register_data_frame(connection, asset_milestone, "asset_milestone")
+
+    error_messages =
+        TEM._validate_investable_and_investment_method_consistency!(String[], connection)
+    @test error_messages == [
+        "Asset 'A' is investable in 'asset_milestone' for milestone_year=1, but 'asset.investment_method' is 'none'. An asset is investable if and only if its investment_method is not 'none'.",
+        "Asset 'B' is not investable in 'asset_milestone' for milestone_year=1, but 'asset.investment_method' is 'simple'. An asset is investable if and only if its investment_method is not 'none'.",
+    ]
+end
+
+@testitem "Check consistency between investable and investment_method - investable but method none - using Tiny data" setup =
+    [CommonSetup] tags = [:unit, :data_validation, :fast] begin
+    connection = _tiny_fixture()
+    DuckDB.query(connection, "UPDATE asset SET investment_method = 'none' WHERE asset = 'wind'")
+    error_messages =
+        TEM._validate_investable_and_investment_method_consistency!(String[], connection)
+    @test error_messages == [
+        "Asset 'wind' is investable in 'asset_milestone' for milestone_year=2030, but 'asset.investment_method' is 'none'. An asset is investable if and only if its investment_method is not 'none'.",
+    ]
+end
+
+@testitem "Check consistency between investable and investment_method - not investable but method not none - using Tiny data" setup =
+    [CommonSetup] tags = [:unit, :data_validation, :fast] begin
+    connection = _tiny_fixture()
+    DuckDB.query(connection, "UPDATE asset_milestone SET investable = false WHERE asset = 'wind'")
+    error_messages =
+        TEM._validate_investable_and_investment_method_consistency!(String[], connection)
+    @test error_messages == [
+        "Asset 'wind' is not investable in 'asset_milestone' for milestone_year=2030, but 'asset.investment_method' is 'simple'. An asset is investable if and only if its investment_method is not 'none'.",
+    ]
+end


### PR DESCRIPTION
An asset should be investable in asset_milestone if and only if its investment_method in asset is not 'none'. This validator enforces both directions of that constraint.

Co-Authored-By: Claude Code (claude-sonnet-4-6) <noreply@anthropic.com>

<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1249 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
