### PR TITLE
Update documentation with CVaR feature

### DIFF
--- a/docs/src/20-user-guide/20-how-to-use.md
+++ b/docs/src/20-user-guide/20-how-to-use.md
@@ -494,3 +494,98 @@ In summary:
 
 Finally, if there are exclusive groups in the bids, i.e., at most 1 bid in the same exclusive group can be accepted, then you also need to modify the underlying JuMP model.
 We need to add a constraint like $\displaystyle \sum_{i: i \in G_k} u_i \leq 1$, where $u_i$ are the unit commitment variables (i.e., the bid-acceptance variables), and $G_k$ are the exclusive groups.
+
+## [Two-Stage Stochastic Optimization](@id stochastic-setup)
+
+Tulipa formulates energy system planning as a **two-stage stochastic optimization** problem:
+
+- **First stage** (investment decisions): capacity investments are made before uncertainty is realized and are therefore **shared across all scenarios**.
+- **Second stage** (operational decisions): dispatch and storage levels are determined after the scenario is revealed and are therefore **scenario-dependent**.
+
+This structure allows the model to find investment plans that are robust against uncertainty in, for example, renewable availability, demand, or hydro inflows.
+
+!!! info
+    Without multiple scenarios (i.e., $\lvert \mathcal{S} \rvert = 1$), the model reduces to a standard deterministic planning problem.
+
+### Defining Stochastic Scenarios
+
+Scenarios are defined through the `rep_periods_mapping` table (or `rep-periods-mapping.csv` for CSV input). Each row maps an original period to a representative period for a given milestone year, with the following key columns for the stochastic feature:
+
+- `scenario`: Integer identifier for the stochastic scenario. Default is `1`, which corresponds to a single deterministic scenario.
+- `rep_period`: The representative period that this original period is mapped to under this scenario.
+- `weight`: The fraction of the original period captured by the representative period.
+
+To run with multiple stochastic scenarios, include rows with different `scenario` values in `rep_periods_mapping`. Representative periods can be organized in two ways:
+
+- **Per-scenario clustering**: each scenario has its own set of representative periods (diagonal block structure in the mapping matrix). With $\lvert \mathcal{S} \rvert$ scenarios and $K$ representative periods each, there are $\lvert \mathcal{S} \rvert \times K$ representative periods in total.
+- **Cross-scenario clustering**: representative periods are shared across scenarios (full matrix structure). With $K$ cross-scenario representative periods, there are only $K$ representative periods in total regardless of the number of scenarios.
+
+See [_TulipaClustering.jl_](https://github.com/TulipaEnergy/TulipaClustering.jl) and the Two-Stage Stochastic Optimization tutorial in the Tutorials section for guidance on how to cluster representative periods per or cross scenario.
+
+### Scenario Probabilities
+
+Scenario probabilities are stored in the `stochastic_scenario` table (or `stochastic-scenario.csv` for CSV input). Each row defines:
+
+- `scenario`: Integer identifier matching the values used in `rep_periods_mapping`.
+- `probability`: Probability of the scenario, in $[0, 1]$. Probabilities must sum to 1.
+- `description` (optional): A free-text description of the scenario (e.g., `'Weather year 1982'`). Default is an empty string.
+
+!!! info "Default probabilities"
+    If no `stochastic_scenario` table or CSV file is provided, Tulipa automatically assigns **uniform probabilities** to all scenarios found in `rep_periods_mapping`: each scenario gets a probability of $1 / \lvert \mathcal{S} \rvert$.
+
+To override the default probabilities, add a `stochastic-scenario.csv` file to your input directory. Another option is to modify the `stochastic_scenario` table in the database directly after calling [`populate_with_defaults!`](@ref):
+
+```julia
+DBInterface.execute(
+    connection,
+    """
+    UPDATE stochastic_scenario
+    SET probability = CASE
+        WHEN scenario = 1 THEN 0.7
+        WHEN scenario = 2 THEN 0.3
+    END;
+    """,
+)
+```
+
+!!! warning "Probabilities must sum to 1"
+    The model validates that all scenario probabilities sum to 1 and raises an error if they do not.
+
+For more details on the objective function and constraints for the stochastic setting, see the [`mathematical formulation`](@ref formulation) section.
+
+## [Risk-Averse Optimization with Conditional Value at Risk (CVaR)](@id cvar-setup)
+
+By default, Tulipa minimizes the **expected total system cost** across stochastic scenarios, which is the standard risk-neutral objective. When multiple stochastic scenarios are present and you want to account for risk, you can activate the **mean-CVaR** (Conditional Value at Risk) formulation. This penalizes scenarios with high costs and produces a solution that is more robust to worst-case outcomes.
+
+The mean-CVaR objective is a convex combination of the expected cost and the CVaR at confidence level $\alpha$:
+
+$$\text{minimize} \quad (1 - \lambda) \cdot \mathbb{E}[C] + \lambda \cdot \text{CVaR}_{\alpha}$$
+
+where $\lambda \in [0, 1]$ controls the trade-off between average performance and risk aversion.
+
+### Setting up CVaR
+
+To activate CVaR, set the following parameters in the `model_parameters` table (or `model-parameters.csv` for CSV input):
+
+- `risk_aversion_weight_lambda`: Risk aversion weight $\lambda \in [0, 1]$. Default is `0.0` (risk-neutral). Increasing this value shifts the objective towards minimizing risk.
+- `risk_aversion_confidence_level_alpha`: Confidence level $\alpha \in (0, 1)$ for the Value at Risk threshold. Default is `0.95`.
+
+!!! info
+    The CVaR feature is only active when **both** `risk_aversion_weight_lambda > 0` **and** there are more than one stochastic scenario ($\lvert \mathcal{S} \rvert > 1$). Otherwise, the model reduces to the standard expected cost minimization regardless of the values set.
+
+!!! tip "Choosing the parameters"
+    - `risk_aversion_weight_lambda = 0.0` gives the fully risk-neutral expected cost solution.
+    - `risk_aversion_weight_lambda = 1.0` minimizes the CVaR only (fully risk-averse).
+    - Typical values are in the range $[0.1, 0.5]$, depending on the desired trade-off between average cost and protection against high-cost scenarios.
+    - A higher `risk_aversion_confidence_level_alpha` (e.g., `0.99` vs `0.95`) focuses the risk measure on a smaller fraction of the worst scenarios.
+
+### What the model adds when CVaR is active
+
+When the CVaR feature is activated, the model automatically creates two additional variables:
+
+- **Value at Risk threshold** ($v^{\mu}$): a single non-negative scalar variable representing the cost threshold at the $\alpha$ confidence level.
+- **Tail excess slack** ($v^{\xi}_{s}$): one non-negative variable per scenario $s \in \mathcal{S}$, capturing how much the total cost of scenario $s$ exceeds the threshold $v^{\mu}$.
+
+These variables are linked through the [scenario tail excess constraints](@ref cvar-constraints), which enforce $v^{\xi}_{s} \geq C_s - v^{\mu}$ for every scenario $s$.
+
+For more details on the mathematical formulation of the CVaR objective and constraints, see the [`mathematical formulation`](@ref formulation) section.

--- a/docs/src/30-concepts.md
+++ b/docs/src/30-concepts.md
@@ -1130,3 +1130,42 @@ In addition, the resolution of all the flows comming into the `atmosphere` asset
 Notice that the flows are defined as power (i.e., instantaneous value); therefore, the result of all the flows going to the `atmosphere` will represent the average CO2 emissions within the day. To compute the total daily emissions, multiply the flow by the duration (i.e., 24h) and then get the total daily value.
 
 As explained in the [modeling greenhouse gas emissions](@ref greenhouse-gas-emissions) section, you can alternatively model the `atmosphere` as a storage asset and account for the total emissions as the storage level of the asset.
+
+## [Two-Stage Stochastic Optimization](@id stochastic-concept)
+
+_TulipaEnergyModel.jl_ formulates energy system planning as a **two-stage stochastic optimization** problem:
+
+- **First stage** (investment decisions): capacity investments are decided before the uncertainty is realized and are therefore the same across all scenarios.
+- **Second stage** (operational decisions): dispatch, storage levels, and other operational variables are determined after the scenario is revealed and can therefore differ between scenarios.
+
+The set of stochastic scenarios $\mathcal{S}$ represents, for example, different weather years or demand outcomes. Each scenario $s \in \mathcal{S}$ is assigned a probability $p^{\text{probability}}_s \in [0,1]$ with $\sum_{s \in \mathcal{S}} p^{\text{probability}}_s = 1$, and the model minimizes the **expected total system cost** across all scenarios.
+
+Scenarios are linked to representative periods through the `rep_periods_mapping` table. Depending on how representative periods are clustered, two structural approaches are possible:
+
+- **Per-scenario clustering**: each scenario has its own set of representative periods (diagonal block structure in the mapping matrix).
+- **Cross-scenario clustering**: representative periods are shared across all scenarios (full matrix structure), which reduces the total number of representative periods.
+
+!!! info
+    By default (single scenario), _TulipaEnergyModel.jl_ behaves as a standard deterministic model. Multi-scenario optimization is activated by providing multiple scenario identifiers in `rep_periods_mapping`. If no probabilities are specified, Tulipa assigns uniform probabilities ($1 / \lvert \mathcal{S} \rvert$) to all scenarios automatically.
+
+See the [two-stage stochastic setup](@ref stochastic-setup) section for instructions on how to configure the model for this feature, and the [mathematical formulation](@ref formulation) for the full objective function and constraints.
+
+## [Risk-Averse Optimization with Conditional Value at Risk (CVaR)](@id cvar-concept)
+
+By default, _TulipaEnergyModel.jl_ minimizes the **expected total system cost** across stochastic scenarios, which is a risk-neutral objective. When the spread of costs across scenarios matters — for example, when avoiding high-cost outcomes is valued — the model supports a **mean-CVaR** (Conditional Value at Risk) objective.
+
+The mean-CVaR objective is a convex combination of the expected cost and the CVaR at confidence level $\alpha$:
+
+$$\text{minimize} \quad (1 - \lambda) \cdot \mathbb{E}[C] + \lambda \cdot \text{CVaR}_{\alpha}$$
+
+where:
+
+- $\lambda \in [0,1]$ is the **risk aversion weight**: $\lambda = 0$ recovers the fully risk-neutral expected cost, while $\lambda = 1$ minimizes only the CVaR.
+- $\alpha \in (0,1)$ is the **confidence level**: the CVaR focuses on the worst $(1-\alpha)$ fraction of scenarios.
+
+The CVaR is computed using the [Rockafellar-Uryasev convex formulation](https://www.risk.net/journal-risk/2161159/optimization-conditional-value-risk), which introduces a scalar Value at Risk threshold variable $v^{\mu}$ and a tail excess slack variable $v^{\xi}_s$ per scenario $s$.
+
+!!! info
+    The CVaR feature only changes the objective function and adds two sets of variables and one set of constraints. All capacity, balance, and storage constraints remain the same.
+
+See the [CVaR setup](@ref cvar-setup) section for instructions on how to activate and configure this feature, and the [mathematical formulation](@ref formulation) for the full formulation.

--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -222,11 +222,13 @@ In addition, the following subsets represent methods for incorporating additiona
 
 ### Parameters for the Model
 
-| Name                              | Domain           | Description          | Units  |
-| --------------------------------- | ---------------- | -------------------- | ------ |
-| $p^{\text{social discount rate}}$ | $\mathbb{R}_{+}$ | Social discount rate | [-]    |
-| $p^{\text{discount year}}$        | $\mathbb{Z}_{+}$ | Discount year        | [year] |
-| $p^{\text{power system base}}$    | $\mathbb{R}_{+}$ | Power system base    | [MVA]  |
+| Name                              | Domain           | Description                                      | Units  |
+| --------------------------------- | ---------------- | ------------------------------------------------ | ------ |
+| $p^{\text{social discount rate}}$ | $\mathbb{R}_{+}$ | Social discount rate                             | [-]    |
+| $p^{\text{discount year}}$        | $\mathbb{Z}_{+}$ | Discount year                                    | [year] |
+| $p^{\text{power system base}}$    | $\mathbb{R}_{+}$ | Power system base                                | [MVA]  |
+| $p^{\lambda}$                     | $[0, 1]$         | Risk aversion weight for the mean-CVaR objective | [-]    |
+| $p^{\alpha}$                      | $(0, 1)$         | Confidence level for the Value at Risk threshold | [-]    |
 
 ### Extra Parameters for Discounting
 
@@ -236,25 +238,27 @@ In addition, the following subsets represent methods for incorporating additiona
 
 ## [Variables](@id math-variables)
 
-| Name                                                            | Domain           | Domains of Indices                                                                                                                                                                                                | Description                                                                                                                                  | Units   |
-| --------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| $v^{\text{flow}}_{f,k_y,b_{k_y}}$                               | $\mathbb{R}$     | $f \in \mathcal{F}$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                                     | Flow $f$ between two assets in representative period $k_y$ and timestep block $b_{k_y}$                                                      | [MW]    |
-| $v^{\text{vintage flow}}_{f,v,k_y,b_{k_y}}$                     | $\mathbb{R}$     | $f \in \mathcal{F}^{\text{out}}_{a,y} \mid a \in \mathcal{A}^{\text{p}} \cup \mathcal{A}^{\text{cv}} \cup \mathcal{A}^{\text{s}} $, $v \in \mathcal{V}$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$ | Vintage flow $f$ between two assets in commission year $v$ in representative period $k_y$ and timestep block $b_{k_y}$                       | [MW]    |
-| $v^{\text{inv}}_{a,y}$                                          | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{i}}_y$, $y \in \mathcal{Y}$                                                                                                                                                             | Number of invested units of asset $a$ at year $y$                                                                                            | [units] |
-| $v^{\text{decom simple}}_{a,y}$                                 | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{simple investment}}$, $y \in \mathcal{Y}$                                                                                                                                               | Number of decommissioned units of asset $a$ that uses simple investment method at year $y$                                                   | [units] |
-| $v^{\text{decom compact}}_{a,y,v}$                              | $\mathbb{Z}_{+}$ | $ (a,y,v) \in \mathcal{D}^{\text{compact investment}}$                                                                                                                                                            | Number of decommissioned units of asset $a$ commissioned in year $v$ that uses compact investment method at year $y$                         | [units] |
-| $v^{\text{inv energy}}_{a,y}$                                   | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{i}}_y \cap \mathcal{A}^{\text{se}}_y$, $y \in \mathcal{Y}$                                                                                                                              | Number of invested units of the energy component of the storage asset $a$ that uses energy method at year $y$                                | [units] |
-| $v^{\text{decom energy simple}}_{a,y}$                          | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{i}}_y \cap \mathcal{A}^{\text{se}}_y$, $y \in \mathcal{Y}$                                                                                                                              | Number of decommissioned units of the energy component of the storage asset $a$ that uses energy method at year $y$                          | [units] |
-| $v^{\text{inv}}_{f,y}$                                          | $\mathbb{Z}_{+}$ | $f \in \mathcal{F}^{\text{ti}}_y$, $y \in \mathcal{Y}$                                                                                                                                                            | Number of invested units of capacity increment of transport flow $f$ at year $y$                                                             | [units] |
-| $v^{\text{decom simple}}_{f,y}$                                 | $\mathbb{Z}_{+}$ | $f \in \mathcal{F}^{\text{ti}}_y$, $y \in \mathcal{Y}$                                                                                                                                                            | Number of decommissioned units of capacity increment of transport flow $f$ at year $y$                                                       | [units] |
-| $v^{\text{rep-period-storage}}_{a,k_y,b_{k_y}}$                 | $\mathbb{R}_{+}$ | $a \in \mathcal{A}^{\text{s}}_y \setminus \mathcal{A}^{\text{ss}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                    | Rep-period-storage level for storage asset $a$, representative period $k_y$, and timestep block $b_{k_y}$                                    | [MWh]   |
-| $v^{\text{inter-period-storage}}_{a,s,p_y}$                     | $\mathbb{R}_{+}$ | $a \in \mathcal{A^{\text{ss}}}_y$, $s \in \mathcal{S}$, $p_y \in \mathcal{P}_y$                                                                                                                                   | inter-period-storage level for storage asset $a$, stochastic scenario $s$, and period $p_y$                                                  | [MWh]   |
-| $v^{\text{accumulated intra-period-storage}}_{a,y,k_y,b_{k_y}}$ | $\mathbb{R}$     | $a \in \mathcal{A}^{\text{ss}}_y$, $y \in \mathcal{Y}$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                  | Accumulated intra-period storage level for seasonal storage asset $a$ at year $y$, representative period $k_y$, and timestep block $b_{k_y}$ | [MWh]   |
-| $v^{\text{is charging}}_{a,k_y,b_{k_y}}$                        | $\{0, 1\}$       | $a \in \mathcal{A}^{\text{sb}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                       | If an storage asset $a$ is charging or not in representative period $k_y$ and timestep block $b_{k_y}$                                       | [-]     |
-| $v^{\text{angle}}_{a,k_y,b_{k_y}}$                              | $\mathbb{R}$     | $a \in \mathcal{A}^{\text{dc-opf}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                   | Electricity angle of asset $a$ in representative period $k_y$ and timestep block $b_{k_y}$                                                   | [rad]   |
-| $v^{\text{units on}}_{a,k_y,b_{k_y}}$                           | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{uc}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                       | Number of units ON of asset $a$ in representative period $k_y$ and timestep block $b_{k_y}$                                                  | [units] |
-| $v^{\text{start up}}_{a,k_y,b_{k_y}}$                           | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{uc 3var}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                  | Number of units of asset $a$ STARTING UP in representative period $k_y$ and timestep block $b_{k_y}$                                         | [units] |
-| $v^{\text{shut down}}_{a,k_y,b_{k_y}}$                          | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{uc 3var}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                  | Number of units of asset $a$ SHUTTING DOWN in representative period $k_y$ and timestep block $b_{k_y}$                                       | [units] |
+| Name                                                            | Domain           | Domains of Indices                                                                                                                                                                                                | Description                                                                                                                                  | Units       |
+| --------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| $v^{\text{flow}}_{f,k_y,b_{k_y}}$                               | $\mathbb{R}$     | $f \in \mathcal{F}$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                                     | Flow $f$ between two assets in representative period $k_y$ and timestep block $b_{k_y}$                                                      | [MW]        |
+| $v^{\text{vintage flow}}_{f,v,k_y,b_{k_y}}$                     | $\mathbb{R}$     | $f \in \mathcal{F}^{\text{out}}_{a,y} \mid a \in \mathcal{A}^{\text{p}} \cup \mathcal{A}^{\text{cv}} \cup \mathcal{A}^{\text{s}} $, $v \in \mathcal{V}$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$ | Vintage flow $f$ between two assets in commission year $v$ in representative period $k_y$ and timestep block $b_{k_y}$                       | [MW]        |
+| $v^{\text{inv}}_{a,y}$                                          | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{i}}_y$, $y \in \mathcal{Y}$                                                                                                                                                             | Number of invested units of asset $a$ at year $y$                                                                                            | [units]     |
+| $v^{\text{decom simple}}_{a,y}$                                 | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{simple investment}}$, $y \in \mathcal{Y}$                                                                                                                                               | Number of decommissioned units of asset $a$ that uses simple investment method at year $y$                                                   | [units]     |
+| $v^{\text{decom compact}}_{a,y,v}$                              | $\mathbb{Z}_{+}$ | $ (a,y,v) \in \mathcal{D}^{\text{compact investment}}$                                                                                                                                                            | Number of decommissioned units of asset $a$ commissioned in year $v$ that uses compact investment method at year $y$                         | [units]     |
+| $v^{\text{inv energy}}_{a,y}$                                   | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{i}}_y \cap \mathcal{A}^{\text{se}}_y$, $y \in \mathcal{Y}$                                                                                                                              | Number of invested units of the energy component of the storage asset $a$ that uses energy method at year $y$                                | [units]     |
+| $v^{\text{decom energy simple}}_{a,y}$                          | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{i}}_y \cap \mathcal{A}^{\text{se}}_y$, $y \in \mathcal{Y}$                                                                                                                              | Number of decommissioned units of the energy component of the storage asset $a$ that uses energy method at year $y$                          | [units]     |
+| $v^{\text{inv}}_{f,y}$                                          | $\mathbb{Z}_{+}$ | $f \in \mathcal{F}^{\text{ti}}_y$, $y \in \mathcal{Y}$                                                                                                                                                            | Number of invested units of capacity increment of transport flow $f$ at year $y$                                                             | [units]     |
+| $v^{\text{decom simple}}_{f,y}$                                 | $\mathbb{Z}_{+}$ | $f \in \mathcal{F}^{\text{ti}}_y$, $y \in \mathcal{Y}$                                                                                                                                                            | Number of decommissioned units of capacity increment of transport flow $f$ at year $y$                                                       | [units]     |
+| $v^{\text{rep-period-storage}}_{a,k_y,b_{k_y}}$                 | $\mathbb{R}_{+}$ | $a \in \mathcal{A}^{\text{s}}_y \setminus \mathcal{A}^{\text{ss}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                    | Rep-period-storage level for storage asset $a$, representative period $k_y$, and timestep block $b_{k_y}$                                    | [MWh]       |
+| $v^{\text{inter-period-storage}}_{a,s,p_y}$                     | $\mathbb{R}_{+}$ | $a \in \mathcal{A^{\text{ss}}}_y$, $s \in \mathcal{S}$, $p_y \in \mathcal{P}_y$                                                                                                                                   | inter-period-storage level for storage asset $a$, stochastic scenario $s$, and period $p_y$                                                  | [MWh]       |
+| $v^{\text{accumulated intra-period-storage}}_{a,y,k_y,b_{k_y}}$ | $\mathbb{R}$     | $a \in \mathcal{A}^{\text{ss}}_y$, $y \in \mathcal{Y}$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                  | Accumulated intra-period storage level for seasonal storage asset $a$ at year $y$, representative period $k_y$, and timestep block $b_{k_y}$ | [MWh]       |
+| $v^{\text{is charging}}_{a,k_y,b_{k_y}}$                        | $\{0, 1\}$       | $a \in \mathcal{A}^{\text{sb}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                       | If an storage asset $a$ is charging or not in representative period $k_y$ and timestep block $b_{k_y}$                                       | [-]         |
+| $v^{\text{angle}}_{a,k_y,b_{k_y}}$                              | $\mathbb{R}$     | $a \in \mathcal{A}^{\text{dc-opf}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                   | Electricity angle of asset $a$ in representative period $k_y$ and timestep block $b_{k_y}$                                                   | [rad]       |
+| $v^{\text{units on}}_{a,k_y,b_{k_y}}$                           | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{uc}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                       | Number of units ON of asset $a$ in representative period $k_y$ and timestep block $b_{k_y}$                                                  | [units]     |
+| $v^{\text{start up}}_{a,k_y,b_{k_y}}$                           | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{uc 3var}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                  | Number of units of asset $a$ STARTING UP in representative period $k_y$ and timestep block $b_{k_y}$                                         | [units]     |
+| $v^{\text{shut down}}_{a,k_y,b_{k_y}}$                          | $\mathbb{Z}_{+}$ | $a \in \mathcal{A}^{\text{uc 3var}}_y$, $k_y \in \mathcal{K}_y$, $b_{k_y} \in \mathcal{B_{k_y}}$                                                                                                                  | Number of units of asset $a$ SHUTTING DOWN in representative period $k_y$ and timestep block $b_{k_y}$                                       | [units]     |
+| $v^{\mu}$                                                       | $\mathbb{R}_{+}$ |                                                                                                                                                                                                                   | Value at Risk threshold (active when $p^{\lambda} > 0$ and $\lvert \mathcal{S} \rvert > 1$)                                                  | [kEUR]      |
+| $v^{\xi}_{s}$                                                   | $\mathbb{R}_{+}$ | $s \in \mathcal{S}$                                                                                                                                                                                               | Tail excess slack for scenario $s$ (active when $p^{\lambda} > 0$ and $\lvert \mathcal{S} \rvert > 1$)                                       | [kEUR]      |
 
 ## [Objective Function](@id math-objective-function)
 
@@ -365,15 +369,25 @@ This definition of the discount factor at year $y$ includes the discounts for th
 
 ### Objective Function
 
-The objective function is formulated as a two-stage stochastic optimization problem, where the investment decisions are the first-stage variables and the expected value of the operation variables is in the second stage.
+The objective function is formulated as a two-stage stochastic optimization problem, where the investment decisions are the first-stage variables and the expected value of the operation variables is in the second stage. When the risk aversion weight $p^{\lambda} > 0$ and there are multiple stochastic scenarios ($|\mathcal{S}| > 1$), the model uses a mean-CVaR (Conditional Value at Risk) formulation to incorporate risk into the objective.
 
 ```math
 \begin{aligned}
-\text{{minimize}} \quad & assets\_investment\_cost + assets\_fixed\_cost \\
+\text{{minimize}} \quad & (1 - p^{\lambda}) \cdot \bigg[ assets\_investment\_cost + assets\_fixed\_cost \\
                         & + flows\_investment\_cost + flows\_fixed\_cost \\
-                        & + \sum_{s \in \mathcal{S}} p^{\text{probability}}_{s} \cdot (flows\_operational\_cost_{s} + unit\_on\_cost_{s})
+                        & + \sum_{s \in \mathcal{S}} p^{\text{probability}}_{s} \cdot (flows\_operational\_cost_{s} + unit\_on\_cost_{s}) \bigg] \\
+                        & + p^{\lambda} \cdot \text{CVaR}_{p^{\alpha}}
 \end{aligned}
 ```
+
+where the CVaR term is:
+
+```math
+\text{CVaR}_{p^{\alpha}} = v^{\mu} + \frac{1}{1 - p^{\alpha}} \sum_{s \in \mathcal{S}} p^{\text{probability}}_{s} \cdot v^{\xi}_{s}
+```
+
+!!! note
+    When $p^{\lambda} = 0$ (the default), the CVaR variables are not created and the objective reduces to the standard expected cost minimization.
 
 Where:
 
@@ -906,3 +920,29 @@ These constraints apply to assets in a group using the investment method $\mathc
 \\ \\ & \forall y \in \mathcal{Y}, \forall g \in \mathcal{G}^{\text{ai}}_y
 \end{aligned}
 ```
+
+### [Conditional Value at Risk Constraints](@id cvar-constraints)
+
+These constraints are only active when $p^{\lambda} > 0$ and $|\mathcal{S}| > 1$. They relate the tail excess slack variable $v^{\xi}_{s}$ to the total system cost per scenario and the Value at Risk threshold $v^{\mu}$.
+
+#### Scenario Tail Excess Constraint
+
+For each stochastic scenario $s$, the non-negative tail excess slack variable $v^{\xi}_{s}$ captures the amount by which the total system cost in scenario $s$ exceeds the Value at Risk threshold $v^{\mu}$:
+
+```math
+\begin{aligned}
+v^{\xi}_{s} \geq total\_cost_{s} - v^{\mu} \quad \forall s \in \mathcal{S}
+\end{aligned}
+```
+
+where the total cost per scenario $s$ is:
+
+```math
+\begin{aligned}
+total\_cost_{s} = & \; assets\_investment\_cost + assets\_fixed\_cost \\
+                  & + flows\_investment\_cost + flows\_fixed\_cost \\
+                  & + flows\_operational\_cost_{s} + unit\_on\_cost_{s}
+\end{aligned}
+```
+
+and the individual cost terms follow the same expressions defined in the [Objective Function](@ref math-objective-function).


### PR DESCRIPTION
Update in the documentation related to the CVaR feature, see #1523. The main changes are:

## Formulation (40-formulation.md)

**1. Parameters for the Model** — Added two new rows for the CVaR parameters:
- $p^{\lambda} \in [0,1]$: Risk aversion weight for the mean-CVaR objective
- $p^{\alpha} \in (0,1)$: Confidence level for the Value at Risk threshold

**2. Variables table** — Added two new rows:
- $v^{\mu} \in \mathbb{R}_+$: Value at Risk threshold (scalar, active when $p^{\lambda} > 0$ and $\lvert\mathcal{S}\rvert > 1$)
- $v^\xi_s \in \mathbb{R}_+$: Tail excess slack per scenario $s$ (active under same conditions)

**3. Objective Function** — Updated the description to mention mean-CVaR and replaced the `minimize` block with the full mean-CVaR formulation: $(1-p^\lambda)\cdot[\text{existing terms}] + p^\lambda \cdot \text{CVaR}_{p^\alpha}$, plus the CVaR definition $v^\mu + \frac{1}{1-p^\alpha}\sum_s p^{\text{prob}}_s v^\xi_s$, and a note that $p^\lambda = 0$ recovers the original formulation.

**4. New section: Conditional Value at Risk Constraints** — Added at the end of the Constraints section, documenting the scenario tail excess constraint $v^\xi_s \geq \text{totalcost}_s - v^\mu$ and defining $\text{totalcost}_s$.

## How to use (20-how-to-use.md)

Two new sections:

1. Two-Stage Stochastic Optimization section placed between the Bids section and the CVaR section, with two subsections: Defining Stochastic Scenarios and Scenario Probabilities.
2. Risk-Averse Optimization with Conditional Value at Risk (CVaR) section at the end of the file, with two subsections: Setting up CVaR and What the model adds when CVaR is active.

## Concepts (30-concepts.md)

Two new sections:

1. Two-Stage Stochastic Optimization: explains the two-stage structure
3. Risk-Averse Optimization with Conditional Value at Risk (CVaR): explains the mean-CVaR objective as a convex combination of expected cost and CVaR

## Related issues

Closes #1529

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
