### PR TITLE
Add min flow limit without unit commitment constraint

### DIFF
--- a/docs/src/20-user-guide/20-how-to-use.md
+++ b/docs/src/20-user-guide/20-how-to-use.md
@@ -494,6 +494,9 @@ The unit commitment constraints are only applied to producer and conversion asse
 - `unit_commitment_integer`: It determines whether the unit commitment variables are considered as integer or not (`true` or `false`)
 - `min_operating_point`: Minimum operating point or minimum stable generation level defined as a portion of the capacity of asset (p.u.)
 
+!!! info "Minimum operating point constraints without unit commitment"
+    Even when `unit_commitment = 'none'`, producer and conversion assets with `min_operating_point > 0` still receive a minimum output-flow constraint (for aggregated and compact profiles vintage methods). This is useful to represent must-run conditions without the full unit commitment formulation.
+
 For more details on the constraints that apply when selecting this method, please visit the [`mathematical formulation`](@ref formulation) section.
 
 ### [Ramping constraints](@id ramping-setup)

--- a/docs/src/20-user-guide/55-outputs.md
+++ b/docs/src/20-user-guide/55-outputs.md
@@ -140,6 +140,14 @@ Associated input parameter: `unit_commitment_integer`
 
 - `dual_min_output_flow_with_unit_commitment`: Dual of the constraint ["minimum output flow above the minimum operating point"](https://tulipaenergy.github.io/TulipaEnergyModel.jl/stable/40-scientific-foundation/40-formulation/#Minimum-output-flow-above-the-minimum-operating-point).
 
+### `cons_min_output_flow_without_unit_commitment_aggregated_vintage_method`
+
+- `dual_min_output_flow_without_unit_commitment_aggregated_vintage_method`: Dual of the constraint ["minimum output constraints without unit commitment"](https://tulipaenergy.github.io/TulipaEnergyModel.jl/stable/40-scientific-foundation/40-formulation/#Minimum-Output-Constraints-Without-Unit-Commitment).
+
+### `cons_min_output_flow_without_unit_commitment_compact_vintage_method`
+
+- `dual_min_output_flow_without_unit_commitment_compact_vintage_method`: Dual of the constraint ["minimum output constraints without unit commitment"](https://tulipaenergy.github.io/TulipaEnergyModel.jl/stable/40-scientific-foundation/40-formulation/#Minimum-Output-Constraints-Without-Unit-Commitment).
+
 ### `cons_transport_flow_limit`
 
 - `dual_max_transport_flow_limit`: Dual of the constraint ["maximum transport flow limit"](https://tulipaenergy.github.io/TulipaEnergyModel.jl/stable/40-scientific-foundation/40-formulation/#Maximum-Transport-Flow-Limit).

--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -563,9 +563,20 @@ e^{\text{flow above min}}_{a,k_y,b_{k_y}} \geq 0  \quad
 \\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc basic}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
 ```
 
-### Minimum Output Constraints Without Unit Commitment
+#### Tight logical constraints for start-up and shut-down variables
 
-For producer and conversion assets without unit commitment, a minimum output flow can still be enforced using `min_operating_point > 0`.
+```math
+v^{\text{on}}_{a, k_y, b_{k_y}} - v^{\text{on}}_{a, k_y, (b_{k_y} - 1)} = v^{\text{start up}}_{a, k_y, b_{k_y}} - v^{\text{shut down}}_{a, k_y, b_{k_y}} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
+\\ v^{\text{start up}}_{a, k_y, b_{k_y}} \leq v^{\text{on}}_{a, k_y, b_{k_y}} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
+\\ v^{\text{shut down}}_{a, k_y, b_{k_y}} \leq v^{\text{available units}}_{a,y} - v^{\text{on}}_{a, k_y, b_{k_y}} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
+```
+
+### [Minimum Output Constraints Without Unit Commitment](@id min-output-constraints-without-unit-commitment)
+
+For producer and conversion assets without unit commitment, a minimum output flow can still be enforced using `min_operating_point > 0`. This is useful for modeling assets that have a minimum output requirement but do not need to be turned on or off, such as run-of-river hydro plants or certain types of chemical processes or must-run units.
 
 The formulation applies only to assets with `unit_commitment = 'none'`. It uses the sum of outgoing flows weighted by $p^{\text{capacity coefficient}}_{f,y}$, so output flows that do not contribute to productive capacity (for example, byproduct emissions with coefficient 0) do not tighten the minimum-output requirement.
 
@@ -577,17 +588,6 @@ The formulation applies only to assets with `unit_commitment = 'none'`. It uses 
 ```math
 \sum_{f \in \mathcal{F}^{\text{out}}_{a,y}} p^{\text{capacity coefficient}}_{f,y} \cdot v^{\text{flow}}_{f,k_y,b_{k_y}} \geq p^{\text{min operating point}}_{a,y} \cdot p^{\text{capacity}}_{a} \cdot \sum_{v \in \mathcal{V} \mid (a,y,v) \in \mathcal{D}^{\text{compact profiles}}} v^{\text{available units compact}}_{a,y,v} \quad
 \\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{compact profiles}} \cap (\mathcal{A}^{\text{p}} \cup \mathcal{A}^{\text{cv}}) \setminus \mathcal{A}^{\text{uc}}_y \;\text{with}\; p^{\text{min operating point}}_{a,y} > 0, \forall k_y \in \mathcal{K}_y, \forall b_{k_y} \in \mathcal{B}_{k_y}
-```
-
-#### Tight logical constraints for start-up and shut-down variables
-
-```math
-v^{\text{on}}_{a, k_y, b_{k_y}} - v^{\text{on}}_{a, k_y, (b_{k_y} - 1)} = v^{\text{start up}}_{a, k_y, b_{k_y}} - v^{\text{shut down}}_{a, k_y, b_{k_y}} \quad
-\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
-\\ v^{\text{start up}}_{a, k_y, b_{k_y}} \leq v^{\text{on}}_{a, k_y, b_{k_y}} \quad
-\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
-\\ v^{\text{shut down}}_{a, k_y, b_{k_y}} \leq v^{\text{available units}}_{a,y} - v^{\text{on}}_{a, k_y, b_{k_y}} \quad
-\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc 3var}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
 ```
 
 ### [Ramping Constraints](@id ramp-constraints)

--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -160,6 +160,8 @@ In addition, the following subsets represent methods for incorporating additiona
 
 #### Extra Parameters for Unit Commitment and Ramping Constraints
 
+The parameter $p^{\text{min operating point}}_{a,y}$ is also used for producer and conversion assets without unit commitment when `unit_commitment = 'none'` and `min_operating_point > 0`.
+
 | Name                                   | Domain           | Domains of Indices                  | Description                                                                                                              | Units          |
 | -------------------------------------- | ---------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------- |
 | $p^{\text{min operating point}}_{a,y}$ | $\mathbb{R}_{+}$ | $a \in \mathcal{A^{\text{uc}}}_y$   | Minimum operating point or minimum stable generation level defined as a portion of the capacity of asset $a$ at year $y$ | [p.u.]         |
@@ -559,6 +561,22 @@ e^{\text{flow above min}}_{a,y,k_y,b_{k_y}} \leq p^{\text{availability profile}}
 ```math
 e^{\text{flow above min}}_{a,k_y,b_{k_y}} \geq 0  \quad
 \\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{uc basic}}_y, \forall k_y \in \mathcal{K}_y,\forall b_{k_y} \in \mathcal{B}_{k_y}
+```
+
+### Minimum Output Constraints Without Unit Commitment
+
+For producer and conversion assets without unit commitment, a minimum output flow can still be enforced using `min_operating_point > 0`.
+
+The formulation applies only to assets with `unit_commitment = 'none'`. It uses the sum of outgoing flows weighted by $p^{\text{capacity coefficient}}_{f,y}$, so output flows that do not contribute to productive capacity (for example, byproduct emissions with coefficient 0) do not tighten the minimum-output requirement.
+
+```math
+\sum_{f \in \mathcal{F}^{\text{out}}_{a,y}} p^{\text{capacity coefficient}}_{f,y} \cdot v^{\text{flow}}_{f,k_y,b_{k_y}} \geq p^{\text{min operating point}}_{a,y} \cdot p^{\text{capacity}}_{a} \cdot v^{\text{available units aggregated}}_{a,y} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{aggregated}} \cap (\mathcal{A}^{\text{p}} \cup \mathcal{A}^{\text{cv}}) \setminus \mathcal{A}^{\text{uc}}_y \;\text{with}\; p^{\text{min operating point}}_{a,y} > 0, \forall k_y \in \mathcal{K}_y, \forall b_{k_y} \in \mathcal{B}_{k_y}
+```
+
+```math
+\sum_{f \in \mathcal{F}^{\text{out}}_{a,y}} p^{\text{capacity coefficient}}_{f,y} \cdot v^{\text{flow}}_{f,k_y,b_{k_y}} \geq p^{\text{min operating point}}_{a,y} \cdot p^{\text{capacity}}_{a} \cdot \sum_{v \in \mathcal{V} \mid (a,y,v) \in \mathcal{D}^{\text{compact profiles}}} v^{\text{available units compact}}_{a,y,v} \quad
+\\ \\ \forall y \in \mathcal{Y}, \forall a \in \mathcal{A}^{\text{compact profiles}} \cap (\mathcal{A}^{\text{p}} \cup \mathcal{A}^{\text{cv}}) \setminus \mathcal{A}^{\text{uc}}_y \;\text{with}\; p^{\text{min operating point}}_{a,y} > 0, \forall k_y \in \mathcal{K}_y, \forall b_{k_y} \in \mathcal{B}_{k_y}
 ```
 
 #### Tight logical constraints for start-up and shut-down variables

--- a/src/constraints/create.jl
+++ b/src/constraints/create.jl
@@ -17,6 +17,8 @@ function compute_constraints_indices(connection)
             :limit_units_on_compact_vintage_method,
             :limit_units_on_aggregated_vintage_method,
             :min_output_flow_with_unit_commitment,
+            :min_output_flow_without_unit_commitment_aggregated_vintage_method,
+            :min_output_flow_without_unit_commitment_compact_vintage_method,
             :max_output_flow_with_basic_unit_commitment,
             :max_ramp_with_unit_commitment,
             :max_ramp_without_unit_commitment,

--- a/src/constraints/min-output-flow.jl
+++ b/src/constraints/min-output-flow.jl
@@ -1,0 +1,131 @@
+"""
+    add_min_output_flow_without_unit_commitment_constraints!(
+        connection, model, expressions, constraints
+    )
+
+Adds the minimum output flow constraints for producer and conversion assets without
+unit commitment and a positive `min_operating_point`.
+
+The constraint enforces:
+```
+sum(capacity_coefficient * outgoing flows) >= min_operating_point [p.u.] * capacity [MW] * available_units [# of units]
+```
+
+This activates only when `unit_commitment = 'none'` and `min_operating_point > 0`.
+Assets with unit commitment already enforce a minimum output flow through the
+`min_output_flow_with_unit_commitment` constraint.
+
+Note that the `capacity_coefficient` ensures that when output flows are scaled down in the capacity constraints,
+they are also reflected in the minimum output flow constraint.
+This is particularly useful for outputs like CO2 emissions,
+which have a coefficient of zero because they do not contribute to the energy output flow and are regarded as byproducts.
+"""
+function add_min_output_flow_without_unit_commitment_constraints!(
+    connection,
+    model,
+    expressions,
+    constraints,
+)
+    expr_avail_aggregated_vintage_method =
+        expressions[:available_asset_units_aggregated_vintage_method].expressions[:assets]
+    expr_avail_compact_method =
+        expressions[:available_asset_units_compact_vintage_method].expressions[:assets]
+
+    # - Aggregated vintage method
+    let table_name = :min_output_flow_without_unit_commitment_aggregated_vintage_method,
+        cons = constraints[table_name]
+
+        indices = _append_min_output_flow_data_to_indices_aggregated_vintage_method(
+            connection,
+            table_name,
+        )
+        attach_constraint!(
+            model,
+            cons,
+            table_name,
+            [
+                @constraint(
+                    model,
+                    outgoing_flow ≥
+                    row.min_operating_point *
+                    row.capacity *
+                    expr_avail_aggregated_vintage_method[row.avail_id],
+                    base_name = "min_output_flow_without_unit_commitment_aggregated_vintage_method[$(row.asset),$(row.milestone_year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+                ) for (row, outgoing_flow) in zip(indices, cons.expressions[:outgoing])
+            ],
+        )
+    end
+
+    # - Compact profiles vintage method
+    let table_name = :min_output_flow_without_unit_commitment_compact_vintage_method,
+        cons = constraints[table_name]
+
+        indices = _append_min_output_flow_data_to_indices_compact_method(connection, table_name)
+        attach_constraint!(
+            model,
+            cons,
+            table_name,
+            [
+                @constraint(
+                    model,
+                    outgoing_flow ≥
+                    row.min_operating_point *
+                    row.capacity *
+                    sum(expr_avail_compact_method[avail_id] for avail_id in row.avail_indices),
+                    base_name = "min_output_flow_without_unit_commitment_compact_vintage_method[$(row.asset),$(row.milestone_year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
+                ) for (row, outgoing_flow) in zip(indices, cons.expressions[:outgoing])
+            ],
+        )
+    end
+
+    return
+end
+
+function _append_min_output_flow_data_to_indices_aggregated_vintage_method(connection, table_name)
+    return DuckDB.query(
+        connection,
+        "SELECT
+            cons.id,
+            cons.asset,
+            cons.milestone_year,
+            cons.rep_period,
+            cons.time_block_start,
+            cons.time_block_end,
+            asset.capacity,
+            asset.min_operating_point,
+            expr_avail.id AS avail_id,
+        FROM cons_$table_name AS cons
+        LEFT JOIN asset
+            ON cons.asset = asset.asset
+        LEFT JOIN expr_available_asset_units_aggregated_vintage_method AS expr_avail
+            ON cons.asset = expr_avail.asset
+            AND cons.milestone_year = expr_avail.milestone_year
+        ORDER BY cons.id
+        ",
+    )
+end
+
+function _append_min_output_flow_data_to_indices_compact_method(connection, table_name)
+    return DuckDB.query(
+        connection,
+        "SELECT
+            cons.id,
+            ANY_VALUE(cons.asset) AS asset,
+            ANY_VALUE(cons.milestone_year) AS milestone_year,
+            ANY_VALUE(cons.rep_period) AS rep_period,
+            ANY_VALUE(cons.time_block_start) AS time_block_start,
+            ANY_VALUE(cons.time_block_end) AS time_block_end,
+            ANY_VALUE(asset.capacity) AS capacity,
+            ANY_VALUE(asset.min_operating_point) AS min_operating_point,
+            ARRAY_AGG(expr_avail.id ORDER BY expr_avail.id) AS avail_indices,
+        FROM cons_$table_name AS cons
+        LEFT JOIN asset
+            ON cons.asset = asset.asset
+        LEFT JOIN expr_available_asset_units_compact_vintage_method AS expr_avail
+            ON cons.asset = expr_avail.asset
+            AND cons.milestone_year = expr_avail.milestone_year
+        GROUP BY cons.id
+        ORDER BY cons.id
+        ",
+    )
+end

--- a/src/constraints/min-output-flow.jl
+++ b/src/constraints/min-output-flow.jl
@@ -108,24 +108,32 @@ end
 function _append_min_output_flow_data_to_indices_compact_method(connection, table_name)
     return DuckDB.query(
         connection,
-        "SELECT
+        """
+        WITH avail_agg AS (
+        SELECT
+            asset,
+            milestone_year,
+            ARRAY_AGG(id ORDER BY id) AS avail_indices
+        FROM expr_available_asset_units_compact_vintage_method
+        GROUP BY asset, milestone_year
+        )
+        SELECT
             cons.id,
-            ANY_VALUE(cons.asset) AS asset,
-            ANY_VALUE(cons.milestone_year) AS milestone_year,
-            ANY_VALUE(cons.rep_period) AS rep_period,
-            ANY_VALUE(cons.time_block_start) AS time_block_start,
-            ANY_VALUE(cons.time_block_end) AS time_block_end,
-            ANY_VALUE(asset.capacity) AS capacity,
-            ANY_VALUE(asset.min_operating_point) AS min_operating_point,
-            ARRAY_AGG(expr_avail.id ORDER BY expr_avail.id) AS avail_indices,
+            cons.asset,
+            cons.milestone_year,
+            cons.rep_period,
+            cons.time_block_start,
+            cons.time_block_end,
+            asset.capacity,
+            asset.min_operating_point,
+            avail_agg.avail_indices,
         FROM cons_$table_name AS cons
         LEFT JOIN asset
             ON cons.asset = asset.asset
-        LEFT JOIN expr_available_asset_units_compact_vintage_method AS expr_avail
-            ON cons.asset = expr_avail.asset
-            AND cons.milestone_year = expr_avail.milestone_year
-        GROUP BY cons.id
+        LEFT JOIN avail_agg
+            ON cons.asset = avail_agg.asset
+            AND cons.milestone_year = avail_agg.milestone_year
         ORDER BY cons.id
-        ",
+        """,
     )
 end

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -243,6 +243,13 @@ function create_model(
         profiles,
     )
 
+    @timeit to "add_min_output_flow_without_unit_commitment_constraints!" add_min_output_flow_without_unit_commitment_constraints!(
+        connection,
+        model,
+        expressions,
+        constraints,
+    )
+
     @timeit to "add_flows_relationships_constraints!" add_flows_relationships_constraints!(
         connection,
         model,

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -711,7 +711,23 @@ function add_expressions_to_constraints!(connection, variables, constraints)
             workspace;
             use_highest_resolution = true,
             multiply_by_duration = false,
+            multiply_by_capacity_coefficient = true,
             add_min_outgoing_flow_duration = true,
+        )
+    end
+
+    for table_name in (
+        :min_output_flow_without_unit_commitment_aggregated_vintage_method,
+        :min_output_flow_without_unit_commitment_compact_vintage_method,
+    )
+        @timeit to "add_expression_terms_rep_period_constraints! for $table_name" add_expression_terms_rep_period_constraints!(
+            connection,
+            constraints[table_name],
+            variables[:flow],
+            workspace;
+            use_highest_resolution = true,
+            multiply_by_duration = false,
+            multiply_by_capacity_coefficient = true,
         )
     end
     @timeit to "add_expression_terms_inter_period_storage_constraints!" add_expression_terms_inter_period_storage_constraints!(

--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -439,6 +439,52 @@ drop sequence id
 create sequence id start 1
 ;
 
+drop table if exists cons_min_output_flow_without_unit_commitment_aggregated_vintage_method
+;
+
+create table cons_min_output_flow_without_unit_commitment_aggregated_vintage_method as
+select
+    nextval('id') as id,
+    t_high.*
+from
+    t_highest_out_flows as t_high
+    left join asset on t_high.asset = asset.asset
+where
+    asset.type in ('producer', 'conversion')
+    and asset.unit_commitment = 'none'
+    and asset.min_operating_point > 0
+    and asset.vintage_method = 'aggregated'
+;
+
+drop sequence id
+;
+
+create sequence id start 1
+;
+
+drop table if exists cons_min_output_flow_without_unit_commitment_compact_vintage_method
+;
+
+create table cons_min_output_flow_without_unit_commitment_compact_vintage_method as
+select
+    nextval('id') as id,
+    t_high.*
+from
+    t_highest_out_flows as t_high
+    left join asset on t_high.asset = asset.asset
+where
+    asset.type in ('producer', 'conversion')
+    and asset.unit_commitment = 'none'
+    and asset.min_operating_point > 0
+    and asset.vintage_method = 'compact_profiles'
+;
+
+drop sequence id
+;
+
+create sequence id start 1
+;
+
 drop table if exists cons_max_output_flow_with_basic_unit_commitment
 ;
 

--- a/test/test-constraint-min-output-flow.jl
+++ b/test/test-constraint-min-output-flow.jl
@@ -111,18 +111,7 @@ end
 
 @testitem "Test min output flow constraint - producer, aggregated, non-investable" setup =
     [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
-    config = ConsMinOutputFlowConfig(;
-        name = "wind",
-        asset_type = :producer,
-        vintage_method = "aggregated",
-        initial_units = 2.0,
-        capacity = 100.0,
-        min_operating_point = 0.4,
-        unit_commitment = "none",
-        investable = false,
-        num_timesteps = 1,
-        num_rps = 2,
-    )
+    config = ConsMinOutputFlowConfig(; name = "wind")
 
     connection, energy_problem = create_min_output_flow_test_problem(config)
     flow = energy_problem.variables[:flow].container
@@ -154,15 +143,9 @@ end
     # Use initial_units > 0 to verify both the constant and the investment term in the RHS.
     config = ConsMinOutputFlowConfig(;
         name = "wind",
-        asset_type = :producer,
-        vintage_method = "aggregated",
         initial_units = 1.0,
-        capacity = 100.0,
         min_operating_point = 0.5,
-        unit_commitment = "none",
         investable = true,
-        num_timesteps = 1,
-        num_rps = 2,
     )
 
     connection, energy_problem = create_min_output_flow_test_problem(config)
@@ -202,14 +185,9 @@ end
     config = ConsMinOutputFlowConfig(;
         name = "smr",
         asset_type = :conversion,
-        vintage_method = "aggregated",
         initial_units = 3.0,
         capacity = 50.0,
         min_operating_point = 0.3,
-        unit_commitment = "none",
-        investable = false,
-        num_timesteps = 1,
-        num_rps = 2,
     )
 
     connection, energy_problem = create_min_output_flow_test_problem(config)
@@ -245,14 +223,9 @@ end
     # flow has zero weight and must not affect the RHS lower bound.
     config = ConsMinOutputFlowConfig(;
         name = "ccgt",
-        asset_type = :producer,
         vintage_method = "aggregated",
-        initial_units = 1.0,
         capacity = 200.0,
         min_operating_point = 0.3,
-        unit_commitment = "none",
-        investable = false,
-        num_timesteps = 1,
         num_rps = 1,
         has_co2_output = true,
         co2_consumer_name = "atmosphere",
@@ -296,15 +269,10 @@ end
     [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
     config = ConsMinOutputFlowConfig(;
         name = "nuclear",
-        asset_type = :producer,
         vintage_method = "compact_profiles",
         initial_units = 3.0,
         capacity = 150.0,
         min_operating_point = 0.5,
-        unit_commitment = "none",
-        investable = false,
-        num_timesteps = 1,
-        num_rps = 2,
     )
 
     connection, energy_problem = create_min_output_flow_test_problem(config)
@@ -336,18 +304,7 @@ end
 
     # Assets with unit_commitment != 'none' use the min_output_flow_with_unit_commitment
     # mechanism instead; they must not appear in the without-UC constraint tables.
-    config = ConsMinOutputFlowConfig(;
-        name = "ccgt_uc",
-        asset_type = :producer,
-        vintage_method = "aggregated",
-        initial_units = 2.0,
-        capacity = 100.0,
-        min_operating_point = 0.4,
-        unit_commitment = "basic",
-        investable = false,
-        num_timesteps = 1,
-        num_rps = 1,
-    )
+    config = ConsMinOutputFlowConfig(; name = "ccgt_uc", unit_commitment = "basic", num_rps = 1)
 
     connection, energy_problem = create_min_output_flow_test_problem(config)
 
@@ -368,18 +325,7 @@ end
 
     # Assets with min_operating_point = 0 have no minimum output requirement,
     # so no constraint rows are created for them.
-    config = ConsMinOutputFlowConfig(;
-        name = "wind",
-        asset_type = :producer,
-        vintage_method = "aggregated",
-        initial_units = 2.0,
-        capacity = 100.0,
-        min_operating_point = 0.0,
-        unit_commitment = "none",
-        investable = false,
-        num_timesteps = 1,
-        num_rps = 1,
-    )
+    config = ConsMinOutputFlowConfig(; name = "wind", min_operating_point = 0.0, num_rps = 1)
 
     connection, energy_problem = create_min_output_flow_test_problem(config)
 

--- a/test/test-constraint-min-output-flow.jl
+++ b/test/test-constraint-min-output-flow.jl
@@ -1,0 +1,421 @@
+@testsnippet ConsMinOutputFlowSetup begin
+    using DuckDB: DuckDB
+    using TulipaBuilder: TulipaBuilder as TB
+    using TulipaClustering: TulipaClustering as TC
+
+    @kwdef struct ConsMinOutputFlowConfig
+        name::String = "producer"
+        asset_type::Symbol = :producer
+        vintage_method::String = "aggregated"
+        initial_units::Float64 = 2.0
+        capacity::Float64 = 100.0
+        min_operating_point::Float64 = 0.4
+        unit_commitment::String = "none"
+        investable::Bool = false
+        num_timesteps::Int = 1
+        num_rps::Int = 2
+        has_co2_output::Bool = false
+        co2_consumer_name::String = "co2_sink"
+    end
+
+    """
+        create_min_output_flow_test_problem(config::ConsMinOutputFlowConfig)
+
+    Create a minimum output flow test problem using the provided configuration.
+    Returns `(connection, energy_problem)`.
+    """
+    function create_min_output_flow_test_problem(config::ConsMinOutputFlowConfig)
+        tulipa = TB.TulipaData()
+
+        # Consumer asset to receive power output
+        TB.add_asset!(tulipa, "demand", :consumer; peak_demand = 200.0)
+
+        # For conversion assets, add an upstream producer feeding into the conversion plant
+        if config.asset_type == :conversion
+            TB.add_asset!(tulipa, "upstream", :producer; capacity = 300.0, initial_units = 1.0)
+        end
+
+        # The main asset under test
+        TB.add_asset!(
+            tulipa,
+            config.name,
+            config.asset_type;
+            capacity = config.capacity,
+            initial_units = config.initial_units,
+            min_operating_point = config.min_operating_point,
+            unit_commitment = config.unit_commitment,
+            vintage_method = config.vintage_method,
+            investable = config.investable,
+        )
+
+        # Outgoing flow to demand (capacity_coefficient defaults to 1.0)
+        TB.add_flow!(tulipa, config.name, "demand")
+
+        # Optional CO2 byproduct flow with capacity_coefficient = 0 (should not constrain output)
+        if config.has_co2_output
+            TB.add_asset!(tulipa, config.co2_consumer_name, :consumer)
+            TB.add_flow!(tulipa, config.name, config.co2_consumer_name; capacity_coefficient = 0.0)
+        end
+
+        # Incoming flow required by conversion assets
+        if config.asset_type == :conversion
+            TB.add_flow!(tulipa, "upstream", config.name)
+        end
+
+        # Attach an availability profile so TulipaClustering can cluster.
+        # One value per original period: num_rps periods of num_timesteps each.
+        profile_length = config.num_timesteps * config.num_rps
+        TB.attach_profile!(
+            tulipa,
+            config.name,
+            :availability,
+            2030,
+            ones(profile_length);
+            scenario = 1,
+        )
+
+        connection = TB.create_connection(tulipa, TEM.schema)
+
+        layout = TC.ProfilesTableLayout(; year = :milestone_year, cols_to_crossby = [:scenario])
+        TC.cluster!(connection, config.num_timesteps, config.num_rps; layout)
+
+        TEM.populate_with_defaults!(connection)
+        energy_problem = TEM.EnergyProblem(connection)
+        TEM.create_model!(energy_problem)
+
+        return (connection, energy_problem)
+    end
+
+    function get_min_output_flow_constraint_data(connection, asset_name, vintage_method)
+        table = "cons_min_output_flow_without_unit_commitment_$(vintage_method)_vintage_method"
+        return DuckDB.query(
+            connection,
+            """SELECT id, milestone_year, rep_period, time_block_start, time_block_end
+               FROM $table
+               WHERE asset = '$asset_name'
+               ORDER BY milestone_year, rep_period, time_block_start""",
+        )
+    end
+
+    function get_flow_var_id(connection, from_asset, to_asset, rep_period, time_block_start)
+        return TEM.get_single_element_from_query_and_ensure_its_only_one(
+            DuckDB.query(
+                connection,
+                """SELECT id FROM var_flow
+                   WHERE from_asset = '$from_asset' AND to_asset = '$to_asset'
+                   AND rep_period = $rep_period AND time_block_start = $time_block_start""",
+            ),
+        )::Int
+    end
+end
+
+@testitem "Test min output flow constraint - producer, aggregated, non-investable" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+    config = ConsMinOutputFlowConfig(;
+        name = "wind",
+        asset_type = :producer,
+        vintage_method = "aggregated",
+        initial_units = 2.0,
+        capacity = 100.0,
+        min_operating_point = 0.4,
+        unit_commitment = "none",
+        investable = false,
+        num_timesteps = 1,
+        num_rps = 2,
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+    flow = energy_problem.variables[:flow].container
+
+    constraint_data = get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+    @test (constraint_data |> collect |> length) == config.num_rps  # one constraint per rep period
+
+    for row in get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+        id = row.id
+        flow_id =
+            get_flow_var_id(connection, config.name, "demand", row.rep_period, row.time_block_start)
+
+        # Expected: flow >= min_operating_point * capacity * initial_units = 0.4 * 100.0 * 2.0 = 80.0
+        expected_cons = JuMP.@build_constraint(
+            flow[flow_id] >= config.min_operating_point * config.capacity * config.initial_units
+        )
+        @test _verify_constraint_using_id(
+            energy_problem.model,
+            :min_output_flow_without_unit_commitment_aggregated_vintage_method,
+            id,
+            expected_cons,
+        )
+    end
+end
+
+@testitem "Test min output flow constraint - producer, aggregated, investable" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+
+    # Use initial_units > 0 to verify both the constant and the investment term in the RHS.
+    config = ConsMinOutputFlowConfig(;
+        name = "wind",
+        asset_type = :producer,
+        vintage_method = "aggregated",
+        initial_units = 1.0,
+        capacity = 100.0,
+        min_operating_point = 0.5,
+        unit_commitment = "none",
+        investable = true,
+        num_timesteps = 1,
+        num_rps = 2,
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+    flow = energy_problem.variables[:flow].container
+
+    # Only the single investable producer has an investment variable
+    assets_investment = energy_problem.variables[:assets_investment].container[1]
+
+    constraint_data = get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+    @test (constraint_data |> collect |> length) == config.num_rps
+
+    for row in get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+        id = row.id
+        flow_id =
+            get_flow_var_id(connection, config.name, "demand", row.rep_period, row.time_block_start)
+
+        # Expected: flow >= min_op * capacity * (initial_units + assets_investment)
+        expected_cons = JuMP.@build_constraint(
+            flow[flow_id] >=
+            config.min_operating_point *
+            config.capacity *
+            (config.initial_units + assets_investment)
+        )
+        @test _verify_constraint_using_id(
+            energy_problem.model,
+            :min_output_flow_without_unit_commitment_aggregated_vintage_method,
+            id,
+            expected_cons,
+        )
+    end
+end
+
+@testitem "Test min output flow constraint - conversion asset, aggregated" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+
+    # Conversion assets are included in the constraint alongside producers.
+    config = ConsMinOutputFlowConfig(;
+        name = "smr",
+        asset_type = :conversion,
+        vintage_method = "aggregated",
+        initial_units = 3.0,
+        capacity = 50.0,
+        min_operating_point = 0.3,
+        unit_commitment = "none",
+        investable = false,
+        num_timesteps = 1,
+        num_rps = 2,
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+    flow = energy_problem.variables[:flow].container
+
+    constraint_data = get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+    @test (constraint_data |> collect |> length) == config.num_rps
+
+    for row in get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+        id = row.id
+        flow_id =
+            get_flow_var_id(connection, config.name, "demand", row.rep_period, row.time_block_start)
+
+        # Expected: flow >= min_op * capacity * initial_units = 0.3 * 50.0 * 3.0 = 45.0
+        expected_cons = JuMP.@build_constraint(
+            flow[flow_id] >= config.min_operating_point * config.capacity * config.initial_units
+        )
+        @test _verify_constraint_using_id(
+            energy_problem.model,
+            :min_output_flow_without_unit_commitment_aggregated_vintage_method,
+            id,
+            expected_cons,
+        )
+    end
+end
+
+@testitem "Test min output flow constraint - CO2 output with zero capacity coefficient" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+
+    # A producer with both an energy output (capacity_coefficient = 1, the default) and a CO2
+    # byproduct output (capacity_coefficient = 0). The min output flow constraint enforces a
+    # minimum on the summed outgoing expression weighted by capacity_coefficient, so the CO2
+    # flow has zero weight and must not affect the RHS lower bound.
+    config = ConsMinOutputFlowConfig(;
+        name = "ccgt",
+        asset_type = :producer,
+        vintage_method = "aggregated",
+        initial_units = 1.0,
+        capacity = 200.0,
+        min_operating_point = 0.3,
+        unit_commitment = "none",
+        investable = false,
+        num_timesteps = 1,
+        num_rps = 1,
+        has_co2_output = true,
+        co2_consumer_name = "atmosphere",
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+    flow = energy_problem.variables[:flow].container
+
+    constraint_data = get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+    @test (constraint_data |> collect |> length) == config.num_rps
+
+    for row in get_min_output_flow_constraint_data(connection, config.name, "aggregated")
+        id = row.id
+        energy_flow_id =
+            get_flow_var_id(connection, config.name, "demand", row.rep_period, row.time_block_start)
+        co2_flow_id = get_flow_var_id(
+            connection,
+            config.name,
+            config.co2_consumer_name,
+            row.rep_period,
+            row.time_block_start,
+        )
+
+        cons_ref =
+            energy_problem.model[:min_output_flow_without_unit_commitment_aggregated_vintage_method][id]
+        cons_obj = JuMP.constraint_object(cons_ref)
+
+        # The energy flow contributes with coefficient 1.0 (capacity_coefficient = 1)
+        @test isapprox(get(cons_obj.func.terms, flow[energy_flow_id], 0.0), 1.0)
+        # The CO2 flow does not contribute: its coefficient is 0.0 or absent entirely
+        @test isapprox(get(cons_obj.func.terms, flow[co2_flow_id], 0.0), 0.0)
+        # The RHS lower bound is based on the energy output capacity only
+        @test isapprox(
+            cons_obj.set.lower,
+            config.min_operating_point * config.capacity * config.initial_units,
+        )
+    end
+end
+
+@testitem "Test min output flow constraint - compact profiles vintage method" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+    config = ConsMinOutputFlowConfig(;
+        name = "nuclear",
+        asset_type = :producer,
+        vintage_method = "compact_profiles",
+        initial_units = 3.0,
+        capacity = 150.0,
+        min_operating_point = 0.5,
+        unit_commitment = "none",
+        investable = false,
+        num_timesteps = 1,
+        num_rps = 2,
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+    flow = energy_problem.variables[:flow].container
+
+    constraint_data = get_min_output_flow_constraint_data(connection, config.name, "compact")
+    @test (constraint_data |> collect |> length) == config.num_rps
+
+    for row in get_min_output_flow_constraint_data(connection, config.name, "compact")
+        id = row.id
+        flow_id =
+            get_flow_var_id(connection, config.name, "demand", row.rep_period, row.time_block_start)
+
+        # Expected: flow >= min_op * capacity * initial_units = 0.5 * 150.0 * 3.0 = 225.0
+        expected_cons = JuMP.@build_constraint(
+            flow[flow_id] >= config.min_operating_point * config.capacity * config.initial_units
+        )
+        @test _verify_constraint_using_id(
+            energy_problem.model,
+            :min_output_flow_without_unit_commitment_compact_vintage_method,
+            id,
+            expected_cons,
+        )
+    end
+end
+
+@testitem "Test min output flow constraint - unit commitment asset is excluded" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+
+    # Assets with unit_commitment != 'none' use the min_output_flow_with_unit_commitment
+    # mechanism instead; they must not appear in the without-UC constraint tables.
+    config = ConsMinOutputFlowConfig(;
+        name = "ccgt_uc",
+        asset_type = :producer,
+        vintage_method = "aggregated",
+        initial_units = 2.0,
+        capacity = 100.0,
+        min_operating_point = 0.4,
+        unit_commitment = "basic",
+        investable = false,
+        num_timesteps = 1,
+        num_rps = 1,
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+
+    @test (
+        get_min_output_flow_constraint_data(connection, config.name, "aggregated") |>
+        collect |>
+        length
+    ) == 0
+    @test (
+        get_min_output_flow_constraint_data(connection, config.name, "compact") |>
+        collect |>
+        length
+    ) == 0
+end
+
+@testitem "Test min output flow constraint - zero min operating point is excluded" setup =
+    [CommonSetup, ConsMinOutputFlowSetup] tags = [:unit, :constraint, :fast] begin
+
+    # Assets with min_operating_point = 0 have no minimum output requirement,
+    # so no constraint rows are created for them.
+    config = ConsMinOutputFlowConfig(;
+        name = "wind",
+        asset_type = :producer,
+        vintage_method = "aggregated",
+        initial_units = 2.0,
+        capacity = 100.0,
+        min_operating_point = 0.0,
+        unit_commitment = "none",
+        investable = false,
+        num_timesteps = 1,
+        num_rps = 1,
+    )
+
+    connection, energy_problem = create_min_output_flow_test_problem(config)
+
+    @test (
+        get_min_output_flow_constraint_data(connection, config.name, "aggregated") |>
+        collect |>
+        length
+    ) == 0
+    @test (
+        get_min_output_flow_constraint_data(connection, config.name, "compact") |>
+        collect |>
+        length
+    ) == 0
+end
+
+@testitem "Test minimum_flow_limit constraint activates correctly in a full solve" setup =
+    [CommonSetup] tags = [:integration, :validation, :fast] begin
+    # Load the Tiny dataset and modify it so that an asset has a minimum output flow
+    # constraint without unit commitment.
+    connection = DBInterface.connect(DuckDB.DB)
+    _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+
+    # ens has initial_units = 1 and is a producer with unit_commitment = 'none'.
+    # Setting min_operating_point = 0.1 enforces a minimum output:
+    #   min_output = 0.1 * capacity(1115) * initial_units(1) = 111.5 MW
+    DuckDB.query(
+        connection,
+        "UPDATE asset SET min_operating_point = 0.1 WHERE asset = 'ens' AND type = 'producer'",
+    )
+
+    energy_problem = TulipaEnergyModel.EnergyProblem(connection)
+    TulipaEnergyModel.create_model!(energy_problem)
+    TulipaEnergyModel.solve_model!(energy_problem)
+
+    @test energy_problem.solved
+    # The must-run constraint forces ens to produce at least min_op * capacity * initial_units = 111.5 MW,
+    # increasing cost vs. the baseline (ens must dispatch even when cheaper options exist).
+    @test energy_problem.objective_value > 269238.43825
+end


### PR DESCRIPTION
The implementation includes:

- **SQL**: Two new `cons_min_output_flow_without_unit_commitment_*` tables in create-constraints.sql
- **Registration**: Keys added to create.jl
- **Constraint logic**: New file min-output-flow.jl with aggregated and compact vintage method variants
- **Expression attachment**: Loop added in model-preparation.jl
- **Add to the Model**: `@timeit` call added in create-model.jl
- **Tests**: test-constraint-min-output-flow.jl
- **Update docs**: update the formulation, how-to, and outputs sections in the docs.

For the test, different edge cases are included:
- producer, aggregated, non-investable
- producer, aggregated, investable
- conversion asset, aggregated
- CO2 output with zero capacity coefficient
- compact profiles vintage method
- unit commitment asset is excluded
- zero min operating point is excluded
- full solve integration test

## Related issues

Closes #1597

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
