### PR TITLE
Fix seasonal storage min/max profile query to use assets_timeframe_profiles

### DIFF
--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -335,6 +335,34 @@ function _append_storage_data_to_indices(connection, table_name)
     join_duration = ""
     select_duration = ""
 
+    # Seasonal (inter-period) storage uses assets_timeframe_profiles (keyed by milestone_year
+    # and scenario), while rep-period storage uses assets_profiles (keyed by commission_year).
+    join_storage_level_profiles = if table_name == :balance_storage_inter_period
+        """
+        LEFT OUTER JOIN assets_timeframe_profiles AS max_storage_level_profile
+            ON cons.asset = max_storage_level_profile.asset
+            AND cons.milestone_year = max_storage_level_profile.milestone_year
+            AND cons.scenario = max_storage_level_profile.scenario
+            AND max_storage_level_profile.profile_type = 'max_storage_level'
+        LEFT OUTER JOIN assets_timeframe_profiles AS min_storage_level_profile
+            ON cons.asset = min_storage_level_profile.asset
+            AND cons.milestone_year = min_storage_level_profile.milestone_year
+            AND cons.scenario = min_storage_level_profile.scenario
+            AND min_storage_level_profile.profile_type = 'min_storage_level'
+        """
+    else
+        """
+        LEFT OUTER JOIN assets_profiles AS max_storage_level_profile
+            ON cons.asset = max_storage_level_profile.asset
+            AND cons.milestone_year = max_storage_level_profile.commission_year
+            AND max_storage_level_profile.profile_type = 'max_storage_level'
+        LEFT OUTER JOIN assets_profiles AS min_storage_level_profile
+            ON cons.asset = min_storage_level_profile.asset
+            AND cons.milestone_year = min_storage_level_profile.commission_year
+            AND min_storage_level_profile.profile_type = 'min_storage_level'
+        """
+    end
+
     if table_name == :balance_storage_inter_period
         DuckDB.query(
             connection,
@@ -396,14 +424,7 @@ function _append_storage_data_to_indices(connection, table_name)
             ON cons.asset = inflows_profile.asset
             AND cons.milestone_year = inflows_profile.commission_year
             AND inflows_profile.profile_type = 'inflows'
-        LEFT OUTER JOIN assets_profiles AS max_storage_level_profile
-            ON cons.asset = max_storage_level_profile.asset
-            AND cons.milestone_year = max_storage_level_profile.commission_year
-            AND max_storage_level_profile.profile_type = 'max_storage_level'
-        LEFT OUTER JOIN assets_profiles AS min_storage_level_profile
-            ON cons.asset = min_storage_level_profile.asset
-            AND cons.milestone_year = min_storage_level_profile.commission_year
-            AND min_storage_level_profile.profile_type = 'min_storage_level'
+        $join_storage_level_profiles
         $join_duration
         ORDER BY cons.id
         ",

--- a/test/test-constraint-storage-min-max-level.jl
+++ b/test/test-constraint-storage-min-max-level.jl
@@ -413,8 +413,8 @@ end
         storage_method_energy = "none",
         investable = false,
         investment_method = "none",
-        max_storage_level_profile = Dict((2030, 1) => [1.0, 1.0, 1.0]),
-        min_storage_level_profile = Dict((2030, 1) => [0.0, 0.0, 0.0]),
+        max_storage_level_profile = Dict((2030, 1) => [0.8, 0.4, 1.0]),
+        min_storage_level_profile = Dict((2030, 1) => [0.2, 0.3, 0.0]),
     )
 
     # Setup test problem with common helper
@@ -474,8 +474,8 @@ end
     storage_asset = ConsStorageMinMaxLevelConfig(;
         is_seasonal = true,
         storage_method_energy = "optimize_storage_capacity",
-        max_storage_level_profile = Dict((2030, 1) => [1.0, 1.0, 1.0]),
-        min_storage_level_profile = Dict((2030, 1) => [0.0, 0.0, 0.0]),
+        max_storage_level_profile = Dict((2030, 1) => [0.8, 0.4, 1.0]),
+        min_storage_level_profile = Dict((2030, 1) => [0.2, 0.3, 0.0]),
     )
 
     # Setup test problem with common helper
@@ -540,8 +540,8 @@ end
     storage_asset = ConsStorageMinMaxLevelConfig(;
         is_seasonal = true,
         storage_method_energy = "use_fixed_energy_to_power_ratio",
-        max_storage_level_profile = Dict((2030, 1) => [1.0, 1.0, 1.0]),
-        min_storage_level_profile = Dict((2030, 1) => [0.0, 0.0, 0.0]),
+        max_storage_level_profile = Dict((2030, 1) => [0.8, 0.4, 1.0]),
+        min_storage_level_profile = Dict((2030, 1) => [0.2, 0.3, 0.0]),
     )
 
     # Setup test problem with common helper


### PR DESCRIPTION
The `_append_storage_data_to_indices` function was always joining `assets_profiles` (keyed by `commission_year`) for the `max_storage_level_profile` and `min_storage_level_profile` lookups, even for seasonal (inter-period) storage, which uses `assets_timeframe_profiles` (keyed by `milestone_year` + `scenario`). Added a conditional `join_storage_level_profiles` string that selects the correct table and join columns based on whether `table_name == :balance_storage_inter_period`

## Related issues

Closes #1553

## Checklist

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
