### PR TITLE
Create output directory in tutorial 1

### DIFF
--- a/docs/src/10-tutorials/12-basics.md
+++ b/docs/src/10-tutorials/12-basics.md
@@ -35,6 +35,10 @@ output_dir = "my-awesome-energy-system/tutorial-1/results"
 
 Since the output directory does not exist yet, we need to create the 'results' folder inside our tutorial folder, otherwise it will error later.
 
+```julia
+mkpath(output_dir)
+```
+
 Let's use TulipaIO to read the files and list them:
 
 ```julia


### PR DESCRIPTION
Add `mkpath(output_dir)` in tutorial 1.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1578

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
