### PR TITLE
Add available-unit investment group constraints

### DIFF
--- a/docs/src/20-user-guide/30-configuring-model-features.md
+++ b/docs/src/20-user-guide/30-configuring-model-features.md
@@ -264,6 +264,7 @@ Here we can see that the assets `Asgard_Solar` and `Midgard_Wind` belong to the 
 !!! info
     Assets in `use_only_investment_units` groups have to allow investment (`asset_milestone.investable = true` for the corresponding year) and must not be consumers (`asset.type != "consumer"`).
     Assets in `use_available_units` groups may be non-investable, which allows limits on existing capacity and decommissioning trajectories.
+    Assets in `use_available_units` groups may be have different `vintage_method`, i.e., they can be `aggregated` or `compact_profiles` and the group constraints will be applied accordingly.
 
 ## [Flow Coefficient in Capacity constraints](@id coefficient-for-capacity-constraints)
 

--- a/docs/src/20-user-guide/30-configuring-model-features.md
+++ b/docs/src/20-user-guide/30-configuring-model-features.md
@@ -203,33 +203,37 @@ In order to define the groups in the model, the following steps are necessary:
 1. Create a group file by defining the `name` property and its parameters in the `investment_group_asset` table (or CSV file).
 2. Assign assets to the group by adding entries to the `investment_group_asset_membership` table (or CSV file).
 
-### [Group Investment constraints](@id investment-group-setup)
+### [Group Asset Constraints](@id investment-group-setup)
 
-A group investment constraint is a constraint of the form
+A group asset constraint is a constraint of the form
 
-$\sum_{a \in G} v^{\text{inv}}_a \times \text{coefficient}_a \left\{\begin{array}{c} \leq \\ \geq \\ =\end{array}\right\} \text{right hand side}$,
+$\sum_{a \in G} x_a \times \text{coefficient}_a \left\{\begin{array}{c} \leq \\ \geq \\ =\end{array}\right\} \text{right hand side}$,
 
-i.e., a sum-product of all investment variables listed in the group multiplied by given coefficients related by a "right hand side".
-An example of group investment are the maximum and minimum investment limits for group of investment variables.
+where `invest_method` selects $x_a$:
+
+- `use_only_investment_units` uses the investment variable for asset $a$ in the group's milestone year.
+- `use_available_units` uses the available units of asset $a$ in the group's milestone year, including initial units, investments that remain within their technical lifetime, and decommissions.
+- `none` creates no constraint.
+
 The mathematical formulation of these constraints is available [here](@ref investment-group-constraints).
 
 !!! info
-    At the moment, group constraints are only supported for investment variables through `investment_group_asset` and `investment_group_asset_membership`.
-    If you need additional constraints involving other variables, add them manually to the JuMP model as shown in the [Bids tutorial](@ref bids-tutorial).
+    Group constraints support investment units and available units through `investment_group_asset` and `investment_group_asset_membership`.
+    If you need constraints involving other variables, add them manually to the JuMP model as shown in the [Bids tutorial](@ref bids-tutorial).
 
-They can be achieved using group investment constraints by adding rows in `investment_group_asset` such that:
+Create group constraints by adding rows in `investment_group_asset` such that:
 
 - Each row in table `investment_group_asset`
   - `name` is the name of the group, and unique identifier.
   - `milestone_year` is the year for which the group is defined.
-  - `invest_method = true`. This parameter enables the model to use the investment group constraints.
-  - `constraint_sense` is either `<=` for maximum and `>=` for minimum.
+  - `invest_method` is `use_only_investment_units`, `use_available_units`, or `none`.
+  - `constraint_sense` is `<=`, `>=`, or `==`.
   - `rhs` is the corresponding value.
 - Each row in table `investment_group_asset_membership`
   - `group_name` should match `investment_group_asset.name`.
   - `asset` is the name of the asset.
   - `milestone_year` should match `investment_group_asset.milestone_year` and `asset.milestone_year`.
-  - `coefficient` should be the capacity value for the investment limit.
+  - `coefficient` multiplies the investment or available-units expression selected by `invest_method`.
 
 !!! warning
     Notice that only one constraint is created per row in `investment_group_asset`, which means that if both the minimum and maximum investment limits are desired, two rows are required in `investment_group_asset`, one with `constraint_sense = '<='` and one with `constraint_sense = '>='`. In this case, the names of the groups must be different, from instance `ccgt_max` and `ccgt_min`.
@@ -246,7 +250,7 @@ input_asset_file = "../../../test/inputs/Norse/investment-group-asset.csv" # hid
 assets = CSV.read(input_asset_file, DataFrame, header = 1) # hide
 ```
 
-In the given data, there are two groups: `renewables` and `ccgt`. Both groups have the `invest_method` parameter set to `true`, indicating that investment group constraints apply to both. For the `renewables` group, the `constraint_sense` is `<=` and the `rhs` is 40000 MW, indicating the this is a maximum investment limit, i.e., that the total investments of assets in the group must be less than or equal to this value. In contrast, the `ccgt` group has `>=` and 10000 MW in the corresponding fields, indicating a minimum investment limit.
+In the given data, there are two groups: `renewables` and `ccgt`. Both use `invest_method = "use_only_investment_units"`, preserving the original investment-limit behavior. For the `renewables` group, the `constraint_sense` is `<=` and the `rhs` is 40000 MW, indicating that this is a maximum investment limit, i.e., that the total investments of assets in the group must be less than or equal to this value. In contrast, the `ccgt` group has `>=` and 10000 MW in the corresponding fields, indicating a minimum investment limit.
 
 Let's now explore which assets are in each group. To do so, we can take a look at the `asset.csv` file:
 
@@ -258,7 +262,8 @@ investment_group_asset_membership = CSV.read(input_file, DataFrame) # hide
 Here we can see that the assets `Asgard_Solar` and `Midgard_Wind` belong to the `renewables` group, while the assets `Asgard_CCGT` and `Midgard_CCGT` belong to the `ccgt` group.
 
 !!! info
-    The assets in the group have to allow investment (`asset_milestone.investable = true` for the corresponding year) and not be of type `consumer` (`asset.type != "consumer"`).
+    Assets in `use_only_investment_units` groups have to allow investment (`asset_milestone.investable = true` for the corresponding year) and must not be consumers (`asset.type != "consumer"`).
+    Assets in `use_available_units` groups may be non-investable, which allows limits on existing capacity and decommissioning trajectories.
 
 ## [Flow Coefficient in Capacity constraints](@id coefficient-for-capacity-constraints)
 

--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -85,7 +85,7 @@ In addition, the following subsets represent methods for incorporating additiona
 
 | Name                        | Description                                         | Elements | Superset                                                     | Notes                                                                                                                                                            |
 | --------------------------- | --------------------------------------------------- | -------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| $\mathcal{G}^{\text{ai}}_y$ | Group of assets that share min/max investment limit |          | $\mathcal{G}^{\text{ai}}_y \subseteq \mathcal{G}^{\text{a}}$ | This set contains assets that have a group investment limit. Please visit the [how-to section](@ref investment-group-setup) to learn how to set up this feature. |
+| $\mathcal{G}^{\text{ai}}_y$ | Group of assets that share a constraint             |          | $\mathcal{G}^{\text{ai}}_y \subseteq \mathcal{G}^{\text{a}}$ | Groups with investment-units or available-units limits. See the [how-to section](@ref investment-group-setup) for configuration.                                 |
 
 ### Sets for Flows Relationships
 
@@ -911,30 +911,35 @@ These constraints allow us to consider a maximum or minimum energy limit for an 
 
 The following constraints aggregate variables of different assets depending on the method that applies to the group.
 
-#### [Investment Limits of a Group](@id investment-group-constraints)
+#### [Asset Group Constraints](@id investment-group-constraints)
 
-These constraints apply to assets in a group using the vintage method $\mathcal{G}^{\text{ai}}_y$. They help impose an investment potential of a spatial area commonly shared by several assets that can be invested there.
+These constraints apply to assets in a group using the method $\mathcal{G}^{\text{ai}}_y$. The group membership coefficient $c_{g,a,y}$ and right-hand side $r_{g,y}$ are defined in the group input tables. The method selects the expression on the left-hand side.
 
-!!! info
-    These constraints are applied to the investments each year. The model does not yet have investment limits to a group's available invested capacity.
+##### Investment Units
 
-##### Minimum Investment Limit of a Group
-
-```math
-\begin{aligned}
-\sum_{a \in \mathcal{A}^{\text{i}}_y | p^{\text{group}}_{a} = g} p^{\text{capacity}}_{a} \cdot v^{\text{inv}}_{a,y} \geq  p^{\text{min invest limit}}_{g,y}
-\\ \\ & \forall y \in \mathcal{Y}, \forall g \in \mathcal{G}^{\text{ai}}_y
-\end{aligned}
-```
-
-##### Maximum Investment Limit of a Group
+When `invest_method = "use_only_investment_units"`, the constraint uses the investment units in the group's milestone year:
 
 ```math
 \begin{aligned}
-\sum_{a \in \mathcal{A}^{\text{i}}_y | p^{\text{group}}_{a} = g} p^{\text{capacity}}_{a} \cdot v^{\text{inv}}_{a,y} \leq  p^{\text{max invest limit}}_{g,y}
-\\ \\ & \forall y \in \mathcal{Y}, \forall g \in \mathcal{G}^{\text{ai}}_y
+\sum_{a \in G_g} c_{g,a,y} \cdot v^{\text{inv}}_{a,y}
+\left\{\begin{array}{c} \leq \\ \geq \\ = \end{array}\right\}
+r_{g,y} \quad \forall y \in \mathcal{Y}, \forall g \in \mathcal{G}^{\text{ai}}_y
 \end{aligned}
 ```
+
+##### Available Units
+
+When `invest_method = "use_available_units"`, the constraint uses the available units at the group's milestone year. This includes initial units, investments that remain within their technical lifetime, and decommissions:
+
+```math
+\begin{aligned}
+\sum_{a \in G_g} c_{g,a,y} \cdot v^{\text{available units}}_{a,y}
+\left\{\begin{array}{c} \leq \\ \geq \\ = \end{array}\right\}
+r_{g,y} \quad \forall y \in \mathcal{Y}, \forall g \in \mathcal{G}^{\text{ai}}_y
+\end{aligned}
+```
+
+Groups with `invest_method = "none"` create no constraint.
 
 ### [Conditional Value at Risk Constraints](@id cvar-constraints)
 

--- a/src/constraints/investment_group.jl
+++ b/src/constraints/investment_group.jl
@@ -66,12 +66,13 @@ function add_investment_group_constraints!(connection, model, variables, express
     return
 end
 
-_get_expression_assets(expressions, k) =
-    if haskey(expressions, k)
-        get(expressions[k].expressions, :assets, JuMP.AffExpr[])
-    else
-        JuMP.AffExpr[]
+function _get_expression_assets(expressions, expression_name)
+    if !haskey(expressions, expression_name)
+        return JuMP.AffExpr[]
     end
+
+    return get(expressions[expression_name].expressions, :assets, JuMP.AffExpr[])
+end
 
 function _create_empty_available_units_table_if_missing!(connection, table_name)
     if isempty(

--- a/src/constraints/investment_group.jl
+++ b/src/constraints/investment_group.jl
@@ -5,10 +5,16 @@ Adds group constraints for assets that share a common limits or bounds.
 """
 function add_investment_group_constraints!(connection, model, variables, expressions, constraints)
     assets_investment = variables[:assets_investment].container
-    expr_available_asset_units_aggregated =
-        _get_expression_assets(expressions, :available_asset_units_aggregated_vintage_method)
-    expr_available_asset_units_compact =
-        _get_expression_assets(expressions, :available_asset_units_compact_vintage_method)
+    expr_available_asset_units_aggregated = get(
+        expressions[:available_asset_units_aggregated_vintage_method].expressions,
+        :assets,
+        JuMP.AffExpr[],
+    )
+    expr_available_asset_units_compact = get(
+        expressions[:available_asset_units_compact_vintage_method].expressions,
+        :assets,
+        JuMP.AffExpr[],
+    )
 
     let table_name = :group_investment
         cons = constraints[table_name]
@@ -66,44 +72,7 @@ function add_investment_group_constraints!(connection, model, variables, express
     return
 end
 
-function _get_expression_assets(expressions, expression_name)
-    if !haskey(expressions, expression_name)
-        return JuMP.AffExpr[]
-    end
-
-    return get(expressions[expression_name].expressions, :assets, JuMP.AffExpr[])
-end
-
-function _create_empty_available_units_table_if_missing!(connection, table_name)
-    if isempty(
-        DuckDB.query(connection, "FROM duckdb_tables() WHERE table_name = '$table_name' LIMIT 1"),
-    )
-        DuckDB.query(
-            connection,
-            """
-            CREATE TEMP TABLE $table_name (
-                id BIGINT,
-                asset VARCHAR,
-                milestone_year INT,
-                commission_year INT
-            );
-            """,
-        )
-    end
-
-    return
-end
-
 function _append_group_data_to_indices!(connection, cons_table_name)
-    _create_empty_available_units_table_if_missing!(
-        connection,
-        "expr_available_asset_units_aggregated_vintage_method",
-    )
-    _create_empty_available_units_table_if_missing!(
-        connection,
-        "expr_available_asset_units_compact_vintage_method",
-    )
-
     return DuckDB.query(
         connection,
         """

--- a/src/constraints/investment_group.jl
+++ b/src/constraints/investment_group.jl
@@ -66,36 +66,17 @@ function add_investment_group_constraints!(connection, model, variables, express
     return
 end
 
-function _get_expression_assets(expressions, expression_name)
-    if !haskey(expressions, expression_name)
-        return JuMP.AffExpr[]
+_get_expression_assets(expressions, k) =
+    if haskey(expressions, k)
+        get(expressions[k].expressions, :assets, JuMP.AffExpr[])
+    else
+        JuMP.AffExpr[]
     end
-
-    return get(expressions[expression_name].expressions, :assets, JuMP.AffExpr[])
-end
-
-function _ensure_group_available_units_tables!(connection)
-    _create_empty_available_units_table_if_missing!(
-        connection,
-        "expr_available_asset_units_aggregated_vintage_method",
-    )
-    _create_empty_available_units_table_if_missing!(
-        connection,
-        "expr_available_asset_units_compact_vintage_method",
-    )
-
-    return
-end
 
 function _create_empty_available_units_table_if_missing!(connection, table_name)
-    table_exists = false
-    for _ in
-        DuckDB.query(connection, "FROM duckdb_tables() WHERE table_name = '$table_name' LIMIT 1")
-        table_exists = true
-        break
-    end
-
-    if !table_exists
+    if isempty(
+        DuckDB.query(connection, "FROM duckdb_tables() WHERE table_name = '$table_name' LIMIT 1"),
+    )
         DuckDB.query(
             connection,
             """
@@ -113,7 +94,14 @@ function _create_empty_available_units_table_if_missing!(connection, table_name)
 end
 
 function _append_group_data_to_indices!(connection, cons_table_name)
-    _ensure_group_available_units_tables!(connection)
+    _create_empty_available_units_table_if_missing!(
+        connection,
+        "expr_available_asset_units_aggregated_vintage_method",
+    )
+    _create_empty_available_units_table_if_missing!(
+        connection,
+        "expr_available_asset_units_compact_vintage_method",
+    )
 
     return DuckDB.query(
         connection,

--- a/src/constraints/investment_group.jl
+++ b/src/constraints/investment_group.jl
@@ -1,10 +1,14 @@
 """
-    add_investment_group_constraints!(connection, model, variables, constraints)
+    add_investment_group_constraints!(connection, model, variables, expressions, constraints)
 
 Adds group constraints for assets that share a common limits or bounds.
 """
-function add_investment_group_constraints!(connection, model, variables, constraints)
+function add_investment_group_constraints!(connection, model, variables, expressions, constraints)
     assets_investment = variables[:assets_investment].container
+    expr_available_asset_units_aggregated =
+        expressions[:available_asset_units_aggregated_vintage_method].expressions[:assets]
+    expr_available_asset_units_compact =
+        expressions[:available_asset_units_compact_vintage_method].expressions[:assets]
 
     let table_name = :group_investment
         cons = constraints[table_name]
@@ -23,20 +27,38 @@ function add_investment_group_constraints!(connection, model, variables, constra
                         MathOptInterface.LessThan(0.0)
                     end
 
+                    group_expression = if row.invest_method == "use_only_investment_units"
+                        sum(
+                            coefficient * assets_investment[id] for (id, coefficient) in zip(
+                                row.var_assets_investment_ids,
+                                row.var_assets_investment_coefficients,
+                            )
+                        )
+                    else
+                        sum(
+                            coefficient * expr_available_asset_units_aggregated[id] for
+                            (id, coefficient) in zip(
+                                row.available_asset_units_aggregated_ids,
+                                row.available_asset_units_aggregated_coefficients,
+                            )
+                        ) + sum(
+                            coefficient * expr_available_asset_units_compact[id] for
+                            (id, coefficient) in zip(
+                                row.available_asset_units_compact_ids,
+                                row.available_asset_units_compact_coefficients,
+                            )
+                        )
+                    end
+
                     @constraint(
                         model,
-                        sum(
-                            coef * assets_investment[var_id] for
-                            (var_id, coef) in zip(row.var_assets_investment_ids, row.coefficients)
-                        ) - row.rhs in constraint_sense,
+                        group_expression - row.rhs in constraint_sense,
                         base_name = "investment_group[$(row.name),$(row.milestone_year)]"
                     )
                 end for row in indices
             ],
         )
     end
-
-    # - TODO: More group constraints e.g., limits on the available investments of a group
 
     return
 end
@@ -45,31 +67,109 @@ function _append_group_data_to_indices!(connection, cons_table_name)
     return DuckDB.query(
         connection,
         """
-        WITH cte_group_expression AS (
-            SELECT
-                investment_group_asset.name AS name,
-                investment_group_asset.milestone_year AS milestone_year,
-                ARRAY_AGG(var.id) AS var_assets_investment_ids,
-                ARRAY_AGG(investment_group_asset_membership.coefficient) AS coefficients,
-            FROM investment_group_asset
-            LEFT JOIN investment_group_asset_membership
-                ON investment_group_asset.name = investment_group_asset_membership.group_name
-                AND investment_group_asset.milestone_year = investment_group_asset_membership.milestone_year
-            LEFT JOIN var_assets_investment AS var
-                ON investment_group_asset_membership.asset = var.asset
-                AND investment_group_asset.milestone_year = var.milestone_year
-            GROUP BY investment_group_asset.name, investment_group_asset.milestone_year
-        )
+        WITH
+            cte_group_investment_expression AS (
+                SELECT
+                    group_asset.name AS name,
+                    group_asset.milestone_year AS milestone_year,
+                    COALESCE(
+                        ARRAY_AGG(var.id ORDER BY group_membership.asset, var.id) FILTER (var.id IS NOT NULL),
+                        []::BIGINT[]
+                    ) AS var_assets_investment_ids,
+                    COALESCE(
+                        ARRAY_AGG(group_membership.coefficient ORDER BY group_membership.asset, var.id) FILTER (var.id IS NOT NULL),
+                        []::DOUBLE[]
+                    ) AS var_assets_investment_coefficients,
+                FROM investment_group_asset AS group_asset
+                LEFT JOIN investment_group_asset_membership AS group_membership
+                    ON group_asset.name = group_membership.group_name
+                    AND group_asset.milestone_year = group_membership.milestone_year
+                LEFT JOIN var_assets_investment AS var
+                    ON group_membership.asset = var.asset
+                    AND group_asset.milestone_year = var.milestone_year
+                WHERE group_asset.invest_method = 'use_only_investment_units'
+                GROUP BY group_asset.name, group_asset.milestone_year
+            ),
+            cte_group_available_asset_units_aggregated AS (
+                SELECT
+                    group_asset.name AS name,
+                    group_asset.milestone_year AS milestone_year,
+                    COALESCE(
+                        ARRAY_AGG(expr.id ORDER BY group_membership.asset, expr.commission_year, expr.id) FILTER (expr.id IS NOT NULL),
+                        []::BIGINT[]
+                    ) AS available_asset_units_aggregated_ids,
+                    COALESCE(
+                        ARRAY_AGG(group_membership.coefficient ORDER BY group_membership.asset, expr.commission_year, expr.id) FILTER (expr.id IS NOT NULL),
+                        []::DOUBLE[]
+                    ) AS available_asset_units_aggregated_coefficients,
+                FROM investment_group_asset AS group_asset
+                LEFT JOIN investment_group_asset_membership AS group_membership
+                    ON group_asset.name = group_membership.group_name
+                    AND group_asset.milestone_year = group_membership.milestone_year
+                LEFT JOIN expr_available_asset_units_aggregated_vintage_method AS expr
+                    ON group_membership.asset = expr.asset
+                    AND group_asset.milestone_year = expr.milestone_year
+                WHERE group_asset.invest_method = 'use_available_units'
+                GROUP BY group_asset.name, group_asset.milestone_year
+            ),
+            cte_group_available_asset_units_compact AS (
+                SELECT
+                    group_asset.name AS name,
+                    group_asset.milestone_year AS milestone_year,
+                    COALESCE(
+                        ARRAY_AGG(expr.id ORDER BY group_membership.asset, expr.commission_year, expr.id) FILTER (expr.id IS NOT NULL),
+                        []::BIGINT[]
+                    ) AS available_asset_units_compact_ids,
+                    COALESCE(
+                        ARRAY_AGG(group_membership.coefficient ORDER BY group_membership.asset, expr.commission_year, expr.id) FILTER (expr.id IS NOT NULL),
+                        []::DOUBLE[]
+                    ) AS available_asset_units_compact_coefficients,
+                FROM investment_group_asset AS group_asset
+                LEFT JOIN investment_group_asset_membership AS group_membership
+                    ON group_asset.name = group_membership.group_name
+                    AND group_asset.milestone_year = group_membership.milestone_year
+                LEFT JOIN expr_available_asset_units_compact_vintage_method AS expr
+                    ON group_membership.asset = expr.asset
+                    AND group_asset.milestone_year = expr.milestone_year
+                WHERE group_asset.invest_method = 'use_available_units'
+                GROUP BY group_asset.name, group_asset.milestone_year
+            )
         SELECT
             cons.*,
-            cte.name,
-            cte.milestone_year,
-            cte.var_assets_investment_ids,
-            cte.coefficients,
+            COALESCE(
+                cte_group_investment_expression.var_assets_investment_ids,
+                []::BIGINT[]
+            ) AS var_assets_investment_ids,
+            COALESCE(
+                cte_group_investment_expression.var_assets_investment_coefficients,
+                []::DOUBLE[]
+            ) AS var_assets_investment_coefficients,
+            COALESCE(
+                cte_group_available_asset_units_aggregated.available_asset_units_aggregated_ids,
+                []::BIGINT[]
+            ) AS available_asset_units_aggregated_ids,
+            COALESCE(
+                cte_group_available_asset_units_aggregated.available_asset_units_aggregated_coefficients,
+                []::DOUBLE[]
+            ) AS available_asset_units_aggregated_coefficients,
+            COALESCE(
+                cte_group_available_asset_units_compact.available_asset_units_compact_ids,
+                []::BIGINT[]
+            ) AS available_asset_units_compact_ids,
+            COALESCE(
+                cte_group_available_asset_units_compact.available_asset_units_compact_coefficients,
+                []::DOUBLE[]
+            ) AS available_asset_units_compact_coefficients,
         FROM $cons_table_name AS cons
-        LEFT JOIN cte_group_expression AS cte
-            ON cons.name = cte.name
-            AND cons.milestone_year = cte.milestone_year
+        LEFT JOIN cte_group_investment_expression
+            ON cons.name = cte_group_investment_expression.name
+            AND cons.milestone_year = cte_group_investment_expression.milestone_year
+        LEFT JOIN cte_group_available_asset_units_aggregated
+            ON cons.name = cte_group_available_asset_units_aggregated.name
+            AND cons.milestone_year = cte_group_available_asset_units_aggregated.milestone_year
+        LEFT JOIN cte_group_available_asset_units_compact
+            ON cons.name = cte_group_available_asset_units_compact.name
+            AND cons.milestone_year = cte_group_available_asset_units_compact.milestone_year
         """,
     )
 end

--- a/src/constraints/investment_group.jl
+++ b/src/constraints/investment_group.jl
@@ -33,7 +33,7 @@ function add_investment_group_constraints!(connection, model, variables, express
                                 row.var_assets_investment_ids,
                                 row.var_assets_investment_coefficients,
                             );
-                            init = 0.0,
+                            init = JuMP.AffExpr(),
                         )
                     else
                         sum(
@@ -42,14 +42,14 @@ function add_investment_group_constraints!(connection, model, variables, express
                                 row.available_asset_units_aggregated_ids,
                                 row.available_asset_units_aggregated_coefficients,
                             );
-                            init = 0.0,
+                            init = JuMP.AffExpr(),
                         ) + sum(
                             coefficient * expr_available_asset_units_compact[id] for
                             (id, coefficient) in zip(
                                 row.available_asset_units_compact_ids,
                                 row.available_asset_units_compact_coefficients,
                             );
-                            init = 0.0,
+                            init = JuMP.AffExpr(),
                         )
                     end
 

--- a/src/constraints/investment_group.jl
+++ b/src/constraints/investment_group.jl
@@ -6,9 +6,9 @@ Adds group constraints for assets that share a common limits or bounds.
 function add_investment_group_constraints!(connection, model, variables, expressions, constraints)
     assets_investment = variables[:assets_investment].container
     expr_available_asset_units_aggregated =
-        expressions[:available_asset_units_aggregated_vintage_method].expressions[:assets]
+        _get_expression_assets(expressions, :available_asset_units_aggregated_vintage_method)
     expr_available_asset_units_compact =
-        expressions[:available_asset_units_compact_vintage_method].expressions[:assets]
+        _get_expression_assets(expressions, :available_asset_units_compact_vintage_method)
 
     let table_name = :group_investment
         cons = constraints[table_name]
@@ -32,7 +32,8 @@ function add_investment_group_constraints!(connection, model, variables, express
                             coefficient * assets_investment[id] for (id, coefficient) in zip(
                                 row.var_assets_investment_ids,
                                 row.var_assets_investment_coefficients,
-                            )
+                            );
+                            init = 0.0,
                         )
                     else
                         sum(
@@ -40,13 +41,15 @@ function add_investment_group_constraints!(connection, model, variables, express
                             (id, coefficient) in zip(
                                 row.available_asset_units_aggregated_ids,
                                 row.available_asset_units_aggregated_coefficients,
-                            )
+                            );
+                            init = 0.0,
                         ) + sum(
                             coefficient * expr_available_asset_units_compact[id] for
                             (id, coefficient) in zip(
                                 row.available_asset_units_compact_ids,
                                 row.available_asset_units_compact_coefficients,
-                            )
+                            );
+                            init = 0.0,
                         )
                     end
 
@@ -63,7 +66,55 @@ function add_investment_group_constraints!(connection, model, variables, express
     return
 end
 
+function _get_expression_assets(expressions, expression_name)
+    if !haskey(expressions, expression_name)
+        return JuMP.AffExpr[]
+    end
+
+    return get(expressions[expression_name].expressions, :assets, JuMP.AffExpr[])
+end
+
+function _ensure_group_available_units_tables!(connection)
+    _create_empty_available_units_table_if_missing!(
+        connection,
+        "expr_available_asset_units_aggregated_vintage_method",
+    )
+    _create_empty_available_units_table_if_missing!(
+        connection,
+        "expr_available_asset_units_compact_vintage_method",
+    )
+
+    return
+end
+
+function _create_empty_available_units_table_if_missing!(connection, table_name)
+    table_exists = false
+    for _ in
+        DuckDB.query(connection, "FROM duckdb_tables() WHERE table_name = '$table_name' LIMIT 1")
+        table_exists = true
+        break
+    end
+
+    if !table_exists
+        DuckDB.query(
+            connection,
+            """
+            CREATE TEMP TABLE $table_name (
+                id BIGINT,
+                asset VARCHAR,
+                milestone_year INT,
+                commission_year INT
+            );
+            """,
+        )
+    end
+
+    return
+end
+
 function _append_group_data_to_indices!(connection, cons_table_name)
+    _ensure_group_available_units_tables!(connection)
+
     return DuckDB.query(
         connection,
         """

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -231,6 +231,7 @@ function create_model(
         connection,
         model,
         variables,
+        expressions,
         constraints,
     )
 

--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -285,10 +285,11 @@ function _validate_assets_in_investment_groups_are_investable!(error_messages, c
     FROM investment_group_asset_membership
     LEFT JOIN investment_group_asset
         ON investment_group_asset_membership.group_name = investment_group_asset.name
+        AND investment_group_asset_membership.milestone_year = investment_group_asset.milestone_year
     LEFT JOIN asset_milestone
         ON investment_group_asset_membership.asset = asset_milestone.asset
         AND investment_group_asset.milestone_year = asset_milestone.milestone_year
-    WHERE NOT asset_milestone.investable
+    WHERE investment_group_asset.invest_method = 'use_only_investment_units' AND NOT asset_milestone.investable
     """
     for row in DuckDB.query(connection, query)
         push!(
@@ -325,16 +326,17 @@ function _validate_group_consistency!(error_messages, connection)
     for row in DuckDB.query(
         connection,
         "FROM (
-            SELECT investment_group_asset.name, COUNT(investment_group_asset_membership.asset) AS count_group_members
+            SELECT investment_group_asset.name, investment_group_asset.milestone_year, COUNT(investment_group_asset_membership.asset) AS count_group_members
             FROM investment_group_asset
             LEFT JOIN investment_group_asset_membership
                 ON investment_group_asset.name = investment_group_asset_membership.group_name
-            GROUP BY investment_group_asset.name
+                AND investment_group_asset.milestone_year = investment_group_asset_membership.milestone_year
+            GROUP BY investment_group_asset.name, investment_group_asset.milestone_year
         ) WHERE count_group_members = 0",
     )
         push!(
             error_messages,
-            "Group '$(row.name)' in 'investment_group_asset' has no members in 'investment_group_asset_membership'",
+            "Group '$(row.name)' in 'investment_group_asset' for milestone_year '$(row.milestone_year)' has no members in 'investment_group_asset_membership'",
         )
     end
 

--- a/src/data-validation.jl
+++ b/src/data-validation.jl
@@ -301,18 +301,34 @@ function _validate_assets_in_investment_groups_are_investable!(error_messages, c
     return error_messages
 end
 
+function _validate_investment_group_membership_group_and_year!(error_messages, connection)
+    query = """
+    SELECT
+        membership.group_name,
+        membership.milestone_year,
+    FROM investment_group_asset_membership AS membership
+    ANTI JOIN investment_group_asset AS groups
+        ON membership.group_name = groups.name
+        AND membership.milestone_year = groups.milestone_year
+    WHERE membership.group_name IS NOT NULL
+        AND membership.milestone_year IS NOT NULL
+    """
+
+    for row in DuckDB.query(connection, query)
+        push!(
+            error_messages,
+            "Table 'investment_group_asset_membership' has invalid (group_name, milestone_year) = ('$(row.group_name)', $(row.milestone_year)). Valid pairs should exist in ('investment_group_asset'.name, 'investment_group_asset'.milestone_year)",
+        )
+    end
+
+    return error_messages
+end
+
 function _validate_group_consistency!(error_messages, connection)
     # Check the values in the table `investment_group_asset_membership`:
-    # - `group_name` comes from `investment_group_asset.name`
+    # - (`group_name`, `milestone_year`) comes from (`investment_group_asset.name`, `investment_group_asset.milestone_year`)
     # - `asset` comes from `asset.asset`
-    _validate_foreign_key!(
-        error_messages,
-        connection,
-        "investment_group_asset_membership",
-        :group_name,
-        "investment_group_asset",
-        :name,
-    )
+    _validate_investment_group_membership_group_and_year!(error_messages, connection)
     _validate_foreign_key!(
         error_messages,
         connection,

--- a/src/input-schemas.json
+++ b/src/input-schemas.json
@@ -801,8 +801,15 @@
       "type": "VARCHAR"
     },
     "invest_method": {
-      "description": "true -> activate group constraints; false -> no group investment constraints",
-      "type": "BOOLEAN"
+      "constraints": {
+        "oneOf": [
+          "none",
+          "use_only_investment_units",
+          "use_available_units"
+        ]
+      },
+      "description": "Method used in the group constraint: none creates no constraint, use_only_investment_units uses investment units, and use_available_units uses available units.",
+      "type": "VARCHAR"
     },
     "milestone_year": {
       "description": "Year of investment and operation decisions in the optimization.",
@@ -824,7 +831,7 @@
     },
     "coefficient": {
       "default": 1.0,
-      "description": "Coefficient of the investment variable corresponding to this asset.",
+      "description": "Coefficient of the expression selected by invest_method for this asset.",
       "type": "DOUBLE"
     },
     "group_name": {

--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -665,12 +665,13 @@ select
     nextval('id') as id,
     ga.name,
     ga.milestone_year,
+    ga.invest_method,
     ga.constraint_sense,
     ga.rhs,
 from
     investment_group_asset as ga
 where
-    ga.invest_method
+    ga.invest_method != 'none'
 ;
 
 drop sequence id

--- a/test/inputs/Norse/investment-group-asset.csv
+++ b/test/inputs/Norse/investment-group-asset.csv
@@ -1,3 +1,3 @@
 name,milestone_year,invest_method,constraint_sense,rhs
-ccgt_min,2030,true,>=,10000
-renewables_max,2030,true,<=,40000
+ccgt_min,2030,use_only_investment_units,>=,10000
+renewables_max,2030,use_only_investment_units,<=,40000

--- a/test/test-constraint-investment-groups.jl
+++ b/test/test-constraint-investment-groups.jl
@@ -3,48 +3,74 @@
     using TulipaBuilder: TulipaBuilder as TB
     using TulipaClustering: TulipaClustering as TC
 
-    function create_investment_group_problem()
+    function create_investment_group_problem(assets, groups)
         tulipa = TB.TulipaData()
 
-        TB.add_asset!(tulipa, "producer1", :producer; investable = true)
-        TB.add_asset!(tulipa, "producer2", :producer; investable = true)
-        TB.add_asset!(
-            tulipa,
-            "producer3",
-            :producer;
-            investable = true,
-            vintage_method = "compact_profiles",
-        )
-        for asset in ("producer1", "producer2", "producer3"), milestone_year in (2030, 2050)
-            TB.attach_profile!(tulipa, asset, :availability, milestone_year, ones(6))
+        for asset in assets
+            TB.add_asset!(
+                tulipa,
+                asset.name,
+                asset.kind;
+                investable = asset.investable,
+                vintage_method = asset.vintage_method,
+            )
+            for (milestone_year, profile) in asset.profiles
+                TB.attach_profile!(tulipa, asset.name, :availability, milestone_year, profile)
+            end
         end
 
         connection = TB.create_connection(tulipa, TEM.schema)
 
-        # There is no way to inform these via TB yet
-        DuckDB.query(
-            connection,
-            """
-            CREATE OR REPLACE TABLE investment_group_asset (name VARCHAR, milestone_year INT, constraint_sense VARCHAR, rhs DOUBLE, invest_method VARCHAR);
-            INSERT INTO investment_group_asset VALUES ('group1', 2030, '<=', 7700, 'use_only_investment_units');
-            INSERT INTO investment_group_asset VALUES ('group1', 2050, '>=', 3300, 'use_only_investment_units');
-            INSERT INTO investment_group_asset VALUES ('group2', 2030, '==', 1234, 'use_only_investment_units');
-            INSERT INTO investment_group_asset VALUES ('group3', 2050, '<=', 987, 'use_available_units');
-            INSERT INTO investment_group_asset VALUES ('group4', 2050, '==', 4321, 'none');
-            """,
+        function insert_rows(table_name, columns, rows)
+            values = join(
+                [
+                    "(" *
+                    join([
+                        if value isa String
+                            "'$(replace(value, "'" => "''"))'"
+                        else
+                            string(value)
+                        end for value in row
+                    ], ", ") *
+                    ")" for row in rows
+                ],
+                ", ",
+            )
+            return DuckDB.query(
+                connection,
+                """
+                CREATE OR REPLACE TABLE $table_name ($(join(columns, ", ")));
+                INSERT INTO $table_name VALUES $values;
+                """,
+            )
+        end
+
+        insert_rows(
+            "investment_group_asset",
+            [
+                "name VARCHAR",
+                "milestone_year INT",
+                "constraint_sense VARCHAR",
+                "rhs DOUBLE",
+                "invest_method VARCHAR",
+            ],
+            [
+                (
+                    group.name,
+                    group.milestone_year,
+                    group.constraint_sense,
+                    group.rhs,
+                    group.invest_method,
+                ) for group in groups
+            ],
         )
-        DuckDB.query(
-            connection,
-            """
-            CREATE OR REPLACE TABLE investment_group_asset_membership (group_name VARCHAR, milestone_year INT, asset VARCHAR, coefficient DOUBLE);
-            INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'producer1', 3.14);
-            INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'producer2', 6.66);
-            INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'producer2', 2.51);
-            INSERT INTO investment_group_asset_membership VALUES ('group2', 2030, 'producer1', 0.73);
-            INSERT INTO investment_group_asset_membership VALUES ('group3', 2050, 'producer1', 2.0);
-            INSERT INTO investment_group_asset_membership VALUES ('group3', 2050, 'producer3', 4.2);
-            INSERT INTO investment_group_asset_membership VALUES ('group4', 2050, 'producer2', 3.45);
-            """,
+        insert_rows(
+            "investment_group_asset_membership",
+            ["group_name VARCHAR", "milestone_year INT", "asset VARCHAR", "coefficient DOUBLE"],
+            [
+                (group.name, group.milestone_year, membership.asset, membership.coefficient) for
+                group in groups for membership in group.memberships
+            ],
         )
 
         layout = TC.ProfilesTableLayout(; year = :milestone_year)
@@ -60,7 +86,78 @@ end
 
 @testitem "Constraints for investment groups" setup = [CommonSetup, ConsInvestmentGroupSetup] tags =
     [:unit, :constraint, :fast] begin
-    con, ep = create_investment_group_problem()
+    assets = [
+        (;
+            name = "producer1",
+            kind = :producer,
+            investable = true,
+            vintage_method = "aggregated",
+            profiles = [(2030, ones(6)), (2050, ones(6))],
+        ),
+        (;
+            name = "producer2",
+            kind = :producer,
+            investable = true,
+            vintage_method = "aggregated",
+            profiles = [(2030, ones(6)), (2050, ones(6))],
+        ),
+        (;
+            name = "producer3",
+            kind = :producer,
+            investable = true,
+            vintage_method = "compact_profiles",
+            profiles = [(2030, ones(6)), (2050, ones(6))],
+        ),
+    ]
+    groups = [
+        (;
+            name = "group1",
+            milestone_year = 2030,
+            constraint_sense = "<=",
+            rhs = 7700.0,
+            invest_method = "use_only_investment_units",
+            memberships = [
+                (asset = "producer1", coefficient = 3.14),
+                (asset = "producer2", coefficient = 6.66),
+            ],
+        ),
+        (;
+            name = "group1",
+            milestone_year = 2050,
+            constraint_sense = ">=",
+            rhs = 3300.0,
+            invest_method = "use_only_investment_units",
+            memberships = [(asset = "producer2", coefficient = 2.51)],
+        ),
+        (;
+            name = "group2",
+            milestone_year = 2030,
+            constraint_sense = "==",
+            rhs = 1234.0,
+            invest_method = "use_only_investment_units",
+            memberships = [(asset = "producer1", coefficient = 0.73)],
+        ),
+        (;
+            name = "group3",
+            milestone_year = 2050,
+            constraint_sense = "<=",
+            rhs = 987.0,
+            invest_method = "use_available_units",
+            memberships = [
+                (asset = "producer1", coefficient = 2.0),
+                (asset = "producer3", coefficient = 4.2),
+            ],
+        ),
+        (;
+            name = "group4",
+            milestone_year = 2050,
+            constraint_sense = "==",
+            rhs = 4321.0,
+            invest_method = "none",
+            memberships = [(asset = "producer2", coefficient = 3.45)],
+        ),
+    ]
+    con, ep = create_investment_group_problem(assets, groups)
 
     var_assets_investment = ep.variables[:assets_investment].container
     var_lookup = Dict(
@@ -109,222 +206,157 @@ end
     end
 end
 
-@testitem "Available-unit group constraints aggregate compact vintages" setup = [CommonSetup] tags =
-    [:unit, :constraint, :fast] begin
-    connection = DBInterface.connect(DuckDB.DB)
-    DuckDB.query(
-        connection,
-        """
-        CREATE TABLE cons_group_investment (
-            id BIGINT,
-            name VARCHAR,
-            milestone_year INT,
-            invest_method VARCHAR,
-            constraint_sense VARCHAR,
-            rhs DOUBLE
-        );
-        INSERT INTO cons_group_investment VALUES (1, 'group1', 2050, 'use_available_units', '<=', 100.0);
-        CREATE TABLE investment_group_asset (
-            name VARCHAR,
-            milestone_year INT,
-            invest_method VARCHAR
-        );
-        INSERT INTO investment_group_asset VALUES ('group1', 2050, 'use_available_units');
-        CREATE TABLE investment_group_asset_membership (
-            group_name VARCHAR,
-            milestone_year INT,
-            asset VARCHAR,
-            coefficient DOUBLE
-        );
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'aggregated_asset', 2.0);
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'compact_asset', 3.0);
-        CREATE TABLE var_assets_investment (id BIGINT, asset VARCHAR, milestone_year INT);
-        CREATE TABLE expr_available_asset_units_aggregated_vintage_method (
-            id BIGINT,
-            asset VARCHAR,
-            milestone_year INT,
-            commission_year INT
-        );
-        INSERT INTO expr_available_asset_units_aggregated_vintage_method VALUES (1, 'aggregated_asset', 2050, 2050);
-        CREATE TABLE expr_available_asset_units_compact_vintage_method (
-            id BIGINT,
-            asset VARCHAR,
-            milestone_year INT,
-            commission_year INT
-        );
-        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (1, 'compact_asset', 2050, 2030);
-        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (2, 'compact_asset', 2050, 2050);
-        """,
-    )
+@testitem "Available-unit group constraints aggregate compact vintages" setup =
+    [CommonSetup, ConsInvestmentGroupSetup] tags = [:unit, :constraint, :fast] begin
+    assets = [
+        (;
+            name = "aggregated_asset",
+            kind = :producer,
+            investable = true,
+            vintage_method = "aggregated",
+            profiles = [(2050, ones(6))],
+        ),
+        (;
+            name = "compact_asset",
+            kind = :producer,
+            investable = true,
+            vintage_method = "compact_profiles",
+            profiles = [(2030, ones(6)), (2050, ones(6))],
+        ),
+    ]
+    groups = [
+        (;
+            name = "group1",
+            milestone_year = 2050,
+            constraint_sense = "<=",
+            rhs = 100.0,
+            invest_method = "use_available_units",
+            memberships = [
+                (asset = "aggregated_asset", coefficient = 2.0),
+                (asset = "compact_asset", coefficient = 3.0),
+            ],
+        ),
+    ]
+    connection, ep = create_investment_group_problem(assets, groups)
 
-    model = JuMP.Model()
-    variables = Dict(:assets_investment => TEM.TulipaVariable(connection, "var_assets_investment"))
     expr_available_asset_units_aggregated =
-        TEM.TulipaExpression(connection, "expr_available_asset_units_aggregated_vintage_method")
+        ep.expressions[:available_asset_units_aggregated_vintage_method].expressions[:assets]
     expr_available_asset_units_compact =
-        TEM.TulipaExpression(connection, "expr_available_asset_units_compact_vintage_method")
-    JuMP.@variable(model, available_units_aggregated)
-    JuMP.@variable(model, available_units_compact[1:2])
-    TEM.attach_expression!(
-        expr_available_asset_units_aggregated,
-        :assets,
-        [JuMP.@expression(model, available_units_aggregated + 0)],
-    )
-    TEM.attach_expression!(
-        expr_available_asset_units_compact,
-        :assets,
-        [JuMP.@expression(model, available_units_compact[id] + 0) for id in 1:2],
-    )
-    expressions = Dict(
-        :available_asset_units_aggregated_vintage_method =>
-            expr_available_asset_units_aggregated,
-        :available_asset_units_compact_vintage_method => expr_available_asset_units_compact,
-    )
-    constraints =
-        Dict(:group_investment => TEM.TulipaConstraint(connection, "cons_group_investment"))
-
-    TEM.add_investment_group_constraints!(connection, model, variables, expressions, constraints)
-
-    observed_constraint = only(_get_cons_object(model, :investment_group))
+        ep.expressions[:available_asset_units_compact_vintage_method].expressions[:assets]
+    aggregated_ids = [
+        row.id for
+        row in ep.expressions[:available_asset_units_aggregated_vintage_method].indices if
+        row.asset == "aggregated_asset" && row.milestone_year == 2050
+    ]
+    compact_ids = [
+        row.id for
+        row in ep.expressions[:available_asset_units_compact_vintage_method].indices if
+        row.asset == "compact_asset" && row.milestone_year == 2050
+    ]
+    observed_constraint = only(_get_cons_object(ep.model, :investment_group))
     expected_constraint = JuMP.@build_constraint(
-        2.0 * available_units_aggregated +
-        3.0 * available_units_compact[1] +
-        3.0 * available_units_compact[2] <= 100.0
+        sum(2.0 * expr_available_asset_units_aggregated[id] for id in aggregated_ids) +
+        sum(3.0 * expr_available_asset_units_compact[id] for id in compact_ids) <= 100.0
     )
     @test _is_constraint_equal(expected_constraint, observed_constraint)
 end
 
-@testitem "Available-unit group constraints aggregate only" setup = [CommonSetup] tags =
-    [:unit, :constraint, :fast] begin
-    connection = DBInterface.connect(DuckDB.DB)
-    DuckDB.query(
-        connection,
-        """
-        CREATE TABLE cons_group_investment (
-            id BIGINT,
-            name VARCHAR,
-            milestone_year INT,
-            invest_method VARCHAR,
-            constraint_sense VARCHAR,
-            rhs DOUBLE
-        );
-        INSERT INTO cons_group_investment VALUES (1, 'group1', 2050, 'use_available_units', '<=', 100.0);
-        CREATE TABLE investment_group_asset (
-            name VARCHAR,
-            milestone_year INT,
-            invest_method VARCHAR
-        );
-        INSERT INTO investment_group_asset VALUES ('group1', 2050, 'use_available_units');
-        CREATE TABLE investment_group_asset_membership (
-            group_name VARCHAR,
-            milestone_year INT,
-            asset VARCHAR,
-            coefficient DOUBLE
-        );
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'aggregated_asset_1', 2.0);
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'aggregated_asset_2', 3.0);
-        CREATE TABLE var_assets_investment (id BIGINT, asset VARCHAR, milestone_year INT);
-        CREATE TABLE expr_available_asset_units_aggregated_vintage_method (
-            id BIGINT,
-            asset VARCHAR,
-            milestone_year INT,
-            commission_year INT
-        );
-        INSERT INTO expr_available_asset_units_aggregated_vintage_method VALUES (1, 'aggregated_asset_1', 2050, 2050);
-        INSERT INTO expr_available_asset_units_aggregated_vintage_method VALUES (2, 'aggregated_asset_2', 2050, 2050);
-        """,
-    )
+@testitem "Available-unit group constraints aggregate only" setup =
+    [CommonSetup, ConsInvestmentGroupSetup] tags = [:unit, :constraint, :fast] begin
+    assets = [
+        (;
+            name = "aggregated_asset_1",
+            kind = :producer,
+            investable = true,
+            vintage_method = "aggregated",
+            profiles = [(2050, ones(6))],
+        ),
+        (;
+            name = "aggregated_asset_2",
+            kind = :producer,
+            investable = true,
+            vintage_method = "aggregated",
+            profiles = [(2050, ones(6))],
+        ),
+    ]
+    groups = [
+        (;
+            name = "group1",
+            milestone_year = 2050,
+            constraint_sense = "<=",
+            rhs = 100.0,
+            invest_method = "use_available_units",
+            memberships = [
+                (asset = "aggregated_asset_1", coefficient = 2.0),
+                (asset = "aggregated_asset_2", coefficient = 3.0),
+            ],
+        ),
+    ]
+    connection, ep = create_investment_group_problem(assets, groups)
 
-    model = JuMP.Model()
-    variables = Dict(:assets_investment => TEM.TulipaVariable(connection, "var_assets_investment"))
     expr_available_asset_units_aggregated =
-        TEM.TulipaExpression(connection, "expr_available_asset_units_aggregated_vintage_method")
-    JuMP.@variable(model, available_units_aggregated[1:2])
-    TEM.attach_expression!(
-        expr_available_asset_units_aggregated,
-        :assets,
-        [JuMP.@expression(model, available_units_aggregated[id] + 0) for id in 1:2],
-    )
-    expressions = Dict(
-        :available_asset_units_aggregated_vintage_method =>
-            expr_available_asset_units_aggregated,
-    )
-    constraints =
-        Dict(:group_investment => TEM.TulipaConstraint(connection, "cons_group_investment"))
-
-    TEM.add_investment_group_constraints!(connection, model, variables, expressions, constraints)
-
-    observed_constraint = only(_get_cons_object(model, :investment_group))
+        ep.expressions[:available_asset_units_aggregated_vintage_method].expressions[:assets]
+    aggregated_ids = [
+        row.id for
+        row in ep.expressions[:available_asset_units_aggregated_vintage_method].indices if
+        row.asset in ("aggregated_asset_1", "aggregated_asset_2") && row.milestone_year == 2050
+    ]
+    observed_constraint = only(_get_cons_object(ep.model, :investment_group))
     expected_constraint = JuMP.@build_constraint(
-        2.0 * available_units_aggregated[1] + 3.0 * available_units_aggregated[2] <= 100.0
+        sum(2.0 * expr_available_asset_units_aggregated[id] for id in aggregated_ids[1:1]) +
+        sum(3.0 * expr_available_asset_units_aggregated[id] for id in aggregated_ids[2:2]) <=
+        100.0
     )
     @test _is_constraint_equal(expected_constraint, observed_constraint)
 end
 
-@testitem "Available-unit group constraints compact only" setup = [CommonSetup] tags =
-    [:unit, :constraint, :fast] begin
-    connection = DBInterface.connect(DuckDB.DB)
-    DuckDB.query(
-        connection,
-        """
-        CREATE TABLE cons_group_investment (
-            id BIGINT,
-            name VARCHAR,
-            milestone_year INT,
-            invest_method VARCHAR,
-            constraint_sense VARCHAR,
-            rhs DOUBLE
-        );
-        INSERT INTO cons_group_investment VALUES (1, 'group1', 2050, 'use_available_units', '<=', 100.0);
-        CREATE TABLE investment_group_asset (
-            name VARCHAR,
-            milestone_year INT,
-            invest_method VARCHAR
-        );
-        INSERT INTO investment_group_asset VALUES ('group1', 2050, 'use_available_units');
-        CREATE TABLE investment_group_asset_membership (
-            group_name VARCHAR,
-            milestone_year INT,
-            asset VARCHAR,
-            coefficient DOUBLE
-        );
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'compact_asset_1', 2.0);
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'compact_asset_2', 3.0);
-        CREATE TABLE var_assets_investment (id BIGINT, asset VARCHAR, milestone_year INT);
-        CREATE TABLE expr_available_asset_units_compact_vintage_method (
-            id BIGINT,
-            asset VARCHAR,
-            milestone_year INT,
-            commission_year INT
-        );
-        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (1, 'compact_asset_1', 2050, 2030);
-        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (2, 'compact_asset_2', 2050, 2030);
-        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (3, 'compact_asset_2', 2050, 2050);
-        """,
-    )
+@testitem "Available-unit group constraints compact only" setup =
+    [CommonSetup, ConsInvestmentGroupSetup] tags = [:unit, :constraint, :fast] begin
+    assets = [
+        (;
+            name = "compact_asset_1",
+            kind = :producer,
+            investable = true,
+            vintage_method = "compact_profiles",
+            profiles = [(2030, ones(6))],
+        ),
+        (;
+            name = "compact_asset_2",
+            kind = :producer,
+            investable = true,
+            vintage_method = "compact_profiles",
+            profiles = [(2030, ones(6)), (2050, ones(6))],
+        ),
+    ]
+    groups = [
+        (;
+            name = "group1",
+            milestone_year = 2050,
+            constraint_sense = "<=",
+            rhs = 100.0,
+            invest_method = "use_available_units",
+            memberships = [
+                (asset = "compact_asset_1", coefficient = 2.0),
+                (asset = "compact_asset_2", coefficient = 3.0),
+            ],
+        ),
+    ]
+    connection, ep = create_investment_group_problem(assets, groups)
 
-    model = JuMP.Model()
-    variables = Dict(:assets_investment => TEM.TulipaVariable(connection, "var_assets_investment"))
     expr_available_asset_units_compact =
-        TEM.TulipaExpression(connection, "expr_available_asset_units_compact_vintage_method")
-    JuMP.@variable(model, available_units_compact[1:3])
-    TEM.attach_expression!(
-        expr_available_asset_units_compact,
-        :assets,
-        [JuMP.@expression(model, available_units_compact[id] + 0) for id in 1:3],
-    )
-    expressions =
-        Dict(:available_asset_units_compact_vintage_method => expr_available_asset_units_compact)
-    constraints =
-        Dict(:group_investment => TEM.TulipaConstraint(connection, "cons_group_investment"))
-
-    TEM.add_investment_group_constraints!(connection, model, variables, expressions, constraints)
-
-    observed_constraint = only(_get_cons_object(model, :investment_group))
-    expected_constraint = JuMP.@build_constraint(
-        2.0 * available_units_compact[1] +
-        3.0 * available_units_compact[2] +
-        3.0 * available_units_compact[3] <= 100.0
-    )
+        ep.expressions[:available_asset_units_compact_vintage_method].expressions[:assets]
+    group = only(groups)
+    expected_terms = [
+        membership.coefficient * sum(
+            expr_available_asset_units_compact[id] for id in [
+                row.id for
+                row in ep.expressions[:available_asset_units_compact_vintage_method].indices if
+                row.asset == membership.asset && row.milestone_year == group.milestone_year
+            ];
+            init = 0.0,
+        ) for membership in group.memberships
+    ]
+    observed_constraint = only(_get_cons_object(ep.model, :investment_group))
+    expected_constraint = JuMP.@build_constraint(sum(expected_terms; init = 0.0) <= 100.0)
     @test _is_constraint_equal(expected_constraint, observed_constraint)
 end

--- a/test/test-constraint-investment-groups.jl
+++ b/test/test-constraint-investment-groups.jl
@@ -8,8 +8,16 @@
 
         TB.add_asset!(tulipa, "producer1", :producer; investable = true)
         TB.add_asset!(tulipa, "producer2", :producer; investable = true)
-        TB.attach_profile!(tulipa, "producer1", :availability, 2030, ones(6))
-        TB.attach_profile!(tulipa, "producer2", :availability, 2050, ones(6))
+        TB.add_asset!(
+            tulipa,
+            "producer3",
+            :producer;
+            investable = true,
+            vintage_method = "compact_profiles",
+        )
+        for asset in ("producer1", "producer2", "producer3"), milestone_year in (2030, 2050)
+            TB.attach_profile!(tulipa, asset, :availability, milestone_year, ones(6))
+        end
 
         connection = TB.create_connection(tulipa, TEM.schema)
 
@@ -17,11 +25,12 @@
         DuckDB.query(
             connection,
             """
-            CREATE OR REPLACE TABLE investment_group_asset (name VARCHAR, milestone_year INT, constraint_sense VARCHAR, rhs DOUBLE, invest_method BOOL);
-            INSERT INTO investment_group_asset VALUES ('group1', 2030, '<=', 7700, true);
-            INSERT INTO investment_group_asset VALUES ('group1', 2050, '>=', 3300, true);
-            INSERT INTO investment_group_asset VALUES ('group2', 2030, '==', 1234, true);
-            INSERT INTO investment_group_asset VALUES ('group2', 2050, '==', 4321, false);
+            CREATE OR REPLACE TABLE investment_group_asset (name VARCHAR, milestone_year INT, constraint_sense VARCHAR, rhs DOUBLE, invest_method VARCHAR);
+            INSERT INTO investment_group_asset VALUES ('group1', 2030, '<=', 7700, 'use_only_investment_units');
+            INSERT INTO investment_group_asset VALUES ('group1', 2050, '>=', 3300, 'use_only_investment_units');
+            INSERT INTO investment_group_asset VALUES ('group2', 2030, '==', 1234, 'use_only_investment_units');
+            INSERT INTO investment_group_asset VALUES ('group3', 2050, '<=', 987, 'use_available_units');
+            INSERT INTO investment_group_asset VALUES ('group4', 2050, '==', 4321, 'none');
             """,
         )
         DuckDB.query(
@@ -32,7 +41,9 @@
             INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'producer2', 6.66);
             INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'producer2', 2.51);
             INSERT INTO investment_group_asset_membership VALUES ('group2', 2030, 'producer1', 0.73);
-            INSERT INTO investment_group_asset_membership VALUES ('group2', 2050, 'producer2', 3.45);
+            INSERT INTO investment_group_asset_membership VALUES ('group3', 2050, 'producer1', 2.0);
+            INSERT INTO investment_group_asset_membership VALUES ('group3', 2050, 'producer3', 4.2);
+            INSERT INTO investment_group_asset_membership VALUES ('group4', 2050, 'producer2', 3.45);
             """,
         )
 
@@ -48,7 +59,7 @@
 end
 
 @testitem "Constraints for investment groups" setup = [CommonSetup, ConsInvestmentGroupSetup] tags =
-    [:unit, :constraint] begin
+    [:unit, :constraint, :fast] begin
     con, ep = create_investment_group_problem()
 
     var_assets_investment = ep.variables[:assets_investment].container
@@ -56,8 +67,23 @@ end
         (row.asset, row.milestone_year) => var_assets_investment[row.id] for
         row in ep.variables[:assets_investment].indices
     )
+    expr_available_asset_units_aggregated =
+        ep.expressions[:available_asset_units_aggregated_vintage_method].expressions[:assets]
+    expr_available_asset_units_compact =
+        ep.expressions[:available_asset_units_compact_vintage_method].expressions[:assets]
+    aggregated_ids = [
+        row.id for
+        row in ep.expressions[:available_asset_units_aggregated_vintage_method].indices if
+        row.asset == "producer1" && row.milestone_year == 2050
+    ]
+    compact_ids = [
+        row.id for
+        row in ep.expressions[:available_asset_units_compact_vintage_method].indices if
+        row.asset == "producer3" && row.milestone_year == 2050
+    ]
+    @test !isempty(aggregated_ids)
+    @test !isempty(compact_ids)
 
-    # :group_investment
     expected_cons_lookup = Dict(
         ("group1", 2030) => JuMP.@build_constraint(
             var_lookup["producer1", 2030] * 3.14 + var_lookup["producer2", 2030] * 6.66 <= 7700
@@ -66,14 +92,103 @@ end
             JuMP.@build_constraint(var_lookup["producer2", 2050] * 2.51 >= 3300),
         ("group2", 2030) =>
             JuMP.@build_constraint(var_lookup["producer1", 2030] * 0.73 == 1234),
-        # No group4, because invest_method is false
+        ("group3", 2050) => JuMP.@build_constraint(
+            sum(2.0 * expr_available_asset_units_aggregated[id] for id in aggregated_ids) +
+            sum(4.2 * expr_available_asset_units_compact[id] for id in compact_ids) <= 987
+        ),
+        # No group4, because invest_method is none
     )
     observed_cons = _get_cons_object(ep.model, :investment_group)
     observed_cons_lookup = Dict(
         (row.name, row.milestone_year) => observed_cons[row.id] for
         row in DuckDB.query(con, "FROM cons_group_investment")
     )
+    @test Set(keys(observed_cons_lookup)) == Set(keys(expected_cons_lookup))
     for ((group_name, milestone_year), observed_cons) in observed_cons_lookup
         @test _is_constraint_equal(expected_cons_lookup[group_name, milestone_year], observed_cons)
     end
+end
+@testitem "Available-unit group constraints aggregate compact vintages" setup = [CommonSetup] tags =
+    [:unit, :constraint, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    DuckDB.query(
+        connection,
+        """
+        CREATE TABLE cons_group_investment (
+            id BIGINT,
+            name VARCHAR,
+            milestone_year INT,
+            invest_method VARCHAR,
+            constraint_sense VARCHAR,
+            rhs DOUBLE
+        );
+        INSERT INTO cons_group_investment VALUES (1, 'group1', 2050, 'use_available_units', '<=', 100.0);
+        CREATE TABLE investment_group_asset (
+            name VARCHAR,
+            milestone_year INT,
+            invest_method VARCHAR
+        );
+        INSERT INTO investment_group_asset VALUES ('group1', 2050, 'use_available_units');
+        CREATE TABLE investment_group_asset_membership (
+            group_name VARCHAR,
+            milestone_year INT,
+            asset VARCHAR,
+            coefficient DOUBLE
+        );
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'aggregated_asset', 2.0);
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'compact_asset', 3.0);
+        CREATE TABLE var_assets_investment (id BIGINT, asset VARCHAR, milestone_year INT);
+        CREATE TABLE expr_available_asset_units_aggregated_vintage_method (
+            id BIGINT,
+            asset VARCHAR,
+            milestone_year INT,
+            commission_year INT
+        );
+        INSERT INTO expr_available_asset_units_aggregated_vintage_method VALUES (1, 'aggregated_asset', 2050, 2050);
+        CREATE TABLE expr_available_asset_units_compact_vintage_method (
+            id BIGINT,
+            asset VARCHAR,
+            milestone_year INT,
+            commission_year INT
+        );
+        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (1, 'compact_asset', 2050, 2030);
+        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (2, 'compact_asset', 2050, 2050);
+        """,
+    )
+
+    model = JuMP.Model()
+    variables = Dict(:assets_investment => TEM.TulipaVariable(connection, "var_assets_investment"))
+    expr_available_asset_units_aggregated =
+        TEM.TulipaExpression(connection, "expr_available_asset_units_aggregated_vintage_method")
+    expr_available_asset_units_compact =
+        TEM.TulipaExpression(connection, "expr_available_asset_units_compact_vintage_method")
+    JuMP.@variable(model, available_units_aggregated)
+    JuMP.@variable(model, available_units_compact[1:2])
+    TEM.attach_expression!(
+        expr_available_asset_units_aggregated,
+        :assets,
+        [JuMP.@expression(model, available_units_aggregated + 0)],
+    )
+    TEM.attach_expression!(
+        expr_available_asset_units_compact,
+        :assets,
+        [JuMP.@expression(model, available_units_compact[id] + 0) for id in 1:2],
+    )
+    expressions = Dict(
+        :available_asset_units_aggregated_vintage_method =>
+            expr_available_asset_units_aggregated,
+        :available_asset_units_compact_vintage_method => expr_available_asset_units_compact,
+    )
+    constraints =
+        Dict(:group_investment => TEM.TulipaConstraint(connection, "cons_group_investment"))
+
+    TEM.add_investment_group_constraints!(connection, model, variables, expressions, constraints)
+
+    observed_constraint = only(_get_cons_object(model, :investment_group))
+    expected_constraint = JuMP.@build_constraint(
+        2.0 * available_units_aggregated +
+        3.0 * available_units_compact[1] +
+        3.0 * available_units_compact[2] <= 100.0
+    )
+    @test _is_constraint_equal(expected_constraint, observed_constraint)
 end

--- a/test/test-constraint-investment-groups.jl
+++ b/test/test-constraint-investment-groups.jl
@@ -108,6 +108,7 @@ end
         @test _is_constraint_equal(expected_cons_lookup[group_name, milestone_year], observed_cons)
     end
 end
+
 @testitem "Available-unit group constraints aggregate compact vintages" setup = [CommonSetup] tags =
     [:unit, :constraint, :fast] begin
     connection = DBInterface.connect(DuckDB.DB)
@@ -189,6 +190,141 @@ end
         2.0 * available_units_aggregated +
         3.0 * available_units_compact[1] +
         3.0 * available_units_compact[2] <= 100.0
+    )
+    @test _is_constraint_equal(expected_constraint, observed_constraint)
+end
+
+@testitem "Available-unit group constraints aggregate only" setup = [CommonSetup] tags =
+    [:unit, :constraint, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    DuckDB.query(
+        connection,
+        """
+        CREATE TABLE cons_group_investment (
+            id BIGINT,
+            name VARCHAR,
+            milestone_year INT,
+            invest_method VARCHAR,
+            constraint_sense VARCHAR,
+            rhs DOUBLE
+        );
+        INSERT INTO cons_group_investment VALUES (1, 'group1', 2050, 'use_available_units', '<=', 100.0);
+        CREATE TABLE investment_group_asset (
+            name VARCHAR,
+            milestone_year INT,
+            invest_method VARCHAR
+        );
+        INSERT INTO investment_group_asset VALUES ('group1', 2050, 'use_available_units');
+        CREATE TABLE investment_group_asset_membership (
+            group_name VARCHAR,
+            milestone_year INT,
+            asset VARCHAR,
+            coefficient DOUBLE
+        );
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'aggregated_asset_1', 2.0);
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'aggregated_asset_2', 3.0);
+        CREATE TABLE var_assets_investment (id BIGINT, asset VARCHAR, milestone_year INT);
+        CREATE TABLE expr_available_asset_units_aggregated_vintage_method (
+            id BIGINT,
+            asset VARCHAR,
+            milestone_year INT,
+            commission_year INT
+        );
+        INSERT INTO expr_available_asset_units_aggregated_vintage_method VALUES (1, 'aggregated_asset_1', 2050, 2050);
+        INSERT INTO expr_available_asset_units_aggregated_vintage_method VALUES (2, 'aggregated_asset_2', 2050, 2050);
+        """,
+    )
+
+    model = JuMP.Model()
+    variables = Dict(:assets_investment => TEM.TulipaVariable(connection, "var_assets_investment"))
+    expr_available_asset_units_aggregated =
+        TEM.TulipaExpression(connection, "expr_available_asset_units_aggregated_vintage_method")
+    JuMP.@variable(model, available_units_aggregated[1:2])
+    TEM.attach_expression!(
+        expr_available_asset_units_aggregated,
+        :assets,
+        [JuMP.@expression(model, available_units_aggregated[id] + 0) for id in 1:2],
+    )
+    expressions = Dict(
+        :available_asset_units_aggregated_vintage_method =>
+            expr_available_asset_units_aggregated,
+    )
+    constraints =
+        Dict(:group_investment => TEM.TulipaConstraint(connection, "cons_group_investment"))
+
+    TEM.add_investment_group_constraints!(connection, model, variables, expressions, constraints)
+
+    observed_constraint = only(_get_cons_object(model, :investment_group))
+    expected_constraint = JuMP.@build_constraint(
+        2.0 * available_units_aggregated[1] + 3.0 * available_units_aggregated[2] <= 100.0
+    )
+    @test _is_constraint_equal(expected_constraint, observed_constraint)
+end
+
+@testitem "Available-unit group constraints compact only" setup = [CommonSetup] tags =
+    [:unit, :constraint, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    DuckDB.query(
+        connection,
+        """
+        CREATE TABLE cons_group_investment (
+            id BIGINT,
+            name VARCHAR,
+            milestone_year INT,
+            invest_method VARCHAR,
+            constraint_sense VARCHAR,
+            rhs DOUBLE
+        );
+        INSERT INTO cons_group_investment VALUES (1, 'group1', 2050, 'use_available_units', '<=', 100.0);
+        CREATE TABLE investment_group_asset (
+            name VARCHAR,
+            milestone_year INT,
+            invest_method VARCHAR
+        );
+        INSERT INTO investment_group_asset VALUES ('group1', 2050, 'use_available_units');
+        CREATE TABLE investment_group_asset_membership (
+            group_name VARCHAR,
+            milestone_year INT,
+            asset VARCHAR,
+            coefficient DOUBLE
+        );
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'compact_asset_1', 2.0);
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'compact_asset_2', 3.0);
+        CREATE TABLE var_assets_investment (id BIGINT, asset VARCHAR, milestone_year INT);
+        CREATE TABLE expr_available_asset_units_compact_vintage_method (
+            id BIGINT,
+            asset VARCHAR,
+            milestone_year INT,
+            commission_year INT
+        );
+        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (1, 'compact_asset_1', 2050, 2030);
+        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (2, 'compact_asset_2', 2050, 2030);
+        INSERT INTO expr_available_asset_units_compact_vintage_method VALUES (3, 'compact_asset_2', 2050, 2050);
+        """,
+    )
+
+    model = JuMP.Model()
+    variables = Dict(:assets_investment => TEM.TulipaVariable(connection, "var_assets_investment"))
+    expr_available_asset_units_compact =
+        TEM.TulipaExpression(connection, "expr_available_asset_units_compact_vintage_method")
+    JuMP.@variable(model, available_units_compact[1:3])
+    TEM.attach_expression!(
+        expr_available_asset_units_compact,
+        :assets,
+        [JuMP.@expression(model, available_units_compact[id] + 0) for id in 1:3],
+    )
+    expressions =
+        Dict(:available_asset_units_compact_vintage_method => expr_available_asset_units_compact)
+    constraints =
+        Dict(:group_investment => TEM.TulipaConstraint(connection, "cons_group_investment"))
+
+    TEM.add_investment_group_constraints!(connection, model, variables, expressions, constraints)
+
+    observed_constraint = only(_get_cons_object(model, :investment_group))
+    expected_constraint = JuMP.@build_constraint(
+        2.0 * available_units_compact[1] +
+        3.0 * available_units_compact[2] +
+        3.0 * available_units_compact[3] <= 100.0
     )
     @test _is_constraint_equal(expected_constraint, observed_constraint)
 end

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -298,7 +298,7 @@ end
         """,
     )
 
-    # Creating investment_group_asset_membership with 1 correct (group, asset) pairs and 2 incorrect pairs
+    # Creating investment_group_asset_membership with 1 correct pair and 3 incorrect pairs
     DuckDB.query(
         connection,
         """
@@ -306,13 +306,15 @@ end
         INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'ccgt');
         INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'bad_asset');
         INSERT INTO investment_group_asset_membership VALUES ('bad_group', 2030, 'ccgt');
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2050, 'ccgt');
         """,
     )
 
     error_messages = TEM._validate_group_consistency!(String[], connection)
     @test Set(error_messages) == Set([
         "Table 'investment_group_asset_membership' column 'asset' has invalid value 'bad_asset'. Valid values should be among column 'asset' of 'asset'",
-        "Table 'investment_group_asset_membership' column 'group_name' has invalid value 'bad_group'. Valid values should be among column 'name' of 'investment_group_asset'",
+        "Table 'investment_group_asset_membership' has invalid (group_name, milestone_year) = ('bad_group', 2030). Valid pairs should exist in ('investment_group_asset'.name, 'investment_group_asset'.milestone_year)",
+        "Table 'investment_group_asset_membership' has invalid (group_name, milestone_year) = ('group1', 2050). Valid pairs should exist in ('investment_group_asset'.name, 'investment_group_asset'.milestone_year)",
     ])
 end
 

--- a/test/test-data-validation.jl
+++ b/test/test-data-validation.jl
@@ -116,6 +116,20 @@ end
           ["Table 'flows_rep_periods_partitions' has bad value for column 'specification': 'bad'"]
 end
 
+@testitem "Test schema oneOf constraints - bad investment group method" setup = [CommonSetup] tags =
+    [:unit, :data_validation, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    _read_csv_folder(connection, joinpath(@__DIR__, "inputs", "Norse"))
+    DuckDB.query(
+        connection,
+        "UPDATE investment_group_asset SET invest_method = 'true' WHERE name = 'ccgt_min'",
+    )
+    @test_throws TEM.DataValidationException TEM.create_internal_tables!(connection)
+    error_messages = TEM._validate_schema_one_of_constraints!(String[], connection)
+    @test error_messages ==
+          ["Table 'investment_group_asset' has bad value for column 'invest_method': 'true'"]
+end
+
 @testitem "Test only transport flows can be investable - using fake data" setup = [CommonSetup] tags =
     [:unit, :data_validation, :fast] begin
     # Create all four combinations of is_transport and investable
@@ -277,7 +291,7 @@ end
         SELECT
             'group1' AS name,
             2030 AS milestone_year,
-            true AS invest_method,
+            'use_only_investment_units' AS invest_method,
             '<=' AS constraint_sense,
             0.0 AS rhs,
         )
@@ -288,10 +302,10 @@ end
     DuckDB.query(
         connection,
         """
-        CREATE TABLE investment_group_asset_membership (group_name VARCHAR, asset VARCHAR);
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 'ccgt');
-        INSERT INTO investment_group_asset_membership VALUES ('group1', 'bad_asset');
-        INSERT INTO investment_group_asset_membership VALUES ('bad_group', 'ccgt');
+        CREATE TABLE investment_group_asset_membership (group_name VARCHAR, milestone_year INT, asset VARCHAR);
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'ccgt');
+        INSERT INTO investment_group_asset_membership VALUES ('group1', 2030, 'bad_asset');
+        INSERT INTO investment_group_asset_membership VALUES ('bad_group', 2030, 'ccgt');
         """,
     )
 
@@ -307,10 +321,16 @@ end
     asset = DataFrame(:asset => ["A1", "A2", "A3"])
     asset_milestone =
         DataFrame(:asset => ["A1", "A2", "A3"], :milestone_year => 2030, :investable => true)
-    investment_group_asset =
-        DataFrame(:name => ["group1", "group2", "bad_group"], :milestone_year => 2030)
-    investment_group_asset_membership =
-        DataFrame(:group_name => ["group1", "group1", "group2"], :asset => ["A1", "A3", "A2"])
+    investment_group_asset = DataFrame(
+        :name => ["group1", "group2", "bad_group"],
+        :milestone_year => 2030,
+        :invest_method => "use_only_investment_units",
+    )
+    investment_group_asset_membership = DataFrame(
+        :group_name => ["group1", "group1", "group2"],
+        :milestone_year => 2030,
+        :asset => ["A1", "A3", "A2"],
+    )
     connection = DBInterface.connect(DuckDB.DB)
     DuckDB.register_data_frame(connection, asset, "asset")
     DuckDB.register_data_frame(connection, asset_milestone, "asset_milestone")
@@ -323,7 +343,7 @@ end
 
     error_messages = TEM._validate_group_consistency!(String[], connection)
     @test error_messages == [
-        "Group 'bad_group' in 'investment_group_asset' has no members in 'investment_group_asset_membership'",
+        "Group 'bad_group' in 'investment_group_asset' for milestone_year '2030' has no members in 'investment_group_asset_membership'",
     ]
 end
 
@@ -336,23 +356,34 @@ end
 
     # Modify group value to bad value
     DuckDB.query(connection, "INSERT INTO investment_group_asset (name) VALUES ('lonely')")
-    @test_throws "Group 'lonely' in 'investment_group_asset' has no members in 'investment_group_asset_membership'" TEM.create_internal_tables!(
+    @test_throws "Group 'lonely' in 'investment_group_asset' for milestone_year" TEM.create_internal_tables!(
         connection,
     )
 end
 
-@testitem "If asset belong to an investable group, then it is investable in the corresponding year" setup =
-    [CommonSetup] tags = [:unit, :data_validation, :fast] begin
-    asset = DataFrame(:asset => ["A1", "A2", "A3"])
+@testitem "Only investment-only group members must be investable" setup = [CommonSetup] tags =
+    [:unit, :data_validation, :fast] begin
+    asset = DataFrame(:asset => ["A1", "A2"])
     asset_milestone = DataFrame(
-        :asset => ["A1", "A1", "A2", "A2", "A3", "A3"],
-        :milestone_year => [2030, 2050, 2030, 2050, 2030, 2050],
-        :investable => [false, false, true, false, true, true],
+        :asset => ["A1", "A1", "A2", "A2"],
+        :milestone_year => [2030, 2050, 2030, 2050],
+        :investable => [false, false, true, false],
     )
-    investment_group_asset =
-        DataFrame(:name => ["group1", "group1"], :milestone_year => [2030, 2050])
-    investment_group_asset_membership =
-        DataFrame(:group_name => "group1", :asset => ["A1", "A2", "A3", "A1", "A2", "A3"])
+    investment_group_asset = DataFrame(
+        :name => ["group1", "group1", "group2", "group3"],
+        :milestone_year => [2030, 2050, 2030, 2050],
+        :invest_method => [
+            "use_available_units",
+            "use_only_investment_units",
+            "use_only_investment_units",
+            "none",
+        ],
+    )
+    investment_group_asset_membership = DataFrame(
+        :group_name => ["group1", "group1", "group2", "group3"],
+        :milestone_year => [2030, 2050, 2030, 2050],
+        :asset => ["A1", "A2", "A1", "A1"],
+    )
 
     connection = DBInterface.connect(DuckDB.DB)
     DuckDB.register_data_frame(connection, asset, "asset")
@@ -366,9 +397,8 @@ end
 
     error_messages = TEM._validate_group_consistency!(String[], connection)
     @test Set(error_messages) == Set([
-        "Asset 'A1' is in investment group 'group1' for milestone_year '2030' but it is not 'asset_milestone.investable'",
-        "Asset 'A1' is in investment group 'group1' for milestone_year '2050' but it is not 'asset_milestone.investable'",
         "Asset 'A2' is in investment group 'group1' for milestone_year '2050' but it is not 'asset_milestone.investable'",
+        "Asset 'A1' is in investment group 'group2' for milestone_year '2030' but it is not 'asset_milestone.investable'",
     ])
 end
 

--- a/utils/scripts/migrate-investment-group-method.py
+++ b/utils/scripts/migrate-investment-group-method.py
@@ -1,0 +1,61 @@
+"""Migrate boolean invest_method values to investment-group methods."""
+
+import os
+
+import duckdb
+
+
+INPUTS = "test/inputs"
+BENCHMARK = "benchmark/EU"
+TUTORIALS = "docs/src/10-tutorials/my-awesome-energy-system"
+
+
+def migrate_folder(folder_path):
+    path = os.path.join(folder_path, "investment-group-asset.csv")
+    if not os.path.exists(path):
+        return
+
+    con = duckdb.connect()
+    con.execute(f"CREATE TABLE investment_group_asset AS SELECT * FROM read_csv_auto('{path}')")
+
+    columns = [row[0] for row in con.execute("DESCRIBE investment_group_asset").fetchall()]
+    if "invest_method" not in columns:
+        con.close()
+        return
+
+    legacy_count = con.execute(
+        """
+        SELECT COUNT(*)
+        FROM investment_group_asset
+        WHERE lower(CAST(invest_method AS VARCHAR)) IN ('true', 'false')
+        """
+    ).fetchone()[0]
+    if legacy_count == 0:
+        con.close()
+        return
+
+    con.execute(
+        f"""
+        COPY (
+            SELECT * REPLACE (
+                CASE lower(CAST(invest_method AS VARCHAR))
+                    WHEN 'true' THEN 'use_only_investment_units'
+                    WHEN 'false' THEN 'none'
+                    ELSE CAST(invest_method AS VARCHAR)
+                END AS invest_method
+            )
+            FROM investment_group_asset
+        ) TO '{path}' (HEADER, DELIMITER ',')
+        """
+    )
+    print(f"{folder_path}: migrated {legacy_count} invest_method values")
+    con.close()
+
+
+for folder in sorted(os.listdir(INPUTS)):
+    migrate_folder(os.path.join(INPUTS, folder))
+
+migrate_folder(BENCHMARK)
+
+for folder in sorted(os.listdir(TUTORIALS)):
+    migrate_folder(os.path.join(TUTORIALS, folder))


### PR DESCRIPTION
Replace the boolean `invest_method` with explicit methods:

- `none`
- `use_only_investment_units`
- `use_available_units`

Available-unit groups reuse the model’s existing aggregated and compact available-unit expressions, preserving initial capacity, surviving investments, and decommissioning behavior. A direct method branch keeps the constraint builder small while allowing groups to mix vintage methods.

The migration script maps legacy `true` to `use_only_investment_units` and `false` to `none`; Norse was migrated with it.

Validation now requires investable members only for investment-only groups and matches group membership by both name and milestone year. Tests cover all methods, both expression containers, compact commission years, and validation behavior. Documentation explains the methods, coefficient semantics, and formulation.

## Related issues

Closes #1302

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
