### PR TITLE
Improve Tulipa performance when running in a loop

### DIFF
--- a/src/TulipaEnergyModel.jl
+++ b/src/TulipaEnergyModel.jl
@@ -20,7 +20,7 @@ using ParametricOptInterface: ParametricOptInterface as POI
 ## Others
 using OrderedCollections: OrderedDict
 using Statistics: Statistics
-using TimerOutputs: TimerOutput, @timeit
+using TimerOutputs: TimerOutput, @timeit, reset_timer!
 
 const to = TimerOutput()
 

--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -326,7 +326,7 @@ function _append_storage_data_to_indices(connection, table_name)
     LAST_VALUE(cons.id) OVER (
         PARTITION BY $id_partition_columns
         ORDER BY $id_order_column
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING -- frame expanding window to all rows, to avoid assuming ordering of ids
     ) AS cycle_id,
     """
 

--- a/src/constraints/storage.jl
+++ b/src/constraints/storage.jl
@@ -66,20 +66,9 @@ function add_storage_constraints!(
                     else
                         # Initial storage is the previous level (a JuMP variable)
                         previous_level::JuMP.VariableRef = if row.time_block_start > 1
-                            var_storage_level[row.id-1]
+                            var_storage_level[row.previous_id::Int]
                         else
-                            # Find last id of this group (there are probably cheaper ways, in case this becomes expensive)
-                            last_id = get_single_element_from_query_and_ensure_its_only_one(
-                                DuckDB.query(
-                                    connection,
-                                    "SELECT
-                                        MAX(id)
-                                    FROM cons_$table_name
-                                    WHERE asset = '$(row.asset)' AND milestone_year = $(row.milestone_year) AND rep_period = $(row.rep_period)
-                                    ",
-                                ),
-                            )::Int
-                            var_storage_level[last_id]
+                            var_storage_level[row.cycle_id::Int]
                         end
                         computed_storage_loss_coef = 1.0
                         if row.storage_loss_from_stored_energy > 0.0
@@ -193,19 +182,9 @@ function add_storage_constraints!(
                     else
                         # Initial storage is the previous level (a JuMP variable)
                         previous_level::JuMP.VariableRef = if row.period_block_start > 1
-                            var_storage_level[row.id-1]
+                            var_storage_level[row.previous_id::Int]
                         else
-                            last_id = get_single_element_from_query_and_ensure_its_only_one(
-                                DuckDB.query(
-                                    connection,
-                                    "SELECT
-                                        MAX(id)
-                                    FROM cons_$table_name
-                                    WHERE asset = '$(row.asset)' AND milestone_year = $(row.milestone_year) AND scenario = $(row.scenario)
-                                    ",
-                                ),
-                            )::Int
-                            var_storage_level[last_id]
+                            var_storage_level[row.cycle_id::Int]
                         end
                         @constraint(
                             model,
@@ -307,7 +286,7 @@ function add_storage_constraints!(
                     else
                         # Initial accumulated storage intra period is the previous level (a JuMP variable)
                         previous_accumulated_level::JuMP.VariableRef =
-                            var_accumulated_storage_level[row.id-1]
+                            var_accumulated_storage_level[row.previous_id::Int]
                         computed_storage_loss_coef = 1.0
                         if row.storage_loss_from_stored_energy > 0.0
                             duration = row.time_block_end - row.time_block_start + 1
@@ -334,6 +313,22 @@ end
 function _append_storage_data_to_indices(connection, table_name)
     join_duration = ""
     select_duration = ""
+    id_partition_columns, id_order_column = if table_name == :balance_storage_inter_period
+        ("cons.asset, cons.milestone_year, cons.scenario", "cons.period_block_start")
+    else
+        ("cons.asset, cons.milestone_year, cons.rep_period", "cons.time_block_start")
+    end
+    select_neighbor_ids = """
+    LAG(cons.id) OVER (
+        PARTITION BY $id_partition_columns
+        ORDER BY $id_order_column
+    ) AS previous_id,
+    LAST_VALUE(cons.id) OVER (
+        PARTITION BY $id_partition_columns
+        ORDER BY $id_order_column
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    ) AS cycle_id,
+    """
 
     # Seasonal (inter-period) storage uses assets_timeframe_profiles (keyed by milestone_year
     # and scenario), while rep-period storage uses assets_profiles (keyed by commission_year).
@@ -397,6 +392,7 @@ function _append_storage_data_to_indices(connection, table_name)
         "SELECT
             cons.*,
             $select_duration
+            $select_neighbor_ids
             asset.capacity,
             asset_commission.investment_limit,
             asset_commission.storage_loss_from_stored_energy,

--- a/src/expressions/intersection.jl
+++ b/src/expressions/intersection.jl
@@ -114,6 +114,8 @@ function attach_expression_on_constraints_grouping_variables!(
         end
 
         # Loop over each constraint
+        workspace_coef_agg = Dict{Int,Float64}()
+        workspace_count_agg = Dict{Int,Int}()
         for (cons_id::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
             group_row.cons_id_vec::Vector{Union{Missing,Int64}},
             group_row.cons_time_block_start_vec::Vector{Union{Missing,Int32}},
@@ -122,8 +124,8 @@ function attach_expression_on_constraints_grouping_variables!(
             time_block = time_block_start:time_block_end
 
             # We keep the coefficient and count to compute the mean later
-            workspace_coef_agg = Dict{Int,Float64}()
-            workspace_count_agg = Dict{Int,Int}()
+            empty!(workspace_coef_agg)
+            empty!(workspace_count_agg)
 
             for timestep in time_block
                 for (var_id, var_coefficient) in workspace[timestep]

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -817,7 +817,7 @@ function prepare_profiles_structure(connection)
             cte_storage_profiles AS (
                 SELECT DISTINCT
                     assets_profiles.profile_name,
-                    assets_profiles.commission_year AS milestone_year
+                    assets_profiles.commission_year AS milestone_year -- here commission_year = milestone_year
                 FROM assets_profiles
                 INNER JOIN asset
                     ON assets_profiles.asset = asset.asset

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -208,13 +208,14 @@ function add_expression_terms_rep_period_constraints!(
             end
 
             # Step 1.2. Loop over each constraint
+            workspace_agg = Dict{Int,Float64}()
             for (cons_id::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
                 group_row.cons_id_vec::Vector{Union{Missing,Int64}},
                 group_row.cons_time_block_start_vec::Vector{Union{Missing,Int32}},
                 group_row.cons_time_block_end_vec::Vector{Union{Missing,Int32}},
             )
                 time_block = time_block_start:time_block_end
-                workspace_agg = Dict{Int,Float64}()
+                empty!(workspace_agg)
                 # Step 1.2.1.
                 for timestep in time_block
                     for (var_id, var_coefficient) in workspace[timestep]
@@ -350,6 +351,7 @@ function add_expression_terms_inter_period_constraints!(
         )
             empty!.(workspace)
 
+            group_flows_accumulation = Dict{Int,Float64}()
             for (
                 var_id_vec::Vector{Union{Missing,Int64}},
                 var_time_block_start_vec::Vector{Union{Missing,Int32}},
@@ -369,7 +371,7 @@ function add_expression_terms_inter_period_constraints!(
             )
 
                 # Loop over each variable in the (group,rp) and accumulate them
-                group_flows_accumulation = Dict{Int,Float64}()
+                empty!(group_flows_accumulation)
 
                 for (var_id::Int64, time_block_start::Int32, time_block_end::Int32) in zip(
                     var_id_vec::Vector{Union{Missing,Int64}},
@@ -401,13 +403,14 @@ function add_expression_terms_inter_period_constraints!(
             end
 
             # Loop over each constraint and aggregate from the workspace into the expression
+            workspace_aggregation = Dict{Int,Float64}()
             for (cons_id::Int64, period_block_start::Int32, period_block_end::Int32) in zip(
                 group_row.cons_id_vec::Vector{Union{Missing,Int64}},
                 group_row.cons_period_block_start_vec::Vector{Union{Missing,Int32}},
                 group_row.cons_period_block_end_vec::Vector{Union{Missing,Int32}},
             )
                 period_block = period_block_start:period_block_end
-                workspace_aggregation = Dict{Int,Float64}()
+                empty!(workspace_aggregation)
                 for period in period_block
                     mergewith!(+, workspace_aggregation, workspace[period])
                 end
@@ -803,7 +806,6 @@ function prepare_profiles_structure(connection)
         )
     )
 
-    # TODO: Try to convert the flow below using group by like above
     # Creating inter_period profiles of inflows using the inflows
     # profiles of rep_periods (asset_milestone.storage_inflows is
     # asset-specific and is not used here).
@@ -812,58 +814,48 @@ function prepare_profiles_structure(connection)
         connection,
         """
         WITH
-            cte_scenarios AS (
-                SELECT DISTINCT scenario
-                FROM rep_periods_mapping
+            cte_storage_profiles AS (
+                SELECT DISTINCT
+                    assets_profiles.profile_name,
+                    assets_profiles.commission_year AS milestone_year
+                FROM assets_profiles
+                INNER JOIN asset
+                    ON assets_profiles.asset = asset.asset
+                WHERE assets_profiles.profile_type = 'inflows'
+                    AND asset.type = 'storage'
+                    AND asset.is_seasonal
             ),
-            cte_storage_assets AS (
-                SELECT asset.asset
-                FROM asset
-                WHERE asset.type = 'storage' AND asset.is_seasonal
+            cte_period_values AS (
+                SELECT
+                    cte_storage_profiles.profile_name,
+                    cte_storage_profiles.milestone_year,
+                    rep_periods_mapping.scenario,
+                    rep_periods_mapping.period,
+                    SUM(profiles_rep_periods.value * rep_periods_mapping.weight) AS value
+                FROM cte_storage_profiles
+                INNER JOIN profiles_rep_periods
+                    ON cte_storage_profiles.profile_name = profiles_rep_periods.profile_name
+                    AND cte_storage_profiles.milestone_year = profiles_rep_periods.milestone_year
+                INNER JOIN rep_periods_mapping
+                    ON profiles_rep_periods.milestone_year = rep_periods_mapping.milestone_year
+                    AND profiles_rep_periods.rep_period = rep_periods_mapping.rep_period
+                GROUP BY
+                    cte_storage_profiles.profile_name,
+                    cte_storage_profiles.milestone_year,
+                    rep_periods_mapping.scenario,
+                    rep_periods_mapping.period
             )
-        SELECT DISTINCT
-            assets_profiles.profile_name,
-            assets_profiles.commission_year,
-            cte_scenarios.scenario
-        FROM assets_profiles
-        INNER JOIN cte_storage_assets
-            ON assets_profiles.asset = cte_storage_assets.asset
-        CROSS JOIN cte_scenarios
-        WHERE assets_profiles.profile_type = 'inflows'
+        SELECT
+            profile_name,
+            milestone_year,
+            scenario,
+            ARRAY_AGG(value ORDER BY period) AS values
+        FROM cte_period_values
+        GROUP BY profile_name, milestone_year, scenario
         """,
     )
-        profile_name = row.profile_name
-        milestone_year = row.commission_year
-        scenario = row.scenario
-        values = Float64[
-            row.value for row in DuckDB.query(
-                connection,
-                """
-                WITH cte_profile_rp AS (
-                    SELECT
-                        $milestone_year AS milestone_year,
-                        $scenario AS scenario,
-                        profiles_rep_periods.rep_period,
-                        profiles_rep_periods.value
-                    FROM profiles_rep_periods
-                    WHERE profile_name = '$profile_name' AND milestone_year = $milestone_year
-                )
-                SELECT
-                    rp_map.period,
-                    SUM(cte_profile_rp.value * rp_map.weight) AS value
-                FROM cte_profile_rp
-                INNER JOIN rep_periods_mapping AS rp_map
-                    ON cte_profile_rp.milestone_year = rp_map.milestone_year
-                    AND cte_profile_rp.scenario = rp_map.scenario
-                    AND cte_profile_rp.rep_period = rp_map.rep_period
-                GROUP BY rp_map.period
-                ORDER BY rp_map.period
-                """,
-            )
-        ]
-        if length(values) > 0
-            inter_period[(profile_name, milestone_year, scenario)] = values
-        end
+        inter_period[(row.profile_name, row.milestone_year, row.scenario)] =
+            convert(Vector{Float64}, row.values)
     end
 
     return ProfileLookup(rep_period, inter_period)
@@ -876,7 +868,7 @@ Gets the model parameters from the 'model_parameters' table in
 the database connection and returns them in a named tuple.
 """
 function get_model_parameters(connection)
-    row = only(collect(DuckDB.query(connection, "SELECT * FROM model_parameters")))
+    row = only(DuckDB.query(connection, "SELECT * FROM model_parameters"))
 
     social_rate = row.discount_rate
     discount_year = row.discount_year

--- a/src/rolling-horizon/rolling-horizon.jl
+++ b/src/rolling-horizon/rolling-horizon.jl
@@ -59,6 +59,8 @@ function run_rolling_horizon(
     save_rolling_solution = false,
     compute_duals = true,
 )
+    reset_timer!(to)
+
     # Validation that the input data must satisfy to run rolling horizon
     @timeit to "Validate rolling horizon input" validate_rolling_horizon_input(
         connection,

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -33,6 +33,8 @@ function run_scenario(
     log_file = "",
     show_log = true,
 )
+    reset_timer!(to)
+
     energy_problem = @timeit to "create EnergyProblem from connection" EnergyProblem(connection)
 
     @timeit to "create_model!" create_model!(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ function _profile_aggregate(
 end
 
 function _profile_aggregate(profile_object::Vector{Float64}, time_block, agg_function)
-    return agg_function(skipmissing(profile_object[time_block]))
+    return agg_function(skipmissing(view(profile_object, time_block)))
 end
 
 function _profile_aggregate(profile_object::ProfileWithRollingHorizon, time_block, agg_function)
@@ -56,7 +56,7 @@ function _profile_aggregate(profile_object::ProfileWithRollingHorizon, time_bloc
         profile_object.values
     end
 
-    return agg_function(skipmissing(profile_value[time_block]))
+    return agg_function(skipmissing(view(profile_value, time_block)))
 end
 
 """


### PR DESCRIPTION
This PR introduces several changes to improve performance in Tulipa, especially when running in a loop. Here is a summary:
 
- Timer reset for `run_scenario` and `run_rolling_horizon`.
- Profile aggregation now uses views instead of slices.
- Storage constraints now use SQL window-computed `previous_id` / `cycle_id` instead of per-row DuckDB lookups and `row.id - 1`.
- Seasonal storage inter-period inflow profile prep is now one grouped SQL query.
- Reused inner-loop aggregation dictionaries in model/expression builders.
- Removed `only(collect(...))` in `get_model_parameters`.

Changes done with the help of CODEX:

`Co-authored-by: Codex <noreply@openai.com>`

## Related issues

Closes #1634 

## Checklist


- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
