### PR TITLE
Refactor objective function for CVaR

### DIFF
--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -368,13 +368,13 @@ This definition of the discount factor at year $y$ includes the discounts for th
 
 ### Objective Function
 
-The objective function is formulated as a two-stage stochastic optimization problem, where the investment decisions are the first-stage variables and the expected value of the operation variables is in the second stage. When the risk aversion weight $p^{\lambda} > 0$ and there are multiple stochastic scenarios ($|\mathcal{S}| > 1$), the model uses a mean-CVaR (Conditional Value at Risk) formulation to incorporate risk into the objective.
+The objective function is formulated as a two-stage stochastic optimization problem, where the investment decisions are the first-stage variables and the expected value of the operation variables is in the second stage. When the risk aversion weight $p^{\lambda} > 0$ and there are multiple stochastic scenarios ($|\mathcal{S}| > 1$), the model uses a mean-CVaR (Conditional Value at Risk) formulation to incorporate risk into the objective to the operation costs (i.e., the risk measure only applies to uncertain quantities).
 
 ```math
 \begin{aligned}
-\text{{minimize}} \quad & (1 - p^{\lambda}) \cdot \bigg[ assets\_investment\_cost + assets\_fixed\_cost \\
-                        & + flows\_investment\_cost + flows\_fixed\_cost \\
-                        & + \sum_{s \in \mathcal{S}} p^{\text{probability}}_{s} \cdot (flows\_operational\_cost_{s} + unit\_on\_cost_{s}) \bigg] \\
+\text{{minimize}} & \quad assets\_investment\_cost +assets\_fixed\_cost \\
+                  & + flows\_investment\_cost + flows\_fixed\_cost \\
+                  & + (1 - p^{\lambda}) \cdot \bigg[\sum_{s \in \mathcal{S}} p^{\text{probability}}_{s} \cdot (flows\_operational\_cost_{s} + unit\_on\_cost_{s}) \bigg] \\
                         & + p^{\lambda} \cdot \text{CVaR}_{p^{\alpha}}
 \end{aligned}
 ```
@@ -938,25 +938,23 @@ These constraints apply to assets in a group using the vintage method $\mathcal{
 
 ### [Conditional Value at Risk Constraints](@id cvar-constraints)
 
-These constraints are only active when $p^{\lambda} > 0$ and $|\mathcal{S}| > 1$. They relate the tail excess slack variable $v^{\xi}_{s}$ to the total system cost per scenario and the Value at Risk threshold $v^{\mu}$.
+These constraints are only active when $p^{\lambda} > 0$ and $|\mathcal{S}| > 1$. They relate the tail excess slack variable $v^{\xi}_{s}$ to the total operational cost per scenario and the Value at Risk threshold $v^{\mu}$.
 
 #### Scenario Tail Excess Constraint
 
-For each stochastic scenario $s$, the non-negative tail excess slack variable $v^{\xi}_{s}$ captures the amount by which the total system cost in scenario $s$ exceeds the Value at Risk threshold $v^{\mu}$:
+For each stochastic scenario $s$, the non-negative tail excess slack variable $v^{\xi}_{s}$ captures the amount by which the total operational cost in scenario $s$ exceeds the Value at Risk threshold $v^{\mu}$:
 
 ```math
 \begin{aligned}
-v^{\xi}_{s} \geq total\_cost_{s} - v^{\mu} \quad \forall s \in \mathcal{S}
+v^{\xi}_{s} \geq total\_operational\_cost_{s} - v^{\mu} \quad \forall s \in \mathcal{S}
 \end{aligned}
 ```
 
-where the total cost per scenario $s$ is:
+where the total operational cost per scenario $s$ is:
 
 ```math
 \begin{aligned}
-total\_cost_{s} = & \; assets\_investment\_cost + assets\_fixed\_cost \\
-                  & + flows\_investment\_cost + flows\_fixed\_cost \\
-                  & + flows\_operational\_cost_{s} + unit\_on\_cost_{s}
+total\_operational\_cost_{s} = & \; flows\_operational\_cost_{s} + unit\_on\_cost_{s}
 \end{aligned}
 ```
 

--- a/src/constraints/conditional_value_at_risk.jl
+++ b/src/constraints/conditional_value_at_risk.jl
@@ -31,8 +31,8 @@ function add_scenario_tail_excess_constraints!(
             return nothing
         end
         var_tail_excess_slack_xi = variables[:tail_excess_slack_xi].container
-        total_cost_per_scenario =
-            expressions[:scenario_tail_excess].expressions[:total_cost_per_scenario]
+        total_operational_cost_per_scenario =
+            expressions[:scenario_tail_excess].expressions[:total_operational_cost_per_scenario]
         var_value_at_risk_threshold_mu = variables[:value_at_risk_threshold_mu].container[1]
         attach_constraint!(
             model,
@@ -42,7 +42,8 @@ function add_scenario_tail_excess_constraints!(
                 @constraint(
                     model,
                     var_tail_excess_slack_xi[row.id::Int64] >=
-                    total_cost_per_scenario[row.id::Int64] - var_value_at_risk_threshold_mu,
+                    total_operational_cost_per_scenario[row.id::Int64] -
+                    var_value_at_risk_threshold_mu,
                     base_name = "$table_name[$(row.scenario)]"
                 ) for row in indices
             ],

--- a/src/expressions/conditional_value_at_risk.jl
+++ b/src/expressions/conditional_value_at_risk.jl
@@ -19,14 +19,68 @@ function add_scenario_tail_excess_expressions!(connection, model, variables, exp
 
     expressions[:scenario_tail_excess] = TulipaExpression(connection, "expr_scenario_tail_excess")
 
+    # if isempty(variables[:tail_excess_slack_xi].container)
+    #     attach_expression!(
+    #         expressions[:scenario_tail_excess],
+    #         :total_cost_per_scenario,
+    #         JuMP.AffExpr[],
+    #     )
+    #     return nothing
+    # end
+
     if isempty(variables[:tail_excess_slack_xi].container)
         attach_expression!(
             expressions[:scenario_tail_excess],
-            :total_cost_per_scenario,
+            :total_operational_cost_per_scenario,
             JuMP.AffExpr[],
         )
         return nothing
     end
+
+    # let table_name = :scenario_tail_excess, expr = expressions[table_name]
+    #     n = expr.num_rows
+
+    #     # Costs that do not depend on scenario (from src/objectives/*.jl)
+    #     base_cost = JuMP.AffExpr(0.0)
+    #     for objective_name in (
+    #         :assets_investment_cost,
+    #         :assets_fixed_cost_compact_method,
+    #         :assets_fixed_cost_simple_method,
+    #         :assets_fixed_cost_compact_vintage_method,
+    #         :assets_fixed_cost_aggregated_vintage_method,
+    #         :storage_assets_energy_investment_cost,
+    #         :storage_assets_energy_fixed_cost,
+    #         :flows_investment_cost,
+    #         :flows_fixed_cost,
+    #     )
+    #         if haskey(model, objective_name)
+    #             JuMP.add_to_expression!(base_cost, model[objective_name])
+    #         end
+    #     end
+
+    #     attach_expression!(expr, :base_cost, fill(base_cost, expr.num_rows))
+
+    #     # Costs that depend on scenario (from src/objectives/*.jl)
+    #     flows_operational_cost_per_scenario =
+    #         expressions[:flows_operational_cost_per_scenario].expressions[:cost]
+    #     vintage_flows_operational_cost_per_scenario =
+    #         expressions[:vintage_flows_operational_cost_per_scenario].expressions[:cost]
+    #     units_on_operational_cost_per_scenario =
+    #         expressions[:units_on_operational_cost_per_scenario].expressions[:cost]
+
+    #     # Construct the total cost per scenario expression for each scenario
+    #     total_cost_per_scenario = Vector{JuMP.AffExpr}(undef, expr.num_rows)
+    #     for i in 1:expr.num_rows
+    #         scenario_cost = JuMP.AffExpr(0.0)
+    #         JuMP.add_to_expression!(scenario_cost, base_cost)
+    #         JuMP.add_to_expression!(scenario_cost, flows_operational_cost_per_scenario[i])
+    #         JuMP.add_to_expression!(scenario_cost, vintage_flows_operational_cost_per_scenario[i])
+    #         JuMP.add_to_expression!(scenario_cost, units_on_operational_cost_per_scenario[i])
+    #         total_cost_per_scenario[i] = scenario_cost
+    #     end
+
+    #     attach_expression!(expr, :total_cost_per_scenario, total_cost_per_scenario)
+    # end
 
     let table_name = :scenario_tail_excess, expr = expressions[table_name]
         n = expr.num_rows
@@ -56,17 +110,20 @@ function add_scenario_tail_excess_expressions!(connection, model, variables, exp
             expressions[:units_on_operational_cost_per_scenario].expressions[:cost]
 
         # Construct the total cost per scenario expression for each scenario
-        total_cost_per_scenario = Vector{JuMP.AffExpr}(undef, expr.num_rows)
+        total_operational_cost_per_scenario = Vector{JuMP.AffExpr}(undef, expr.num_rows)
         for i in 1:expr.num_rows
             scenario_cost = JuMP.AffExpr(0.0)
-            JuMP.add_to_expression!(scenario_cost, base_cost)
             JuMP.add_to_expression!(scenario_cost, flows_operational_cost_per_scenario[i])
             JuMP.add_to_expression!(scenario_cost, vintage_flows_operational_cost_per_scenario[i])
             JuMP.add_to_expression!(scenario_cost, units_on_operational_cost_per_scenario[i])
-            total_cost_per_scenario[i] = scenario_cost
+            total_operational_cost_per_scenario[i] = scenario_cost
         end
 
-        attach_expression!(expr, :total_cost_per_scenario, total_cost_per_scenario)
+        attach_expression!(
+            expr,
+            :total_operational_cost_per_scenario,
+            total_operational_cost_per_scenario,
+        )
     end
 
     return nothing

--- a/src/expressions/conditional_value_at_risk.jl
+++ b/src/expressions/conditional_value_at_risk.jl
@@ -19,15 +19,6 @@ function add_scenario_tail_excess_expressions!(connection, model, variables, exp
 
     expressions[:scenario_tail_excess] = TulipaExpression(connection, "expr_scenario_tail_excess")
 
-    # if isempty(variables[:tail_excess_slack_xi].container)
-    #     attach_expression!(
-    #         expressions[:scenario_tail_excess],
-    #         :total_cost_per_scenario,
-    #         JuMP.AffExpr[],
-    #     )
-    #     return nothing
-    # end
-
     if isempty(variables[:tail_excess_slack_xi].container)
         attach_expression!(
             expressions[:scenario_tail_excess],
@@ -37,69 +28,8 @@ function add_scenario_tail_excess_expressions!(connection, model, variables, exp
         return nothing
     end
 
-    # let table_name = :scenario_tail_excess, expr = expressions[table_name]
-    #     n = expr.num_rows
-
-    #     # Costs that do not depend on scenario (from src/objectives/*.jl)
-    #     base_cost = JuMP.AffExpr(0.0)
-    #     for objective_name in (
-    #         :assets_investment_cost,
-    #         :assets_fixed_cost_compact_method,
-    #         :assets_fixed_cost_simple_method,
-    #         :assets_fixed_cost_compact_vintage_method,
-    #         :assets_fixed_cost_aggregated_vintage_method,
-    #         :storage_assets_energy_investment_cost,
-    #         :storage_assets_energy_fixed_cost,
-    #         :flows_investment_cost,
-    #         :flows_fixed_cost,
-    #     )
-    #         if haskey(model, objective_name)
-    #             JuMP.add_to_expression!(base_cost, model[objective_name])
-    #         end
-    #     end
-
-    #     attach_expression!(expr, :base_cost, fill(base_cost, expr.num_rows))
-
-    #     # Costs that depend on scenario (from src/objectives/*.jl)
-    #     flows_operational_cost_per_scenario =
-    #         expressions[:flows_operational_cost_per_scenario].expressions[:cost]
-    #     vintage_flows_operational_cost_per_scenario =
-    #         expressions[:vintage_flows_operational_cost_per_scenario].expressions[:cost]
-    #     units_on_operational_cost_per_scenario =
-    #         expressions[:units_on_operational_cost_per_scenario].expressions[:cost]
-
-    #     # Construct the total cost per scenario expression for each scenario
-    #     total_cost_per_scenario = Vector{JuMP.AffExpr}(undef, expr.num_rows)
-    #     for i in 1:expr.num_rows
-    #         scenario_cost = JuMP.AffExpr(0.0)
-    #         JuMP.add_to_expression!(scenario_cost, base_cost)
-    #         JuMP.add_to_expression!(scenario_cost, flows_operational_cost_per_scenario[i])
-    #         JuMP.add_to_expression!(scenario_cost, vintage_flows_operational_cost_per_scenario[i])
-    #         JuMP.add_to_expression!(scenario_cost, units_on_operational_cost_per_scenario[i])
-    #         total_cost_per_scenario[i] = scenario_cost
-    #     end
-
-    #     attach_expression!(expr, :total_cost_per_scenario, total_cost_per_scenario)
-    # end
-
     let table_name = :scenario_tail_excess, expr = expressions[table_name]
         n = expr.num_rows
-
-        # Costs that do not depend on scenario (from src/objectives/*.jl)
-        base_cost = JuMP.AffExpr(0.0)
-        for objective_name in (
-            :assets_investment_cost,
-            :assets_fixed_cost_compact_vintage_method,
-            :assets_fixed_cost_aggregated_vintage_method,
-            :storage_assets_energy_investment_cost,
-            :storage_assets_energy_fixed_cost,
-            :flows_investment_cost,
-            :flows_fixed_cost,
-        )
-            if haskey(model, objective_name)
-                JuMP.add_to_expression!(base_cost, model[objective_name])
-            end
-        end
 
         # Costs that depend on scenario (from src/objectives/*.jl)
         flows_operational_cost_per_scenario =
@@ -110,8 +40,8 @@ function add_scenario_tail_excess_expressions!(connection, model, variables, exp
             expressions[:units_on_operational_cost_per_scenario].expressions[:cost]
 
         # Construct the total cost per scenario expression for each scenario
-        total_operational_cost_per_scenario = Vector{JuMP.AffExpr}(undef, expr.num_rows)
-        for i in 1:expr.num_rows
+        total_operational_cost_per_scenario = Vector{JuMP.AffExpr}(undef, n)
+        for i in 1:n
             scenario_cost = JuMP.AffExpr(0.0)
             JuMP.add_to_expression!(scenario_cost, flows_operational_cost_per_scenario[i])
             JuMP.add_to_expression!(scenario_cost, vintage_flows_operational_cost_per_scenario[i])

--- a/src/objectives/assets_fixed_cost_aggregated_vintage_method.jl
+++ b/src/objectives/assets_fixed_cost_aggregated_vintage_method.jl
@@ -3,7 +3,6 @@ function _add_assets_fixed_cost_aggregated_vintage_method!(
     model,
     expressions,
     objective_expr,
-    lambda,
 )
     expr_available_asset_units_aggregated_vintage_method =
         expressions[:available_asset_units_aggregated_vintage_method]
@@ -39,7 +38,7 @@ function _add_assets_fixed_cost_aggregated_vintage_method!(
         connection,
         objective_expr,
         "assets_fixed_cost_aggregated_vintage_method",
-        (1 - lambda) * assets_fixed_cost_aggregated_vintage_method,
+        assets_fixed_cost_aggregated_vintage_method,
     )
 
     return

--- a/src/objectives/assets_fixed_cost_compact_vintage_method.jl
+++ b/src/objectives/assets_fixed_cost_compact_vintage_method.jl
@@ -3,7 +3,6 @@ function _add_assets_fixed_cost_compact_vintage_method!(
     model,
     expressions,
     objective_expr,
-    lambda,
 )
     expr_available_asset_units_compact_vintage_method =
         expressions[:available_asset_units_compact_vintage_method]
@@ -39,7 +38,7 @@ function _add_assets_fixed_cost_compact_vintage_method!(
         connection,
         objective_expr,
         "assets_fixed_cost_compact_vintage_method",
-        (1 - lambda) * assets_fixed_cost_compact_vintage_method,
+        assets_fixed_cost_compact_vintage_method,
     )
 
     return

--- a/src/objectives/assets_investment_cost.jl
+++ b/src/objectives/assets_investment_cost.jl
@@ -1,4 +1,4 @@
-function _add_assets_investment_cost!(connection, model, variables, objective_expr, lambda)
+function _add_assets_investment_cost!(connection, model, variables, objective_expr)
     assets_investment = variables[:assets_investment]
 
     indices = DuckDB.query(
@@ -25,12 +25,7 @@ function _add_assets_investment_cost!(connection, model, variables, objective_ex
             (row, asset_investment) in zip(indices, assets_investment.container)
         )
     )
-    _add_to_objective!(
-        connection,
-        objective_expr,
-        "assets_investment_cost",
-        (1 - lambda) * assets_investment_cost,
-    )
+    _add_to_objective!(connection, objective_expr, "assets_investment_cost", assets_investment_cost)
 
     return
 end

--- a/src/objectives/create.jl
+++ b/src/objectives/create.jl
@@ -29,32 +29,18 @@ function add_objective!(connection, model, variables, expressions, model_paramet
         )""",
     )
     objective_expr = JuMP.AffExpr(0.0)
-
-    _add_assets_investment_cost!(connection, model, variables, objective_expr, lambda)
-    _add_assets_fixed_cost_compact_vintage_method!(
-        connection,
-        model,
-        expressions,
-        objective_expr,
-        lambda,
-    )
+    _add_assets_investment_cost!(connection, model, variables, objective_expr)
+    _add_assets_fixed_cost_compact_vintage_method!(connection, model, expressions, objective_expr)
     _add_assets_fixed_cost_aggregated_vintage_method!(
         connection,
         model,
         expressions,
         objective_expr,
-        lambda,
     )
-    _add_storage_assets_energy_investment_cost!(
-        connection,
-        model,
-        variables,
-        objective_expr,
-        lambda,
-    )
-    _add_storage_assets_energy_fixed_cost!(connection, model, expressions, objective_expr, lambda)
-    _add_flows_investment_cost!(connection, model, variables, objective_expr, lambda)
-    _add_flows_fixed_cost!(connection, model, expressions, objective_expr, lambda)
+    _add_storage_assets_energy_investment_cost!(connection, model, variables, objective_expr)
+    _add_storage_assets_energy_fixed_cost!(connection, model, expressions, objective_expr)
+    _add_flows_investment_cost!(connection, model, variables, objective_expr)
+    _add_flows_fixed_cost!(connection, model, expressions, objective_expr)
     _add_flows_operational_cost!(connection, model, expressions, objective_expr, lambda)
     _add_vintage_flows_operational_cost!(connection, model, expressions, objective_expr, lambda)
     _add_units_on_operational_cost!(connection, model, expressions, objective_expr, lambda)

--- a/src/objectives/create.jl
+++ b/src/objectives/create.jl
@@ -29,6 +29,8 @@ function add_objective!(connection, model, variables, expressions, model_paramet
         )""",
     )
     objective_expr = JuMP.AffExpr(0.0)
+
+    # Add components that do not depend on scenario
     _add_assets_investment_cost!(connection, model, variables, objective_expr)
     _add_assets_fixed_cost_compact_vintage_method!(connection, model, expressions, objective_expr)
     _add_assets_fixed_cost_aggregated_vintage_method!(
@@ -41,6 +43,8 @@ function add_objective!(connection, model, variables, expressions, model_paramet
     _add_storage_assets_energy_fixed_cost!(connection, model, expressions, objective_expr)
     _add_flows_investment_cost!(connection, model, variables, objective_expr)
     _add_flows_fixed_cost!(connection, model, expressions, objective_expr)
+
+    # Add components that depend on scenario
     _add_flows_operational_cost!(connection, model, expressions, objective_expr, lambda)
     _add_vintage_flows_operational_cost!(connection, model, expressions, objective_expr, lambda)
     _add_units_on_operational_cost!(connection, model, expressions, objective_expr, lambda)

--- a/src/objectives/flows_fixed_cost.jl
+++ b/src/objectives/flows_fixed_cost.jl
@@ -1,4 +1,4 @@
-function _add_flows_fixed_cost!(connection, model, expressions, objective_expr, lambda)
+function _add_flows_fixed_cost!(connection, model, expressions, objective_expr)
     expr_available_flow_units_aggregated_vintage_method =
         expressions[:available_flow_units_aggregated_vintage_method]
 
@@ -35,12 +35,7 @@ function _add_flows_fixed_cost!(connection, model, expressions, objective_expr, 
             )
         )
     )
-    _add_to_objective!(
-        connection,
-        objective_expr,
-        "flows_fixed_cost",
-        (1 - lambda) * flows_fixed_cost,
-    )
+    _add_to_objective!(connection, objective_expr, "flows_fixed_cost", flows_fixed_cost)
 
     return
 end

--- a/src/objectives/flows_investment_cost.jl
+++ b/src/objectives/flows_investment_cost.jl
@@ -1,4 +1,4 @@
-function _add_flows_investment_cost!(connection, model, variables, objective_expr, lambda)
+function _add_flows_investment_cost!(connection, model, variables, objective_expr)
     flows_investment = variables[:flows_investment]
 
     indices = DuckDB.query(
@@ -26,12 +26,7 @@ function _add_flows_investment_cost!(connection, model, variables, objective_exp
             (row, flow_investment) in zip(indices, flows_investment.container)
         )
     )
-    _add_to_objective!(
-        connection,
-        objective_expr,
-        "flows_investment_cost",
-        (1 - lambda) * flows_investment_cost,
-    )
+    _add_to_objective!(connection, objective_expr, "flows_investment_cost", flows_investment_cost)
 
     return
 end

--- a/src/objectives/storage_assets_energy_fixed_cost.jl
+++ b/src/objectives/storage_assets_energy_fixed_cost.jl
@@ -1,10 +1,4 @@
-function _add_storage_assets_energy_fixed_cost!(
-    connection,
-    model,
-    expressions,
-    objective_expr,
-    lambda,
-)
+function _add_storage_assets_energy_fixed_cost!(connection, model, expressions, objective_expr)
     expr_available_energy_units_aggregated_vintage_method =
         expressions[:available_energy_units_aggregated_vintage_method]
 
@@ -39,7 +33,7 @@ function _add_storage_assets_energy_fixed_cost!(
         connection,
         objective_expr,
         "storage_assets_energy_fixed_cost",
-        (1 - lambda) * storage_assets_energy_fixed_cost,
+        storage_assets_energy_fixed_cost,
     )
 
     return

--- a/src/objectives/storage_assets_energy_investment_cost.jl
+++ b/src/objectives/storage_assets_energy_investment_cost.jl
@@ -1,10 +1,4 @@
-function _add_storage_assets_energy_investment_cost!(
-    connection,
-    model,
-    variables,
-    objective_expr,
-    lambda,
-)
+function _add_storage_assets_energy_investment_cost!(connection, model, variables, objective_expr)
     assets_investment_energy = variables[:assets_investment_energy]
 
     indices = DuckDB.query(
@@ -35,7 +29,7 @@ function _add_storage_assets_energy_investment_cost!(
         connection,
         objective_expr,
         "storage_assets_energy_investment_cost",
-        (1 - lambda) * storage_assets_energy_investment_cost,
+        storage_assets_energy_investment_cost,
     )
 
     return

--- a/test/test-constraint-scenario-tail-excess.jl
+++ b/test/test-constraint-scenario-tail-excess.jl
@@ -128,21 +128,9 @@ end
     expressions = energy_problem.expressions
 
     # Extract the variables
-    assets_investment = variables[:assets_investment].container[1]
-    assets_decommission = variables[:assets_decommission].container[1]
     flow = variables[:flow].container
     tail_excess_vars = variables[:tail_excess_slack_xi].container
     value_at_risk_threshold_mu = only(variables[:value_at_risk_threshold_mu].container)
-
-    # Create expected base cost (scenario independent part of the cost expression)
-    constant_cost = asset.capacity * asset.initial_units * asset.fixed_cost
-    investment_cost = asset.capacity * (asset.investment_cost + asset.fixed_cost)
-    decommission_cost = -1.0 * asset.capacity * asset.fixed_cost
-    base_cost = JuMP.AffExpr(constant_cost)
-    for (coef, var) in
-        ((investment_cost, assets_investment), (decommission_cost, assets_decommission))
-        JuMP.add_to_expression!(base_cost, coef, var)
-    end
 
     # Create expected flows operational cost per scenario
     weight_lookup = create_weight_lookup(connection)
@@ -164,12 +152,9 @@ end
 
     for row in scenario_tail_excess_indices
         id, scenario = row.id, row.scenario
-        cost_per_scenario = JuMP.AffExpr(0.0)
-        JuMP.add_to_expression!(cost_per_scenario, base_cost)
-        JuMP.add_to_expression!(cost_per_scenario, operational_cost_per_scenario[scenario])
-
         expected_cons = JuMP.@build_constraint(
-            tail_excess_vars[id] >= cost_per_scenario - value_at_risk_threshold_mu
+            tail_excess_vars[id] >=
+            operational_cost_per_scenario[scenario] - value_at_risk_threshold_mu
         )
         @test _verify_constraint_using_id(model, :scenario_tail_excess, id, expected_cons)
     end
@@ -196,28 +181,13 @@ end
     TulipaEnergyModel.create_model!(energy_problem)
 
     total_cost_per_scenario =
-        energy_problem.expressions[:scenario_tail_excess].expressions[:total_cost_per_scenario]
+        energy_problem.expressions[:scenario_tail_excess].expressions[:total_operational_cost_per_scenario]
 
     model = energy_problem.model
     scenario_tail_excess_indices = energy_problem.constraints[:scenario_tail_excess].indices
     tail_excess_vars = energy_problem.variables[:tail_excess_slack_xi].container
     value_at_risk_threshold_mu =
         only(energy_problem.variables[:value_at_risk_threshold_mu].container)
-
-    base_cost = JuMP.AffExpr(0.0)
-    for objective_name in (
-        :assets_investment_cost,
-        :assets_fixed_cost_compact_vintage_method,
-        :assets_fixed_cost_aggregated_vintage_method,
-        :storage_assets_energy_investment_cost,
-        :storage_assets_energy_fixed_cost,
-        :flows_investment_cost,
-        :flows_fixed_cost,
-    )
-        if haskey(model, objective_name)
-            JuMP.add_to_expression!(base_cost, model[objective_name])
-        end
-    end
 
     flows_operational_cost_per_scenario = Dict(
         row.scenario =>
@@ -239,7 +209,6 @@ end
     for row in scenario_tail_excess_indices
         id, scenario = row.id, row.scenario
         cost_per_scenario = JuMP.AffExpr(0.0)
-        JuMP.add_to_expression!(cost_per_scenario, base_cost)
         JuMP.add_to_expression!(cost_per_scenario, flows_operational_cost_per_scenario[scenario])
         JuMP.add_to_expression!(
             cost_per_scenario,
@@ -269,7 +238,7 @@ end
 
     # Check that no constraints were created for scenario tail excess
     @test isempty(
-        energy_problem.expressions[:scenario_tail_excess].expressions[:total_cost_per_scenario],
+        energy_problem.expressions[:scenario_tail_excess].expressions[:total_operational_cost_per_scenario],
     )
 
     # Check that the expr_scenario_tail_excess table is empty


### PR DESCRIPTION
This pull request refines the treatment of risk in the objective function and constraints of the optimization model by ensuring that Conditional Value at Risk (CVaR) is applied only to operational costs, not to investment or fixed costs. It also simplifies the code by removing unnecessary weighting of deterministic cost terms and updates documentation and tests to reflect these changes.

**Objective function and risk modeling:**

- The objective function is updated so that CVaR and risk aversion weights apply only to operational costs, not to investment or fixed costs. Deterministic cost components are no longer multiplied by the risk aversion factor. [[1]](diffhunk://#diff-bd36014b78ed229d5756b4d6a0390fc4e6dc563254d63a330a6fb1e0295195d7L371-R377) [[2]](diffhunk://#diff-d40240ae6a1df70cb790ae4afb27e40290ab3165a53ae1e6637597ad2f698f6bL33-R47)

**Constraint and expression updates:**

- The scenario tail excess (CVaR) constraints and corresponding expressions are revised to operate only on operational costs per scenario, rather than total system costs (which previously included deterministic costs). [[1]](diffhunk://#diff-bd36014b78ed229d5756b4d6a0390fc4e6dc563254d63a330a6fb1e0295195d7L941-R957) [[2]](diffhunk://#diff-32158fb8cabf25014551055b99c3a05681acd9756f743c331f5e7ab6c4dae516L34-R35) [[3]](diffhunk://#diff-32158fb8cabf25014551055b99c3a05681acd9756f743c331f5e7ab6c4dae516L45-R46) [[4]](diffhunk://#diff-c167244d8ef8863e5cd193711f9a19a15c49e0b0d67867602d2bec1d6dad7288L25-R25) [[5]](diffhunk://#diff-c167244d8ef8863e5cd193711f9a19a15c49e0b0d67867602d2bec1d6dad7288L34-L49) [[6]](diffhunk://#diff-c167244d8ef8863e5cd193711f9a19a15c49e0b0d67867602d2bec1d6dad7288L59-R56)

**Objective function code simplification:**

- All deterministic cost components (`assets_investment_cost`, `assets_fixed_cost_*`, `flows_investment_cost`, `flows_fixed_cost`, etc.) are now added to the objective without the risk aversion weighting factor `(1 - lambda)`. The lambda parameter is removed from their function signatures and usages. [[1]](diffhunk://#diff-3f485363597753c6c5147d8729945a55b40be451dfab22d087782cc1917e4a17L1-R1) [[2]](diffhunk://#diff-3f485363597753c6c5147d8729945a55b40be451dfab22d087782cc1917e4a17L28-R28) [[3]](diffhunk://#diff-30b96b9b677f87c048eff140ffe3ca5d307b278725b9ff752ce5561b88978f33L6) [[4]](diffhunk://#diff-30b96b9b677f87c048eff140ffe3ca5d307b278725b9ff752ce5561b88978f33L42-R41) [[5]](diffhunk://#diff-34e9babba951d8b6a7c4616373c158429e1667f032f361fbe9d7cbff053af383L6) [[6]](diffhunk://#diff-34e9babba951d8b6a7c4616373c158429e1667f032f361fbe9d7cbff053af383L42-R41) [[7]](diffhunk://#diff-b51ddad44e2a84d8db2dbeb64669190443bd10f9ff7a6c19580e9b54e4b10bbcL1-R1) [[8]](diffhunk://#diff-b51ddad44e2a84d8db2dbeb64669190443bd10f9ff7a6c19580e9b54e4b10bbcL38-R38) [[9]](diffhunk://#diff-05ab2f4a2389d0a816430ed8f117905f29fb07881636d289a145f6e193029e1cL1-R1) [[10]](diffhunk://#diff-05ab2f4a2389d0a816430ed8f117905f29fb07881636d289a145f6e193029e1cL29-R29) [[11]](diffhunk://#diff-e4707b6342b22a243cd8a20c9ee0c780739e38daaaa07011d71af3e55f3bca45L1-R1) [[12]](diffhunk://#diff-e4707b6342b22a243cd8a20c9ee0c780739e38daaaa07011d71af3e55f3bca45L42-R36) [[13]](diffhunk://#diff-22d14dd46ebfdd78077ade043143986a2f4461ce261bd533fe030429c0331591L1-R1) [[14]](diffhunk://#diff-22d14dd46ebfdd78077ade043143986a2f4461ce261bd533fe030429c0331591L38-R32) [[15]](diffhunk://#diff-d40240ae6a1df70cb790ae4afb27e40290ab3165a53ae1e6637597ad2f698f6bL33-R47)

**Documentation and test updates:**

- Documentation is updated to clarify that risk measures and scenario tail excess constraints apply only to operational costs. [[1]](diffhunk://#diff-bd36014b78ed229d5756b4d6a0390fc4e6dc563254d63a330a6fb1e0295195d7L371-R377) [[2]](diffhunk://#diff-bd36014b78ed229d5756b4d6a0390fc4e6dc563254d63a330a6fb1e0295195d7L941-R957)
- Tests are revised to align with the new logic, removing references to deterministic costs in CVaR-related checks. [[1]](diffhunk://#diff-87fdb66609efbeb19cb26ed96255336168cfc850de9876f31c30e0532edd0632L131-L146) [[2]](diffhunk://#diff-87fdb66609efbeb19cb26ed96255336168cfc850de9876f31c30e0532edd0632L167-R157) [[3]](diffhunk://#diff-87fdb66609efbeb19cb26ed96255336168cfc850de9876f31c30e0532edd0632L199-L221)

## Related issues

Closes #1629 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing