### PR TITLE
Add tolerance to clustering to fix tests

### DIFF
--- a/test/test-tutorial-files.jl
+++ b/test/test-tutorial-files.jl
@@ -26,6 +26,8 @@
             method = :convex_hull,
             distance = TC.Distances.CosineDist(),
             weight_type = :convex,
+            tol = 1e-6,
+            weight_fitting_kwargs = Dict(:learning_rate => 0.001, :niters => 1000),
             layout = TC.ProfilesTableLayout(; year = :milestone_year),
         )
         return nothing
@@ -45,6 +47,8 @@
             method = :convex_hull,
             distance = TC.Distances.CosineDist(),
             weight_type = :convex,
+            tol = 1e-6,
+            weight_fitting_kwargs = Dict(:learning_rate => 0.001, :niters => 1000),
             layout = TC.ProfilesTableLayout(; year = :milestone_year),
         )
         return nothing
@@ -69,6 +73,8 @@
             method = :convex_hull,
             distance = TC.Distances.CosineDist(),
             weight_type = :convex,
+            tol = 1e-6,
+            weight_fitting_kwargs = Dict(:learning_rate => 0.001, :niters => 1000),
             layout,
         )
         return nothing
@@ -112,22 +118,22 @@ end
     [:integration, :slow] begin
     connection = _tutorial_connection("tutorial-4"; preprocess! = _cluster_tutorial_4!)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 1.6915474820088142e8 atol = 1e-5
+    @test energy_problem.objective_value ≈ 1.7546138830254573e8 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 1.6915474820088142e8 atol = 1e-5
+    @test energy_problem.objective_value ≈ 1.7546138830254573e8 atol = 1e-5
 end
 
 @testitem "Tutorial 5 objective value" setup = [CommonSetup, TutorialSetup] tags =
     [:integration, :slow] begin
     connection = _tutorial_connection("tutorial-5"; preprocess! = _cluster_tutorial_5!)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 2.8640757860279405e8 atol = 1e-5
+    @test energy_problem.objective_value ≈ 3.05072872119844e8 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 2.8640757860279405e8 atol = 1e-5
+    @test energy_problem.objective_value ≈ 3.05072872119844e8 atol = 1e-5
 end
 
 @testitem "Tutorial 6 simple method objective value" setup = [CommonSetup, TutorialSetup] tags =
@@ -156,11 +162,11 @@ end
     [:integration, :slow] begin
     connection = _tutorial_connection("tutorial-9"; preprocess! = _cluster_tutorial_9!)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 497.19915030358084 atol = 1e-5
+    @test energy_problem.objective_value ≈ 499.24509272162777 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 497.19915030358084 atol = 1e-5
+    @test energy_problem.objective_value ≈ 499.24509272162777 atol = 1e-5
 end
 
 @testitem "Tutorial CVaR objective value" setup = [CommonSetup, TutorialSetup] tags =


### PR DESCRIPTION
This pull request added new parameters to clustering function calls so we always get the same solution within the test's tolerance. As consequence, it also updated expected objective values in several integration tests

Test parameterization improvements:
* Added `tol` and `weight_fitting_kwargs` arguments to several calls, providing finer control over convex hull fitting and optimization within the test cases in `test/test-tutorial-files.jl`. [[1]](diffhunk://#diff-7eefcb1eb9c2d18b7e6189b3050fde8b6fb157f249f1979592902934f8752a65R29-R30) [[2]](diffhunk://#diff-7eefcb1eb9c2d18b7e6189b3050fde8b6fb157f249f1979592902934f8752a65R50-R51) [[3]](diffhunk://#diff-7eefcb1eb9c2d18b7e6189b3050fde8b6fb157f249f1979592902934f8752a65R76-R77)

Test expectation updates:
* Updated expected objective values in integration tests for Tutorials 4, 5, and 9 to match new model outputs, ensuring the tests remain valid after recent changes. [[1]](diffhunk://#diff-7eefcb1eb9c2d18b7e6189b3050fde8b6fb157f249f1979592902934f8752a65L115-R136) [[2]](diffhunk://#diff-7eefcb1eb9c2d18b7e6189b3050fde8b6fb157f249f1979592902934f8752a65L159-R169)

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #1641

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
