### PR TITLE
Change objective discounting

### DIFF
--- a/benchmark/model-mps-folder/Multi-year Investments.mps
+++ b/benchmark/model-mps-folder/Multi-year Investments.mps
@@ -6484,7 +6484,7 @@ COLUMNS
     flows_investment[2030,("ccgt",_"demand")] min_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,3,22:22] 100
     flows_investment[2030,("ccgt",_"demand")] min_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,3,23:23] 100
     flows_investment[2030,("ccgt",_"demand")] min_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,3,24:24] 100
-    flows_investment[2030,("ccgt",_"demand")] OBJ 28447.352182855106
+    flows_investment[2030,("ccgt",_"demand")] OBJ 28968.217923282817
     flows_investment[2050,("ccgt",_"demand")] max_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,1,1:1] -100
     flows_investment[2050,("ccgt",_"demand")] max_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,1,2:2] -100
     flows_investment[2050,("ccgt",_"demand")] max_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,1,3:3] -100
@@ -6629,7 +6629,7 @@ COLUMNS
     flows_investment[2050,("ccgt",_"demand")] min_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,3,22:22] 100
     flows_investment[2050,("ccgt",_"demand")] min_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,3,23:23] 100
     flows_investment[2050,("ccgt",_"demand")] min_transport_flow_limit_aggregated_vintage_method[(ccgt,demand),2050,3,24:24] 100
-    flows_investment[2050,("ccgt",_"demand")] OBJ 14543.132610911514
+    flows_investment[2050,("ccgt",_"demand")] OBJ 14831.523342572647
     MARKER    'MARKER'                 'INTORG'
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,1:1] -50
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,2:2] -50
@@ -6919,7 +6919,7 @@ COLUMNS
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,3,22:22] -50
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,3,23:23] -50
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,3,24:24] -50
-    assets_investment[2030,battery] OBJ 16343.623757053916
+    assets_investment[2030,battery] OBJ 16479.420896522566
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,1,1:1] -50
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,1,2:2] -50
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,1,3:3] -50
@@ -7064,7 +7064,7 @@ COLUMNS
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,3,22:22] -50
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,3,23:23] -50
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,3,24:24] -50
-    assets_investment[2050,battery] OBJ 705.5340571895382
+    assets_investment[2050,battery] OBJ 715.0615875792707
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,1:1] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,2:2] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,3:3] -100
@@ -7137,7 +7137,7 @@ COLUMNS
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,22:22] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,23:23] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,24:24] -100
-    assets_investment[2030,ocgt] OBJ 48609.85202634835
+    assets_investment[2030,ocgt] OBJ 48702.86376571045
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,1,1:1] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,1,2:2] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,1,3:3] -100
@@ -7210,7 +7210,7 @@ COLUMNS
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,3,22:22] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,3,23:23] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,3,24:24] -100
-    assets_investment[2050,ocgt] OBJ 1862.4594780377693
+    assets_investment[2050,ocgt] OBJ 1869.0652324413174
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,6:6] -0.2
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,7:7] -1.2
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,8:8] -3
@@ -7247,7 +7247,7 @@ COLUMNS
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,15:15] -4
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,16:16] -2.3000000000000003
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,17:17] -0.5
-    assets_investment[2030,solar] OBJ 6194.684187315461
+    assets_investment[2030,solar] OBJ 6213.658582145328
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,1,6:6] -0.2
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,1,7:7] -1.2
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,1,8:8] -3
@@ -7284,7 +7284,7 @@ COLUMNS
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,3,15:15] -4
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,3,16:16] -2.3000000000000003
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,3,17:17] -0.5
-    assets_investment[2050,solar] OBJ 240.65613256246368
+    assets_investment[2050,solar] OBJ 241.9772834431733
     assets_investment[2030,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2030,1,1:1] -5.5
     assets_investment[2030,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2030,1,2:2] -5.5
     assets_investment[2030,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2030,1,3:3] -5.5
@@ -7430,7 +7430,7 @@ COLUMNS
     assets_investment[2030,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,3,23:23] -37
     assets_investment[2030,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,3,24:24] -37
     assets_investment[2030,wind] limit_decommission_compact_vintage_method[wind,2050,2030] 1
-    assets_investment[2030,wind] OBJ 39675.21557660766
+    assets_investment[2030,wind] OBJ 39827.754829161495
     assets_investment[2050,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,1,1:1] -5.5
     assets_investment[2050,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,1,2:2] -5.5
     assets_investment[2050,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,1,3:3] -5.5
@@ -7503,7 +7503,7 @@ COLUMNS
     assets_investment[2050,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,3,22:22] -37
     assets_investment[2050,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,3,23:23] -37
     assets_investment[2050,wind] max_output_flows_limit_compact_profiles_vintage_method[wind,2050,3,24:24] -37
-    assets_investment[2050,wind] OBJ 1508.634298434524
+    assets_investment[2050,wind] OBJ 1519.178098732495
     MARKER    'MARKER'                 'INTEND'
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,1:1] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,2:2] -100
@@ -7649,7 +7649,7 @@ COLUMNS
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,3,22:22] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,3,23:23] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,3,24:24] -100
-    assets_investment_energy[2030,battery] OBJ 42397.36519006819
+    assets_investment_energy[2030,battery] OBJ 42408.526598791635
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,1,1:1] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,1,2:2] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,1,3:3] -100
@@ -7722,7 +7722,7 @@ COLUMNS
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,3,22:22] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,3,23:23] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,3,24:24] -100
-    assets_investment_energy[2050,battery] OBJ 2291.333925043442
+    assets_investment_energy[2050,battery] OBJ 2292.6042624287397
     MARKER    'MARKER'                 'INTORG'
     assets_decommission[battery,2030,2030] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,1:1] 50
     assets_decommission[battery,2030,2030] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,2:2] 50

--- a/benchmark/model-mps-folder/Norse.mps
+++ b/benchmark/model-mps-folder/Norse.mps
@@ -34999,7 +34999,7 @@ COLUMNS
     flows_investment[2030,("Asgard_E_demand",_"Midgard_E_demand")] min_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Midgard_E_demand),2030,2,22:22] 1000
     flows_investment[2030,("Asgard_E_demand",_"Midgard_E_demand")] min_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Midgard_E_demand),2030,2,23:23] 1000
     flows_investment[2030,("Asgard_E_demand",_"Midgard_E_demand")] min_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Midgard_E_demand),2030,2,24:24] 1000
-    flows_investment[2030,("Asgard_E_demand",_"Midgard_E_demand")] OBJ 2000000
+    flows_investment[2030,("Asgard_E_demand",_"Midgard_E_demand")] OBJ 2040000
     MARKER    'MARKER'                 'INTEND'
     flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] max_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Valhalla_E_balance),2030,1,1:1] -950
     flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] max_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Valhalla_E_balance),2030,1,2:2] -950
@@ -35385,7 +35385,7 @@ COLUMNS
     flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] min_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Valhalla_E_balance),2030,2,22:22] 980
     flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] min_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Valhalla_E_balance),2030,2,23:23] 980
     flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] min_transport_flow_limit_aggregated_vintage_method[(Asgard_E_demand,Valhalla_E_balance),2030,2,24:24] 980
-    flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] OBJ 5000000
+    flows_investment[2030,("Asgard_E_demand",_"Valhalla_E_balance")] OBJ 5100000
     MARKER    'MARKER'                 'INTORG'
     flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] max_transport_flow_limit_aggregated_vintage_method[(Midgard_E_demand,Valhalla_E_balance),2030,1,1:1] -1000
     flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] max_transport_flow_limit_aggregated_vintage_method[(Midgard_E_demand,Valhalla_E_balance),2030,1,2:2] -1000
@@ -35771,7 +35771,7 @@ COLUMNS
     flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] min_transport_flow_limit_aggregated_vintage_method[(Midgard_E_demand,Valhalla_E_balance),2030,2,22:22] 1000
     flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] min_transport_flow_limit_aggregated_vintage_method[(Midgard_E_demand,Valhalla_E_balance),2030,2,23:23] 1000
     flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] min_transport_flow_limit_aggregated_vintage_method[(Midgard_E_demand,Valhalla_E_balance),2030,2,24:24] 1000
-    flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] OBJ 3500000
+    flows_investment[2030,("Midgard_E_demand",_"Valhalla_E_balance")] OBJ 3570000
     assets_investment[2030,Asgard_CCGT] max_output_flows_limit_aggregated_vintage_method[Asgard_CCGT,2030,1,1:1] -500
     assets_investment[2030,Asgard_CCGT] max_output_flows_limit_aggregated_vintage_method[Asgard_CCGT,2030,1,2:2] -500
     assets_investment[2030,Asgard_CCGT] max_output_flows_limit_aggregated_vintage_method[Asgard_CCGT,2030,1,3:3] -500
@@ -36157,7 +36157,7 @@ COLUMNS
     assets_investment[2030,Asgard_CCGT] limit_units_on_aggregated_vintage_method[Asgard_CCGT,2030,2,23:23] -1
     assets_investment[2030,Asgard_CCGT] limit_units_on_aggregated_vintage_method[Asgard_CCGT,2030,2,24:24] -1
     assets_investment[2030,Asgard_CCGT] investment_group[ccgt_min,2030] 500
-    assets_investment[2030,Asgard_CCGT] OBJ 325000
+    assets_investment[2030,Asgard_CCGT] OBJ 341250
     assets_investment[2030,Midgard_Wind] max_output_flows_limit_aggregated_vintage_method[Midgard_Wind,2030,1,1:1] -1.107
     assets_investment[2030,Midgard_Wind] max_output_flows_limit_aggregated_vintage_method[Midgard_Wind,2030,1,2:2] -1.059
     assets_investment[2030,Midgard_Wind] max_output_flows_limit_aggregated_vintage_method[Midgard_Wind,2030,1,3:3] -1.083
@@ -36351,7 +36351,7 @@ COLUMNS
     assets_investment[2030,Midgard_Wind] max_output_flows_limit_aggregated_vintage_method[Midgard_Wind,2030,2,23:23] -2.3031
     assets_investment[2030,Midgard_Wind] max_output_flows_limit_aggregated_vintage_method[Midgard_Wind,2030,2,24:24] -2.3354999999999997
     assets_investment[2030,Midgard_Wind] investment_group[renewables_max,2030] 3
-    assets_investment[2030,Midgard_Wind] OBJ 3900
+    assets_investment[2030,Midgard_Wind] OBJ 4095
     assets_investment[2030,Midgard_PHS] max_output_flows_limit_aggregated_vintage_method[Midgard_PHS,2030,1,1:1] -200
     assets_investment[2030,Midgard_PHS] max_output_flows_limit_aggregated_vintage_method[Midgard_PHS,2030,1,2:2] -200
     assets_investment[2030,Midgard_PHS] max_output_flows_limit_aggregated_vintage_method[Midgard_PHS,2030,1,3:3] -200
@@ -36736,7 +36736,7 @@ COLUMNS
     assets_investment[2030,Midgard_PHS] max_input_flows_limit_aggregated_vintage_method[Midgard_PHS,2030,2,22:22] -200
     assets_investment[2030,Midgard_PHS] max_input_flows_limit_aggregated_vintage_method[Midgard_PHS,2030,2,23:23] -200
     assets_investment[2030,Midgard_PHS] max_input_flows_limit_aggregated_vintage_method[Midgard_PHS,2030,2,24:24] -200
-    assets_investment[2030,Midgard_PHS] OBJ 160000
+    assets_investment[2030,Midgard_PHS] OBJ 168000
     assets_investment[2030,Valhalla_Fuel_cell] max_output_flows_limit_aggregated_vintage_method[Valhalla_Fuel_cell,2030,1,1:1] -100
     assets_investment[2030,Valhalla_Fuel_cell] max_output_flows_limit_aggregated_vintage_method[Valhalla_Fuel_cell,2030,1,2:2] -100
     assets_investment[2030,Valhalla_Fuel_cell] max_output_flows_limit_aggregated_vintage_method[Valhalla_Fuel_cell,2030,1,3:3] -100
@@ -36929,7 +36929,7 @@ COLUMNS
     assets_investment[2030,Valhalla_Fuel_cell] max_output_flows_limit_aggregated_vintage_method[Valhalla_Fuel_cell,2030,2,22:22] -100
     assets_investment[2030,Valhalla_Fuel_cell] max_output_flows_limit_aggregated_vintage_method[Valhalla_Fuel_cell,2030,2,23:23] -100
     assets_investment[2030,Valhalla_Fuel_cell] max_output_flows_limit_aggregated_vintage_method[Valhalla_Fuel_cell,2030,2,24:24] -100
-    assets_investment[2030,Valhalla_Fuel_cell] OBJ 80000
+    assets_investment[2030,Valhalla_Fuel_cell] OBJ 84000
     assets_investment[2030,Asgard_Solar] max_output_flows_limit_aggregated_vintage_method[Asgard_Solar,2030,1,9:9] -4.3999999999999995
     assets_investment[2030,Asgard_Solar] max_output_flows_limit_aggregated_vintage_method[Asgard_Solar,2030,1,10:10] -12.6
     assets_investment[2030,Asgard_Solar] max_output_flows_limit_aggregated_vintage_method[Asgard_Solar,2030,1,11:11] -17.5
@@ -36995,7 +36995,7 @@ COLUMNS
     assets_investment[2030,Asgard_Solar] max_output_flows_limit_aggregated_vintage_method[Asgard_Solar,2030,2,13:15] -17.875
     assets_investment[2030,Asgard_Solar] max_output_flows_limit_aggregated_vintage_method[Asgard_Solar,2030,2,16:16] -0.25
     assets_investment[2030,Asgard_Solar] investment_group[renewables_max,2030] 100
-    assets_investment[2030,Asgard_Solar] OBJ 35000
+    assets_investment[2030,Asgard_Solar] OBJ 36750
     assets_investment[2030,Asgard_Battery] max_output_flows_limit_aggregated_vintage_method[Asgard_Battery,2030,1,1:3] -100
     assets_investment[2030,Asgard_Battery] max_output_flows_limit_aggregated_vintage_method[Asgard_Battery,2030,1,4:6] -100
     assets_investment[2030,Asgard_Battery] max_output_flows_limit_aggregated_vintage_method[Asgard_Battery,2030,1,7:9] -100
@@ -37401,7 +37401,7 @@ COLUMNS
     assets_investment[2030,Asgard_Battery] max_storage_level_intra_rep_period_limit[Asgard_Battery,2030,2,13:16] -10000
     assets_investment[2030,Asgard_Battery] max_storage_level_intra_rep_period_limit[Asgard_Battery,2030,2,17:20] -10000
     assets_investment[2030,Asgard_Battery] max_storage_level_intra_rep_period_limit[Asgard_Battery,2030,2,21:24] -10000
-    assets_investment[2030,Asgard_Battery] OBJ 30000
+    assets_investment[2030,Asgard_Battery] OBJ 31500
     assets_investment[2030,Valhalla_H2_generator] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_generator,2030,1,1:1] -100
     assets_investment[2030,Valhalla_H2_generator] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_generator,2030,1,2:2] -100
     assets_investment[2030,Valhalla_H2_generator] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_generator,2030,1,3:3] -100
@@ -37594,7 +37594,7 @@ COLUMNS
     assets_investment[2030,Valhalla_H2_generator] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_generator,2030,2,22:22] -100
     assets_investment[2030,Valhalla_H2_generator] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_generator,2030,2,23:23] -100
     assets_investment[2030,Valhalla_H2_generator] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_generator,2030,2,24:24] -100
-    assets_investment[2030,Valhalla_H2_generator] OBJ 47900
+    assets_investment[2030,Valhalla_H2_generator] OBJ 50295.00000000001
     MARKER    'MARKER'                 'INTEND'
     assets_investment[2030,Midgard_Nuclear_SMR] max_output_flows_limit_aggregated_vintage_method[Midgard_Nuclear_SMR,2030,1,1:1] -150
     assets_investment[2030,Midgard_Nuclear_SMR] max_output_flows_limit_aggregated_vintage_method[Midgard_Nuclear_SMR,2030,1,2:2] -150
@@ -37788,7 +37788,7 @@ COLUMNS
     assets_investment[2030,Midgard_Nuclear_SMR] max_output_flows_limit_aggregated_vintage_method[Midgard_Nuclear_SMR,2030,2,22:22] -150
     assets_investment[2030,Midgard_Nuclear_SMR] max_output_flows_limit_aggregated_vintage_method[Midgard_Nuclear_SMR,2030,2,23:23] -150
     assets_investment[2030,Midgard_Nuclear_SMR] max_output_flows_limit_aggregated_vintage_method[Midgard_Nuclear_SMR,2030,2,24:24] -150
-    assets_investment[2030,Midgard_Nuclear_SMR] OBJ 900000
+    assets_investment[2030,Midgard_Nuclear_SMR] OBJ 945000
     assets_investment[2030,Midgard_CCGT] max_output_flows_limit_aggregated_vintage_method[Midgard_CCGT,2030,1,1:1] -500
     assets_investment[2030,Midgard_CCGT] max_output_flows_limit_aggregated_vintage_method[Midgard_CCGT,2030,1,2:2] -500
     assets_investment[2030,Midgard_CCGT] max_output_flows_limit_aggregated_vintage_method[Midgard_CCGT,2030,1,3:3] -500
@@ -38174,7 +38174,7 @@ COLUMNS
     assets_investment[2030,Midgard_CCGT] limit_units_on_aggregated_vintage_method[Midgard_CCGT,2030,2,23:23] -1
     assets_investment[2030,Midgard_CCGT] limit_units_on_aggregated_vintage_method[Midgard_CCGT,2030,2,24:24] -1
     assets_investment[2030,Midgard_CCGT] investment_group[ccgt_min,2030] 500
-    assets_investment[2030,Midgard_CCGT] OBJ 325000
+    assets_investment[2030,Midgard_CCGT] OBJ 341250
     MARKER    'MARKER'                 'INTORG'
     assets_investment[2030,Valhalla_GT] max_output_flows_limit_aggregated_vintage_method[Valhalla_GT,2030,1,1:1] -500
     assets_investment[2030,Valhalla_GT] max_output_flows_limit_aggregated_vintage_method[Valhalla_GT,2030,1,2:2] -500
@@ -38368,7 +38368,7 @@ COLUMNS
     assets_investment[2030,Valhalla_GT] max_output_flows_limit_aggregated_vintage_method[Valhalla_GT,2030,2,22:22] -500
     assets_investment[2030,Valhalla_GT] max_output_flows_limit_aggregated_vintage_method[Valhalla_GT,2030,2,23:23] -500
     assets_investment[2030,Valhalla_GT] max_output_flows_limit_aggregated_vintage_method[Valhalla_GT,2030,2,24:24] -500
-    assets_investment[2030,Valhalla_GT] OBJ 200000
+    assets_investment[2030,Valhalla_GT] OBJ 210000
     assets_investment[2030,Valhalla_H2_storage] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_storage,2030,1,1:1] -500
     assets_investment[2030,Valhalla_H2_storage] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_storage,2030,1,2:2] -500
     assets_investment[2030,Valhalla_H2_storage] max_output_flows_limit_aggregated_vintage_method[Valhalla_H2_storage,2030,1,3:3] -500
@@ -38753,7 +38753,7 @@ COLUMNS
     assets_investment[2030,Valhalla_H2_storage] max_input_flows_limit_aggregated_vintage_method[Valhalla_H2_storage,2030,2,22:22] -500
     assets_investment[2030,Valhalla_H2_storage] max_input_flows_limit_aggregated_vintage_method[Valhalla_H2_storage,2030,2,23:23] -500
     assets_investment[2030,Valhalla_H2_storage] max_input_flows_limit_aggregated_vintage_method[Valhalla_H2_storage,2030,2,24:24] -500
-    assets_investment[2030,Valhalla_H2_storage] OBJ 50
+    assets_investment[2030,Valhalla_H2_storage] OBJ 52.50000000000001
     assets_investment[2030,Valhalla_Electrolyser] max_output_flows_limit_aggregated_vintage_method[Valhalla_Electrolyser,2030,1,1:1] -100
     assets_investment[2030,Valhalla_Electrolyser] max_output_flows_limit_aggregated_vintage_method[Valhalla_Electrolyser,2030,1,2:2] -100
     assets_investment[2030,Valhalla_Electrolyser] max_output_flows_limit_aggregated_vintage_method[Valhalla_Electrolyser,2030,1,3:3] -100
@@ -38946,7 +38946,7 @@ COLUMNS
     assets_investment[2030,Valhalla_Electrolyser] max_output_flows_limit_aggregated_vintage_method[Valhalla_Electrolyser,2030,2,22:22] -100
     assets_investment[2030,Valhalla_Electrolyser] max_output_flows_limit_aggregated_vintage_method[Valhalla_Electrolyser,2030,2,23:23] -100
     assets_investment[2030,Valhalla_Electrolyser] max_output_flows_limit_aggregated_vintage_method[Valhalla_Electrolyser,2030,2,24:24] -100
-    assets_investment[2030,Valhalla_Electrolyser] OBJ 126000
+    assets_investment[2030,Valhalla_Electrolyser] OBJ 132300
     assets_investment[2030,Valhalla_Heat_pump] max_output_flows_limit_aggregated_vintage_method[Valhalla_Heat_pump,2030,1,1:1] -100
     assets_investment[2030,Valhalla_Heat_pump] max_output_flows_limit_aggregated_vintage_method[Valhalla_Heat_pump,2030,1,2:2] -100
     assets_investment[2030,Valhalla_Heat_pump] max_output_flows_limit_aggregated_vintage_method[Valhalla_Heat_pump,2030,1,3:3] -100
@@ -39139,7 +39139,7 @@ COLUMNS
     assets_investment[2030,Valhalla_Heat_pump] max_output_flows_limit_aggregated_vintage_method[Valhalla_Heat_pump,2030,2,22:22] -100
     assets_investment[2030,Valhalla_Heat_pump] max_output_flows_limit_aggregated_vintage_method[Valhalla_Heat_pump,2030,2,23:23] -100
     assets_investment[2030,Valhalla_Heat_pump] max_output_flows_limit_aggregated_vintage_method[Valhalla_Heat_pump,2030,2,24:24] -100
-    assets_investment[2030,Valhalla_Heat_pump] OBJ 30000
+    assets_investment[2030,Valhalla_Heat_pump] OBJ 31500
     MARKER    'MARKER'                 'INTEND'
     assets_investment_energy[2030,Midgard_PHS] max_storage_level_intra_rep_period_limit[Midgard_PHS,2030,1,1:1] -100
     assets_investment_energy[2030,Midgard_PHS] max_storage_level_intra_rep_period_limit[Midgard_PHS,2030,1,2:2] -100
@@ -39333,7 +39333,7 @@ COLUMNS
     assets_investment_energy[2030,Midgard_PHS] max_storage_level_intra_rep_period_limit[Midgard_PHS,2030,2,22:22] -100
     assets_investment_energy[2030,Midgard_PHS] max_storage_level_intra_rep_period_limit[Midgard_PHS,2030,2,23:23] -100
     assets_investment_energy[2030,Midgard_PHS] max_storage_level_intra_rep_period_limit[Midgard_PHS,2030,2,24:24] -100
-    assets_investment_energy[2030,Midgard_PHS] OBJ 50500
+    assets_investment_energy[2030,Midgard_PHS] OBJ 53000
     assets_decommission[G_imports,2030,2030] max_output_flows_limit_aggregated_vintage_method[G_imports,2030,1,1:1] 75000
     assets_decommission[G_imports,2030,2030] max_output_flows_limit_aggregated_vintage_method[G_imports,2030,1,2:2] 75000
     assets_decommission[G_imports,2030,2030] max_output_flows_limit_aggregated_vintage_method[G_imports,2030,1,3:3] 75000

--- a/benchmark/model-mps-folder/Tinier.mps
+++ b/benchmark/model-mps-folder/Tinier.mps
@@ -1515,7 +1515,7 @@ COLUMNS
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2030,3,22:22] -400
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2030,3,23:23] -400
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2030,3,24:24] -400
-    assets_investment[2030,ccgt] OBJ 16000
+    assets_investment[2030,ccgt] OBJ 16800
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,1:1] -5.5
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,2:2] -5.5
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,3:3] -5.5
@@ -1588,7 +1588,7 @@ COLUMNS
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,3,22:22] -37
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,3,23:23] -37
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,3,24:24] -37
-    assets_investment[2030,wind] OBJ 3500
+    assets_investment[2030,wind] OBJ 3675
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,6:6] -0.2
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,7:7] -1.2
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,8:8] -3
@@ -1625,7 +1625,7 @@ COLUMNS
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,15:15] -4
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,16:16] -2.3000000000000003
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,17:17] -0.5
-    assets_investment[2030,solar] OBJ 500
+    assets_investment[2030,solar] OBJ 525
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,1:1] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,2:2] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,3:3] -100
@@ -1698,7 +1698,7 @@ COLUMNS
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,22:22] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,23:23] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,24:24] -100
-    assets_investment[2030,ocgt] OBJ 2500
+    assets_investment[2030,ocgt] OBJ 2625
     MARKER    'MARKER'                 'INTEND'
 RHS
     rhs       max_output_flows_limit_aggregated_vintage_method[ccgt,2030,1,1:1] 0

--- a/benchmark/model-mps-folder/Tiny.mps
+++ b/benchmark/model-mps-folder/Tiny.mps
@@ -1515,7 +1515,7 @@ COLUMNS
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2030,3,22:22] -400
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2030,3,23:23] -400
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2030,3,24:24] -400
-    assets_investment[2030,ccgt] OBJ 16000
+    assets_investment[2030,ccgt] OBJ 16800
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,1:1] -5.5
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,2:2] -5.5
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,3:3] -5.5
@@ -1588,7 +1588,7 @@ COLUMNS
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,3,22:22] -37
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,3,23:23] -37
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,3,24:24] -37
-    assets_investment[2030,wind] OBJ 3500
+    assets_investment[2030,wind] OBJ 3675
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,6:6] -0.2
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,7:7] -1.2
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,8:8] -3
@@ -1625,7 +1625,7 @@ COLUMNS
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,15:15] -4
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,16:16] -2.3000000000000003
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,3,17:17] -0.5
-    assets_investment[2030,solar] OBJ 500
+    assets_investment[2030,solar] OBJ 525
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,1:1] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,2:2] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,3:3] -100
@@ -1698,7 +1698,7 @@ COLUMNS
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,22:22] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,23:23] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,3,24:24] -100
-    assets_investment[2030,ocgt] OBJ 2500
+    assets_investment[2030,ocgt] OBJ 2625
     MARKER    'MARKER'                 'INTEND'
 RHS
     rhs       max_output_flows_limit_aggregated_vintage_method[ccgt,2030,1,1:1] 0

--- a/benchmark/model-mps-folder/TwoStage-StochOpt RPs cross Scenario.mps
+++ b/benchmark/model-mps-folder/TwoStage-StochOpt RPs cross Scenario.mps
@@ -25820,7 +25820,7 @@ COLUMNS
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,8,22:22] -800
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,8,23:23] -800
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,8,24:24] -800
-    assets_investment[2030,ccgt] OBJ 1696000000
+    assets_investment[2030,ccgt] OBJ 1760000000
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,1:1] -196.44901418961217
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,2:2] -190.04414048563163
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,3:3] -193.01324964216835
@@ -26013,7 +26013,7 @@ COLUMNS
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,8,22:22] -110.75373987372681
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,8,23:23] -83.54848043214864
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,8,24:24] -77.6037428428048
-    assets_investment[2030,wind] OBJ 1249800000
+    assets_investment[2030,wind] OBJ 1295800000
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,9:9] -9.955792989290435
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,10:10] -47.21006252974052
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,11:11] -92.9502575955552
@@ -26104,7 +26104,7 @@ COLUMNS
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,8,18:18] -136.72941176576325
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,8,19:19] -37.98756290269395
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,8,20:20] -1.142401850409655
-    assets_investment[2030,solar] OBJ 945500000
+    assets_investment[2030,solar] OBJ 985500000
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,1:1] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,2:2] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,3:3] -100
@@ -26297,7 +26297,7 @@ COLUMNS
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,8,22:22] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,8,23:23] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,8,24:24] -100
-    assets_investment[2030,ocgt] OBJ 180000000
+    assets_investment[2030,ocgt] OBJ 187250000
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2030,1,1:1] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2030,1,2:2] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2030,1,3:3] -100
@@ -26490,7 +26490,7 @@ COLUMNS
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,8,22:22] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,8,23:23] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,8,24:24] -100
-    assets_investment[2030,electrolizer] OBJ 204565000
+    assets_investment[2030,electrolizer] OBJ 212415000
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2030,1,1:1] -8.66422716651228
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2030,1,2:2] -4.4865339604706485
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2030,1,3:3] -4.4966248949117755
@@ -26677,7 +26677,7 @@ COLUMNS
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,8,22:22] -243.2918347362304
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,8,23:23] -241.4834263827168
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,8,24:24] -195.50828487662196
-    assets_investment[2030,wind_offshore] OBJ 3376000000
+    assets_investment[2030,wind_offshore] OBJ 3507000000
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,1:1] -50
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,2:2] -50
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,3:3] -50
@@ -27062,7 +27062,7 @@ COLUMNS
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,8,22:22] -50
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,8,23:23] -50
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,8,24:24] -50
-    assets_investment[2030,battery] OBJ 112600000
+    assets_investment[2030,battery] OBJ 116600000
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,5,1:1] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,5,2:2] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,5,3:3] -800
@@ -27159,7 +27159,7 @@ COLUMNS
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,8,22:22] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,8,23:23] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,8,24:24] -800
-    assets_investment[2050,ccgt] OBJ 8.136465114577469e7
+    assets_investment[2050,ccgt] OBJ 8.503288370306346e7
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,5,1:1] -196.44901418961217
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,5,2:2] -190.04414048563163
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,5,3:3] -193.01324964216835
@@ -27256,7 +27256,7 @@ COLUMNS
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,8,22:22] -110.75373987372681
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,8,23:23] -83.54848043214864
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,8,24:24] -77.6037428428048
-    assets_investment[2050,wind] OBJ 6.78803488237382e7
+    assets_investment[2050,wind] OBJ 7.078436626492524e7
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,5,9:9] -9.955792989290435
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,5,10:10] -47.21006252974052
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,5,11:11] -92.9502575955552
@@ -27302,7 +27302,7 @@ COLUMNS
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,8,18:18] -136.72941176576325
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,8,19:19] -37.98756290269395
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,8,20:20] -1.142401850409655
-    assets_investment[2050,solar] OBJ 4.944236917585462e7
+    assets_investment[2050,solar] OBJ 5.1639487634647325e7
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,5,1:1] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,5,2:2] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,5,3:3] -100
@@ -27399,7 +27399,7 @@ COLUMNS
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,8,22:22] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,8,23:23] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,8,24:24] -100
-    assets_investment[2050,ocgt] OBJ 9.788473835170925e6
+    assets_investment[2050,ocgt] OBJ 1.0227897526929464e7
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,5,1:1] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,5,2:2] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,5,3:3] -100
@@ -27496,7 +27496,7 @@ COLUMNS
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,8,22:22] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,8,23:23] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,8,24:24] -100
-    assets_investment[2050,electrolizer] OBJ 2.8340668599156374e6
+    assets_investment[2050,electrolizer] OBJ 2.9525202029114207e6
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,5,1:1] -8.66422716651228
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,5,2:2] -4.4865339604706485
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,5,3:3] -4.4966248949117755
@@ -27590,7 +27590,7 @@ COLUMNS
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,8,22:22] -243.2918347362304
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,8,23:23] -241.4834263827168
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,8,24:24] -195.50828487662196
-    assets_investment[2050,wind_offshore] OBJ 1.294616860220511e8
+    assets_investment[2050,wind_offshore] OBJ 1.3473477032315403e8
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,5,1:1] -50
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,5,2:2] -50
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,5,3:3] -50
@@ -27783,7 +27783,7 @@ COLUMNS
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,8,22:22] -50
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,8,23:23] -50
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,8,24:24] -50
-    assets_investment[2050,battery] OBJ 2.9690668599156374e6
+    assets_investment[2050,battery] OBJ 3.0875202029114207e6
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,1:1] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,2:2] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,3:3] -100
@@ -27976,7 +27976,7 @@ COLUMNS
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,8,22:22] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,8,23:23] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,8,24:24] -100
-    assets_investment_energy[2030,battery] OBJ 8000000
+    assets_investment_energy[2030,battery] OBJ 8400000
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,5,1:1] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,5,2:2] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,5,3:3] -100
@@ -28073,7 +28073,7 @@ COLUMNS
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,8,22:22] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,8,23:23] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,8,24:24] -100
-    assets_investment_energy[2050,battery] OBJ 236906.68599156375
+    assets_investment_energy[2050,battery] OBJ 248752.02029114208
     storage_level_intra_rep_period[battery,2030,1,1:1] max_storage_level_intra_rep_period_limit[battery,2030,1,1:1] 1
     storage_level_intra_rep_period[battery,2030,1,1:1] min_storage_level_intra_rep_period_limit[battery,2030,1,1:1] 1
     storage_level_intra_rep_period[battery,2030,1,1:1] balance_storage_rep_period[battery,2030,1,1:1] 1

--- a/benchmark/model-mps-folder/TwoStage-StochOpt RPs per Scenario.mps
+++ b/benchmark/model-mps-folder/TwoStage-StochOpt RPs per Scenario.mps
@@ -51164,7 +51164,7 @@ COLUMNS
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,24,22:22] -800
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,24,23:23] -800
     assets_investment[2030,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,24,24:24] -800
-    assets_investment[2030,ccgt] OBJ 1696000000
+    assets_investment[2030,ccgt] OBJ 1760000000
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,1:1] -104.44867743038115
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,2:2] -92.41494842480972
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,3:3] -80.72677536276804
@@ -51741,7 +51741,7 @@ COLUMNS
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,24,22:22] -235.54029823382479
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,24,23:23] -258.62059469977845
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,24,24:24] -271.5049209273877
-    assets_investment[2030,wind] OBJ 1249800000
+    assets_investment[2030,wind] OBJ 1295800000
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,9:9] -40.26243206668076
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,10:10] -149.83153885205925
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,11:11] -238.03779638123234
@@ -52000,7 +52000,7 @@ COLUMNS
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,24,15:15] -78.33219059886954
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,24,16:16] -54.27955158237515
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,24,17:17] -24.67511414718869
-    assets_investment[2030,solar] OBJ 945500000
+    assets_investment[2030,solar] OBJ 985500000
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,1:1] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,2:2] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,3:3] -100
@@ -52577,7 +52577,7 @@ COLUMNS
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,24,22:22] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,24,23:23] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,24,24:24] -100
-    assets_investment[2030,ocgt] OBJ 180000000
+    assets_investment[2030,ocgt] OBJ 187250000
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2030,1,1:1] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2030,1,2:2] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2030,1,3:3] -100
@@ -53154,7 +53154,7 @@ COLUMNS
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,24,22:22] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,24,23:23] -100
     assets_investment[2030,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,24,24:24] -100
-    assets_investment[2030,electrolizer] OBJ 204565000
+    assets_investment[2030,electrolizer] OBJ 212415000
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2030,1,1:1] -17.52841064075125
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2030,1,2:2] -8.917436496002512
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2030,1,3:3] -6.743069121657956
@@ -53683,7 +53683,7 @@ COLUMNS
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,24,22:22] -234.6514929245678
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,24,23:23] -76.12589582395655
     assets_investment[2030,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,24,24:24] -36.30678159137165
-    assets_investment[2030,wind_offshore] OBJ 3376000000
+    assets_investment[2030,wind_offshore] OBJ 3507000000
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,1:1] -50
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,2:2] -50
     assets_investment[2030,battery] max_output_flows_limit_aggregated_vintage_method[battery,2030,1,3:3] -50
@@ -54836,7 +54836,7 @@ COLUMNS
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,24,22:22] -50
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,24,23:23] -50
     assets_investment[2030,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,24,24:24] -50
-    assets_investment[2030,battery] OBJ 112600000
+    assets_investment[2030,battery] OBJ 116600000
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,9,1:1] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,9,2:2] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,9,3:3] -800
@@ -55125,7 +55125,7 @@ COLUMNS
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,24,22:22] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,24,23:23] -800
     assets_investment[2050,ccgt] max_output_flows_limit_aggregated_vintage_method[ccgt,2050,24,24:24] -800
-    assets_investment[2050,ccgt] OBJ 8.136465114577469e7
+    assets_investment[2050,ccgt] OBJ 8.503288370306346e7
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,9,1:1] -104.44867743038115
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,9,2:2] -92.41494842480972
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,9,3:3] -80.72677536276804
@@ -55414,7 +55414,7 @@ COLUMNS
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,24,22:22] -235.54029823382479
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,24,23:23] -258.62059469977845
     assets_investment[2050,wind] max_output_flows_limit_aggregated_vintage_method[wind,2050,24,24:24] -271.5049209273877
-    assets_investment[2050,wind] OBJ 6.78803488237382e7
+    assets_investment[2050,wind] OBJ 7.078436626492524e7
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,9,9:9] -40.26243206668076
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,9,10:10] -149.83153885205925
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,9,11:11] -238.03779638123234
@@ -55544,7 +55544,7 @@ COLUMNS
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,24,15:15] -78.33219059886954
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,24,16:16] -54.27955158237515
     assets_investment[2050,solar] max_output_flows_limit_aggregated_vintage_method[solar,2050,24,17:17] -24.67511414718869
-    assets_investment[2050,solar] OBJ 4.944236917585462e7
+    assets_investment[2050,solar] OBJ 5.1639487634647325e7
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,9,1:1] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,9,2:2] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,9,3:3] -100
@@ -55833,7 +55833,7 @@ COLUMNS
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,24,22:22] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,24,23:23] -100
     assets_investment[2050,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2050,24,24:24] -100
-    assets_investment[2050,ocgt] OBJ 9.788473835170925e6
+    assets_investment[2050,ocgt] OBJ 1.0227897526929464e7
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,9,1:1] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,9,2:2] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,9,3:3] -100
@@ -56122,7 +56122,7 @@ COLUMNS
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,24,22:22] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,24,23:23] -100
     assets_investment[2050,electrolizer] max_output_flows_limit_aggregated_vintage_method[electrolizer,2050,24,24:24] -100
-    assets_investment[2050,electrolizer] OBJ 2.8340668599156374e6
+    assets_investment[2050,electrolizer] OBJ 2.9525202029114207e6
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,9,1:1] -17.52841064075125
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,9,2:2] -8.917436496002512
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,9,3:3] -6.743069121657956
@@ -56387,7 +56387,7 @@ COLUMNS
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,24,22:22] -234.6514929245678
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,24,23:23] -76.12589582395655
     assets_investment[2050,wind_offshore] max_output_flows_limit_aggregated_vintage_method[wind_offshore,2050,24,24:24] -36.30678159137165
-    assets_investment[2050,wind_offshore] OBJ 1.294616860220511e8
+    assets_investment[2050,wind_offshore] OBJ 1.3473477032315403e8
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,9,1:1] -50
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,9,2:2] -50
     assets_investment[2050,battery] max_output_flows_limit_aggregated_vintage_method[battery,2050,9,3:3] -50
@@ -56964,7 +56964,7 @@ COLUMNS
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,24,22:22] -50
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,24,23:23] -50
     assets_investment[2050,battery] max_input_flows_limit_aggregated_vintage_method[battery,2050,24,24:24] -50
-    assets_investment[2050,battery] OBJ 2.9690668599156374e6
+    assets_investment[2050,battery] OBJ 3.0875202029114207e6
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,1:1] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,2:2] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2030,1,3:3] -100
@@ -57541,7 +57541,7 @@ COLUMNS
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,24,22:22] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,24,23:23] -100
     assets_investment_energy[2030,battery] max_storage_level_intra_rep_period_limit[battery,2050,24,24:24] -100
-    assets_investment_energy[2030,battery] OBJ 8000000
+    assets_investment_energy[2030,battery] OBJ 8400000
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,9,1:1] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,9,2:2] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,9,3:3] -100
@@ -57830,7 +57830,7 @@ COLUMNS
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,24,22:22] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,24,23:23] -100
     assets_investment_energy[2050,battery] max_storage_level_intra_rep_period_limit[battery,2050,24,24:24] -100
-    assets_investment_energy[2050,battery] OBJ 236906.68599156375
+    assets_investment_energy[2050,battery] OBJ 248752.02029114208
     storage_level_intra_rep_period[battery,2030,1,1:1] max_storage_level_intra_rep_period_limit[battery,2030,1,1:1] 1
     storage_level_intra_rep_period[battery,2030,1,1:1] min_storage_level_intra_rep_period_limit[battery,2030,1,1:1] 1
     storage_level_intra_rep_period[battery,2030,1,1:1] balance_storage_rep_period[battery,2030,1,1:1] 1

--- a/benchmark/model-mps-folder/UC-ramping.mps
+++ b/benchmark/model-mps-folder/UC-ramping.mps
@@ -1435,7 +1435,7 @@ COLUMNS
     assets_investment[2030,ccgt] limit_units_on_aggregated_vintage_method[ccgt,2030,1,16:18] -1
     assets_investment[2030,ccgt] limit_units_on_aggregated_vintage_method[ccgt,2030,1,19:21] -1
     assets_investment[2030,ccgt] limit_units_on_aggregated_vintage_method[ccgt,2030,1,22:24] -1
-    assets_investment[2030,ccgt] OBJ 8000
+    assets_investment[2030,ccgt] OBJ 8400
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,1:1] -16.400000000000002
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,2:2] -15.2
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,3:3] -14.2
@@ -1460,7 +1460,7 @@ COLUMNS
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,22:22] -38.800000000000004
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,23:23] -32.9
     assets_investment[2030,wind] max_output_flows_limit_aggregated_vintage_method[wind,2030,1,24:24] -30.8
-    assets_investment[2030,wind] OBJ 10000
+    assets_investment[2030,wind] OBJ 10500
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,7:7] -0.5
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,8:8] -3.5000000000000004
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,9:9] -10
@@ -1473,7 +1473,7 @@ COLUMNS
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,16:16] -14.499999999999998
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,17:17] -6.5
     assets_investment[2030,solar] max_output_flows_limit_aggregated_vintage_method[solar,2030,1,18:18] -1.5
-    assets_investment[2030,solar] OBJ 750
+    assets_investment[2030,solar] OBJ 787.5
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,1:1] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,2:2] -100
     assets_investment[2030,ocgt] max_output_flows_limit_aggregated_vintage_method[ocgt,2030,1,3:3] -100
@@ -1522,7 +1522,7 @@ COLUMNS
     assets_investment[2030,ocgt] limit_units_on_aggregated_vintage_method[ocgt,2030,1,22:22] -1
     assets_investment[2030,ocgt] limit_units_on_aggregated_vintage_method[ocgt,2030,1,23:23] -1
     assets_investment[2030,ocgt] limit_units_on_aggregated_vintage_method[ocgt,2030,1,24:24] -1
-    assets_investment[2030,ocgt] OBJ 2500
+    assets_investment[2030,ocgt] OBJ 2625
     MARKER    'MARKER'                 'INTEND'
     assets_decommission[gas,2030,2030] max_output_flows_limit_aggregated_vintage_method[gas,2030,1,1:1] 1800
     assets_decommission[gas,2030,2030] max_output_flows_limit_aggregated_vintage_method[gas,2030,1,2:2] 1800

--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -336,7 +336,13 @@ The model accounts for discounting in multi-year investment modelling. For more 
 #### Discounting Factor for Asset Investment Costs
 
 ```math
-p_{a, y}^{\text{discounting factor asset inv cost}}=\frac{1}{(1+p^{\text{social discount rate}})^{y-p^{\text{discount year}}}}(1-\frac{p_{a, y}^{\text{salvage value}}}{p_{a, y}^{\text{inv cost}}}) \quad \forall a \in \mathcal{A}_y^{\text{i}}, \forall y \in \mathcal{Y}
+p_{a, y}^{\text{discounting factor asset inv cost}}=
+\begin{cases}
+0, & p_{a,y}^{\text{inv cost}} = 0, \\
+\dfrac{1}{(1+p^{\text{social discount rate}})^{y-p^{\text{discount year}}}}
+\left(1+p_{a,y}^{\text{technology-specific discount rate}}-\dfrac{p_{a,y}^{\text{salvage value}}}{p_{a,y}^{\text{inv cost}}}\right), & p_{a,y}^{\text{inv cost}} > 0,
+\end{cases}
+\quad \forall a \in \mathcal{A}_y^{\text{i}}, \forall y \in \mathcal{Y}
 ```
 
 where salvage value is
@@ -348,13 +354,27 @@ p^{\text{salvage value}}_{a, y} = p^{\text{annualized inv cost}}_{a, y} \sum_{i=
 and where annualized cost is
 
 ```math
-p^{\text{annualized inv cost}}_{a, y} = \frac{p^{\text{technology-specific discount rate}}_{a, y}}{ (1+p^{\text{technology-specific discount rate}}_{a, y}) \cdot \bigg( 1 - \frac{1}{ (1+p^{\text{technology-specific discount rate}}_{a, y})^{p^{\text{economic lifetime}}_{a, y}} } \bigg) } p^{\text{inv cost}}_{a, y} \quad \forall a \in \mathcal{A}_y^{\text{i}}, \forall y \in \mathcal{Y}
+p^{\text{annualized inv cost}}_{a, y} =
+\begin{cases}
+\dfrac{p^{\text{inv cost}}_{a,y}}{p^{\text{economic lifetime}}_{a,y}}, & p^{\text{technology-specific discount rate}}_{a,y}=0, \\
+\dfrac{p^{\text{technology-specific discount rate}}_{a,y}}{1-\dfrac{1}{(1+p^{\text{technology-specific discount rate}}_{a,y})^{p^{\text{economic lifetime}}_{a,y}}}}p^{\text{inv cost}}_{a,y}, & p^{\text{technology-specific discount rate}}_{a,y}>0,
+\end{cases}
+\quad \forall a \in \mathcal{A}_y^{\text{i}}, \forall y \in \mathcal{Y}
 ```
+
+!!! info "The same formula covers single-year and multi-year models"
+    The discounting factor above (and its transport-flow counterpart below) needs no special case for single-year versus multi-year models. In plain terms, the model charges the annualized cost once for every year of the asset's economic lifetime that falls inside the model horizon, starting from the commissioning year $y$, while the salvage value credits back the lifetime years that extend beyond the horizon, so an investment is never charged for time it is not used within the study. The commissioning year is the key differentiator: in a single-year model only the commissioning year lies inside the horizon, so the factor charges exactly one year of annualized cost (discounted to the discount year by the social rate only), whereas in a multi-year model the same factor additionally charges the remaining represented years, each first discounted back to the commissioning year with the technology-specific rate and then to the discount year with the social rate.
 
 #### Discounting Factor for Storage-Energy Investment Costs
 
 ```math
-p_{a, y}^{\text{discounting factor asset energy inv cost}}=\frac{1}{(1+p^{\text{social discount rate}})^{y-p^{\text{discount year}}}}(1-\frac{p_{a, y}^{\text{salvage value energy}}}{p_{a, y}^{\text{inv cost energy}}}) \quad \forall a \in \mathcal{A}_y^{\text{i}} \cap \mathcal{A}_y^{\text{se}}, \forall y \in \mathcal{Y}
+p_{a, y}^{\text{discounting factor asset energy inv cost}}=
+\begin{cases}
+0, & p_{a,y}^{\text{inv cost energy}} = 0, \\
+\dfrac{1}{(1+p^{\text{social discount rate}})^{y-p^{\text{discount year}}}}
+\left(1+p_{a,y}^{\text{technology-specific discount rate}}-\dfrac{p_{a,y}^{\text{salvage value energy}}}{p_{a,y}^{\text{inv cost energy}}}\right), & p_{a,y}^{\text{inv cost energy}} > 0,
+\end{cases}
+\quad \forall a \in \mathcal{A}_y^{\text{i}} \cap \mathcal{A}_y^{\text{se}}, \forall y \in \mathcal{Y}
 ```
 
 where salvage value is
@@ -366,13 +386,24 @@ p^{\text{salvage value energy}}_{a, y} = p^{\text{annualized inv cost energy}}_{
 and where annualized cost is
 
 ```math
-p^{\text{annualized inv cost energy}}_{a, y} = \frac{p^{\text{technology-specific discount rate}}_{a, y}}{ (1+p^{\text{technology-specific discount rate}}_{a, y}) \cdot \bigg( 1 - \frac{1}{ (1+p^{\text{technology-specific discount rate}}_{a, y})^{p^{\text{economic lifetime}}_{a, y}} } \bigg) } p^{\text{inv cost energy}}_{a, y} \quad \forall a \in \mathcal{A}_y^{\text{i}} \cap \mathcal{A}_y^{\text{se}}, \forall y \in \mathcal{Y}
+p^{\text{annualized inv cost energy}}_{a, y} =
+\begin{cases}
+\dfrac{p^{\text{inv cost energy}}_{a,y}}{p^{\text{economic lifetime}}_{a,y}}, & p^{\text{technology-specific discount rate}}_{a,y}=0, \\
+\dfrac{p^{\text{technology-specific discount rate}}_{a,y}}{1-\dfrac{1}{(1+p^{\text{technology-specific discount rate}}_{a,y})^{p^{\text{economic lifetime}}_{a,y}}}}p^{\text{inv cost energy}}_{a,y}, & p^{\text{technology-specific discount rate}}_{a,y}>0,
+\end{cases}
+\quad \forall a \in \mathcal{A}_y^{\text{i}} \cap \mathcal{A}_y^{\text{se}}, \forall y \in \mathcal{Y}
 ```
 
 #### Discounting Factor for Flow Investment Costs
 
 ```math
-p_{f, y}^{\text{discounting factor flow inv cost}}=\frac{1}{(1+p^{\text{social discount rate}})^{y-p^{\text{discount year}}}}(1-\frac{p_{f, y}^{\text{salvage value}}}{p_{f, y}^{\text{inv cost}}}) \quad \forall f \in \mathcal{F}_y^{\text{ti}}, \forall y \in \mathcal{Y}
+p_{f, y}^{\text{discounting factor flow inv cost}}=
+\begin{cases}
+0, & p_{f,y}^{\text{inv cost}} = 0, \\
+\dfrac{1}{(1+p^{\text{social discount rate}})^{y-p^{\text{discount year}}}}
+\left(1+p_{f,y}^{\text{technology-specific discount rate}}-\dfrac{p_{f,y}^{\text{salvage value}}}{p_{f,y}^{\text{inv cost}}}\right), & p_{f,y}^{\text{inv cost}} > 0,
+\end{cases}
+\quad \forall f \in \mathcal{F}_y^{\text{ti}}, \forall y \in \mathcal{Y}
 ```
 
 where salvage value is
@@ -384,7 +415,12 @@ p^{\text{salvage value}}_{f, y} = p^{\text{annualized inv cost}}_{f, y} \sum_{i=
 and where annualized cost is
 
 ```math
-p^{\text{annualized inv cost}}_{f, y} = \frac{p^{\text{technology-specific discount rate}}_{f, y}}{ (1+p^{\text{technology-specific discount rate}}_{f, y}) \cdot \bigg( 1 - \frac{1}{ (1+p^{\text{technology-specific discount rate}}_{f, y})^{p^{\text{economic lifetime}}_{f, y}} } \bigg) } p^{\text{inv cost}}_{f, y} \quad \forall f \in \mathcal{F}_y^{\text{ti}}, \forall y \in \mathcal{Y}
+p^{\text{annualized inv cost}}_{f, y} =
+\begin{cases}
+\dfrac{p^{\text{inv cost}}_{f,y}}{p^{\text{economic lifetime}}_{f,y}}, & p^{\text{technology-specific discount rate}}_{f,y}=0, \\
+\dfrac{p^{\text{technology-specific discount rate}}_{f,y}}{1-\dfrac{1}{(1+p^{\text{technology-specific discount rate}}_{f,y})^{p^{\text{economic lifetime}}_{f,y}}}}p^{\text{inv cost}}_{f,y}, & p^{\text{technology-specific discount rate}}_{f,y}>0,
+\end{cases}
+\quad \forall f \in \mathcal{F}_y^{\text{ti}}, \forall y \in \mathcal{Y}
 ```
 
 #### Discounting Factor for Operation Costs

--- a/src/objectives/create.jl
+++ b/src/objectives/create.jl
@@ -110,8 +110,7 @@ function _investment_discount_sql(;
                 WHEN $discount_rate = 0
                     THEN $cost / $economic_lifetime
                 ELSE $discount_rate / (
-                    (1 + $discount_rate) *
-                    (1 - 1 / ((1 + $discount_rate) ** $economic_lifetime))
+                    1 - 1 / ((1 + $discount_rate) ** $economic_lifetime)
                     ) * $cost
             END AS $annualized,
             CASE
@@ -131,7 +130,7 @@ function _investment_discount_sql(;
                 -- the weight does not accept a zero cost in the denominator
                 WHEN $cost = 0
                     THEN 0.0 -- zero investment cost, so the weight does not matter
-                ELSE investment_year_discount * (1 - $salvage / $cost)
+                ELSE investment_year_discount * (1 + $discount_rate - $salvage / $cost)
             END AS $weight"""
 end
 

--- a/test/io-outputs/energy-problem-model-solved.txt
+++ b/test/io-outputs/energy-problem-model-solved.txt
@@ -5,14 +5,14 @@ EnergyProblem:
     - Number of structural constraints: 432
   - Model solved!
     - Termination status: OPTIMAL
-    - Objective value: 269238.4382415648
+    - Objective value: 278067.19298455375
     - Objective breakdown:
       - assets_fixed_cost_aggregated_vintage_method: 0.0
       - assets_fixed_cost_compact_vintage_method: 0.0
-      - assets_investment_cost: 177000.0
+      - assets_investment_cost: 185324.99999999942
       - flows_fixed_cost: 0.0
       - flows_investment_cost: 0.0
-      - flows_operational_cost: 92238.43824156489
+      - flows_operational_cost: 92742.1929845544
       - storage_assets_energy_fixed_cost: 0.0
       - storage_assets_energy_investment_cost: 0.0
       - units_on_operational_cost: 0.0

--- a/test/test-case-studies.jl
+++ b/test/test-case-studies.jl
@@ -26,11 +26,11 @@ end
         connection = DBInterface.connect(DuckDB.DB)
         _read_csv_folder(connection, dir)
         energy_problem = TulipaEnergyModel.run_scenario(connection; optimizer, show_log = false)
-        @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
+        @test energy_problem.objective_value ≈ 278067.19298 rtol = 1e-8
         # populate_with_defaults shouldn't change the solution
         TulipaEnergyModel.populate_with_defaults!(connection)
         energy_problem = TulipaEnergyModel.run_scenario(connection; optimizer, show_log = false)
-        @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
+        @test energy_problem.objective_value ≈ 278067.19298 rtol = 1e-8
     end
 end
 
@@ -40,11 +40,11 @@ end
     TulipaIO.read_csv_folder(connection, dir)
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
+    @test energy_problem.objective_value ≈ 278067.19298 rtol = 1e-8
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 269238.43825 rtol = 1e-8
+    @test energy_problem.objective_value ≈ 278067.19298 rtol = 1e-8
 end
 
 @testitem "Storage Assets Case Study" setup = [CommonSetup] tags =
@@ -73,7 +73,7 @@ end
         optimizer_parameters,
         show_log = false,
     )
-    @test energy_problem.objective_value ≈ 293074.923309 atol = 1e-5
+    @test energy_problem.objective_value ≈ 302419.52581 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(
@@ -82,7 +82,7 @@ end
         optimizer_parameters,
         show_log = false,
     )
-    @test energy_problem.objective_value ≈ 293074.923309 atol = 1e-5
+    @test energy_problem.objective_value ≈ 302419.52581 atol = 1e-5
 end
 
 @testitem "Tiny Variable Resolution Case Study" setup = [CommonSetup] tags =
@@ -103,11 +103,11 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 4623425.16649 atol = 1e-5
+    @test energy_problem.objective_value ≈ 4633702.87318 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 4623425.16649 atol = 1e-5
+    @test energy_problem.objective_value ≈ 4633702.87318 atol = 1e-5
 end
 
 @testitem "Power Flow Case Study" setup = [CommonSetup] tags = [:case_study, :integration, :slow] begin
@@ -128,11 +128,11 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 89360.638146 atol = 1e-5
+    @test energy_problem.objective_value ≈ 89360.63814 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 89360.638146 atol = 1e-5
+    @test energy_problem.objective_value ≈ 89360.63814 atol = 1e-5
 end
 
 @testitem "Two-stage Stochastic Optimization Cross Scenario Case Study" setup = [CommonSetup] tags =
@@ -141,11 +141,11 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 10_331_281_729.650423 atol = 1e-5
+    @test energy_problem.objective_value ≈ 10_488_052_379.10485 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 10_331_281_729.650423 atol = 1e-5
+    @test energy_problem.objective_value ≈ 10_488_052_379.10485 atol = 1e-5
 end
 
 @testitem "Two-stage Stochastic Optimization Per Scenario Case Study" setup = [CommonSetup] tags =
@@ -154,11 +154,11 @@ end
     connection = DBInterface.connect(DuckDB.DB)
     _read_csv_folder(connection, dir)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 11_794_495_552.83554 atol = 1e-5
+    @test energy_problem.objective_value ≈ 11_904_858_425.81369 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 11_794_495_552.83554 atol = 1e-5
+    @test energy_problem.objective_value ≈ 11_904_858_425.81369 atol = 1e-5
 end
 
 @testitem "CVaR Case Study" setup = [CommonSetup] tags = [:case_study, :integration, :slow, :cvar] begin

--- a/test/test-objective-breakdown.jl
+++ b/test/test-objective-breakdown.jl
@@ -49,6 +49,6 @@ end
     @test rows[2050].weight_for_asset_investment_discount == 0.0
 
     # Energy investment cost is positive, so the weight is calculated based on the formula.
-    @test rows[2030].weight_for_asset_investment_energy_discount ≈ 0.744093915 atol = 1e-6
-    @test rows[2050].weight_for_asset_investment_energy_discount ≈ 0.050813475 atol = 1e-6
+    @test rows[2030].weight_for_asset_investment_energy_discount ≈ 0.781298611 atol = 1e-6
+    @test rows[2050].weight_for_asset_investment_energy_discount ≈ 0.053354149 atol = 1e-6
 end

--- a/test/test-objective-discounting-factors.jl
+++ b/test/test-objective-discounting-factors.jl
@@ -1,0 +1,206 @@
+@testitem "Test investment discounting" setup = [CommonSetup] tags =
+    [:integration, :validation, :fast] begin
+    function annualized_investment_cost(
+        investment_cost,
+        technology_discount_rate,
+        economic_lifetime,
+    )
+        technology_discount_rate == 0 && return investment_cost / economic_lifetime
+        return technology_discount_rate /
+               (1 - 1 / (1 + technology_discount_rate)^economic_lifetime) * investment_cost
+    end
+
+    function salvage_value(
+        investment_cost,
+        technology_discount_rate,
+        economic_lifetime,
+        milestone_year,
+        last_year,
+    )
+        milestone_year + economic_lifetime <= last_year + 1 && return 0.0
+        return annualized_investment_cost(
+            investment_cost,
+            technology_discount_rate,
+            economic_lifetime,
+        ) * sum(
+            1 / (1 + technology_discount_rate)^(year - milestone_year) for
+            year in (last_year+1):(milestone_year+economic_lifetime-1)
+        )
+    end
+
+    function investment_discounting_factor(
+        investment_cost,
+        technology_discount_rate,
+        economic_lifetime,
+        milestone_year,
+        last_year,
+        social_discount_rate,
+        discount_year,
+    )
+        investment_cost == 0 && return 0.0
+        salvage = salvage_value(
+            investment_cost,
+            technology_discount_rate,
+            economic_lifetime,
+            milestone_year,
+            last_year,
+        )
+        return 1 / (1 + social_discount_rate)^(milestone_year - discount_year) *
+               (1 + technology_discount_rate - salvage / investment_cost)
+    end
+
+    function _investment_factors(case)
+        connection = DBInterface.connect(DuckDB.DB)
+        _read_csv_folder(connection, joinpath(INPUT_FOLDER, case))
+        energy_problem = TulipaEnergyModel.EnergyProblem(connection)
+        TulipaEnergyModel.create_model!(energy_problem)
+        parameters = only(
+            DuckDB.query(
+                connection,
+                "SELECT discount_rate AS social_discount_rate, discount_year FROM model_parameters",
+            ),
+        )
+        last_year =
+            only(
+                DuckDB.query(
+                    connection,
+                    "SELECT MAX(milestone_year) AS last_year FROM rep_periods_data",
+                ),
+            ).last_year
+        rows = collect(
+            DuckDB.query(
+                connection,
+                "SELECT
+                    o.milestone_year,
+                    o.investment_cost,
+                    o.annualized_cost,
+                    o.salvage_value,
+                    o.weight_for_asset_investment_discount AS discounting_factor,
+                    a.discount_rate AS technology_discount_rate,
+                    a.economic_lifetime
+                FROM t_objective_assets AS o
+                JOIN asset AS a ON a.asset = o.asset
+                WHERE o.investment_cost > 0",
+            ),
+        )
+        return (;
+            social_discount_rate = parameters.social_discount_rate,
+            discount_year = parameters.discount_year,
+            last_year,
+            rows,
+        )
+    end
+
+    single = _investment_factors("Tiny")
+    @test !isempty(single.rows)
+    for row in single.rows
+        @test row.annualized_cost ≈ annualized_investment_cost(
+            row.investment_cost,
+            row.technology_discount_rate,
+            row.economic_lifetime,
+        )
+        @test row.salvage_value == 0.0
+        @test row.discounting_factor ≈ investment_discounting_factor(
+            row.investment_cost,
+            row.technology_discount_rate,
+            row.economic_lifetime,
+            row.milestone_year,
+            single.last_year,
+            single.social_discount_rate,
+            single.discount_year,
+        )
+        @test row.discounting_factor ≈
+              1 / (1 + single.social_discount_rate)^(row.milestone_year - single.discount_year) *
+              (1 + row.technology_discount_rate)
+    end
+
+    multi = _investment_factors("Multi-year Investments")
+    @test !isempty(multi.rows)
+    for row in multi.rows
+        @test row.annualized_cost ≈ annualized_investment_cost(
+            row.investment_cost,
+            row.technology_discount_rate,
+            row.economic_lifetime,
+        )
+        @test row.salvage_value ≈ salvage_value(
+            row.investment_cost,
+            row.technology_discount_rate,
+            row.economic_lifetime,
+            row.milestone_year,
+            multi.last_year,
+        )
+        @test row.discounting_factor ≈ investment_discounting_factor(
+            row.investment_cost,
+            row.technology_discount_rate,
+            row.economic_lifetime,
+            row.milestone_year,
+            multi.last_year,
+            multi.social_discount_rate,
+            multi.discount_year,
+        )
+        if row.salvage_value > 0
+            @test row.discounting_factor <
+                  1 / (1 + multi.social_discount_rate)^(row.milestone_year - multi.discount_year) *
+                  (1 + row.technology_discount_rate)
+        end
+    end
+end
+
+@testitem "Zero-discount annualized cost is investment cost over lifetime" setup = [CommonSetup] tags =
+    [:integration, :validation, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+    energy_problem = TulipaEnergyModel.EnergyProblem(connection)
+
+    # With a zero technology-specific discount rate, the CRF annualized cost reduces
+    # to a straight-line split of the investment cost over the economic lifetime.
+    DuckDB.query(connection, "UPDATE asset SET discount_rate = 0, economic_lifetime = 5")
+    TulipaEnergyModel.create_model!(energy_problem)
+
+    rows = collect(
+        DuckDB.query(
+            connection,
+            "SELECT o.annualized_cost, o.investment_cost, a.economic_lifetime
+            FROM t_objective_assets AS o
+            JOIN asset AS a ON a.asset = o.asset
+            WHERE o.investment_cost > 0",
+        ),
+    )
+    @test !isempty(rows)
+    for row in rows
+        @test row.annualized_cost == row.investment_cost / row.economic_lifetime
+    end
+end
+
+@testitem "Single-year investment uses the same formula as multi-year" setup = [CommonSetup] tags =
+    [:integration, :validation, :fast] begin
+    connection = DBInterface.connect(DuckDB.DB)
+    _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
+    energy_problem = TulipaEnergyModel.EnergyProblem(connection)
+
+    # Tiny is a single-year horizon
+    DuckDB.query(connection, "UPDATE asset SET economic_lifetime = 10")
+    TulipaEnergyModel.create_model!(energy_problem)
+
+    rows = collect(
+        DuckDB.query(
+            connection,
+            "SELECT
+                investment_cost,
+                annualized_cost,
+                salvage_value,
+                investment_year_discount,
+                weight_for_asset_investment_discount AS discounting_factor
+            FROM t_objective_assets
+            WHERE investment_cost > 0",
+        ),
+    )
+    @test !isempty(rows)
+    for row in rows
+        # The lifetime extends beyond the single-year horizon, so salvage is active,
+        # yet the discounting factor still reduces to a single annualized payment
+        @test row.salvage_value > 0
+        @test row.discounting_factor ≈
+              row.investment_year_discount * row.annualized_cost / row.investment_cost
+    end
+end

--- a/test/test-objective-discounting-factors.jl
+++ b/test/test-objective-discounting-factors.jl
@@ -60,13 +60,12 @@
                 "SELECT discount_rate AS social_discount_rate, discount_year FROM model_parameters",
             ),
         )
-        last_year =
-            only(
-                DuckDB.query(
-                    connection,
-                    "SELECT MAX(milestone_year) AS last_year FROM rep_periods_data",
-                ),
-            ).last_year
+        last_year = only(
+            DuckDB.query(
+                connection,
+                "SELECT MAX(milestone_year) AS last_year FROM rep_periods_data",
+            ),
+        ).last_year
         rows = collect(
             DuckDB.query(
                 connection,

--- a/test/test-objective-discounting-factors.jl
+++ b/test/test-objective-discounting-factors.jl
@@ -1,5 +1,4 @@
-@testitem "Test investment discounting" setup = [CommonSetup] tags =
-    [:integration, :validation, :fast] begin
+@testsnippet InvestmentDiscountingSetup begin
     function annualized_investment_cost(
         investment_cost,
         technology_discount_rate,
@@ -48,7 +47,10 @@
         return 1 / (1 + social_discount_rate)^(milestone_year - discount_year) *
                (1 + technology_discount_rate - salvage / investment_cost)
     end
+end
 
+@testitem "Test investment discounting" setup = [CommonSetup, InvestmentDiscountingSetup] tags =
+    [:integration, :validation, :fast] begin
     function _investment_factors(case)
         connection = DBInterface.connect(DuckDB.DB)
         _read_csv_folder(connection, joinpath(INPUT_FOLDER, case))
@@ -137,11 +139,6 @@
             multi.social_discount_rate,
             multi.discount_year,
         )
-        if row.salvage_value > 0
-            @test row.discounting_factor <
-                  1 / (1 + multi.social_discount_rate)^(row.milestone_year - multi.discount_year) *
-                  (1 + row.technology_discount_rate)
-        end
     end
 end
 
@@ -171,8 +168,8 @@ end
     end
 end
 
-@testitem "Single-year investment uses the same formula as multi-year" setup = [CommonSetup] tags =
-    [:integration, :validation, :fast] begin
+@testitem "Single-year investment uses the same formula as multi-year" setup =
+    [CommonSetup, InvestmentDiscountingSetup] tags = [:integration, :validation, :fast] begin
     connection = DBInterface.connect(DuckDB.DB)
     _read_csv_folder(connection, joinpath(INPUT_FOLDER, "Tiny"))
     energy_problem = TulipaEnergyModel.EnergyProblem(connection)
@@ -181,24 +178,37 @@ end
     DuckDB.query(connection, "UPDATE asset SET economic_lifetime = 10")
     TulipaEnergyModel.create_model!(energy_problem)
 
+    last_year = only(
+        DuckDB.query(connection, "SELECT MAX(milestone_year) AS last_year FROM rep_periods_data"),
+    ).last_year
     rows = collect(
         DuckDB.query(
             connection,
             "SELECT
-                investment_cost,
-                annualized_cost,
-                salvage_value,
-                investment_year_discount,
-                weight_for_asset_investment_discount AS discounting_factor
-            FROM t_objective_assets
-            WHERE investment_cost > 0",
+                o.milestone_year,
+                o.investment_cost,
+                o.annualized_cost,
+                o.salvage_value,
+                o.investment_year_discount,
+                o.weight_for_asset_investment_discount AS discounting_factor,
+                a.discount_rate AS technology_discount_rate,
+                a.economic_lifetime
+            FROM t_objective_assets AS o
+            JOIN asset AS a ON a.asset = o.asset
+            WHERE o.investment_cost > 0",
         ),
     )
     @test !isempty(rows)
     for row in rows
         # The lifetime extends beyond the single-year horizon, so salvage is active,
         # yet the discounting factor still reduces to a single annualized payment
-        @test row.salvage_value > 0
+        @test row.salvage_value ≈ salvage_value(
+            row.investment_cost,
+            row.technology_discount_rate,
+            row.economic_lifetime,
+            row.milestone_year,
+            last_year,
+        )
         @test row.discounting_factor ≈
               row.investment_year_discount * row.annualized_cost / row.investment_cost
     end

--- a/test/test-tutorial-files.jl
+++ b/test/test-tutorial-files.jl
@@ -140,33 +140,33 @@ end
     [:integration, :slow] begin
     connection = _tutorial_connection("tutorial-6-simple-method")
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 8.502460892530702e6 atol = 1e-5
+    @test energy_problem.objective_value ≈ 8511709.40963 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 8.502460892530702e6 atol = 1e-5
+    @test energy_problem.objective_value ≈ 8511709.40963 atol = 1e-5
 end
 
 @testitem "Tutorial 6 compact method objective value" setup = [CommonSetup, TutorialSetup] tags =
     [:integration, :slow] begin
     connection = _tutorial_connection("tutorial-6-compact-method")
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 8.619710327700023e6 atol = 1e-5
+    @test energy_problem.objective_value ≈ 8629317.65966 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 8.619710327700023e6 atol = 1e-5
+    @test energy_problem.objective_value ≈ 8629317.65966 atol = 1e-5
 end
 
 @testitem "Tutorial 9 objective value" setup = [CommonSetup, TutorialSetup] tags =
     [:integration, :slow] begin
     connection = _tutorial_connection("tutorial-9"; preprocess! = _cluster_tutorial_9!)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 499.24509272162777 atol = 1e-5
+    @test energy_problem.objective_value ≈ 512.84209 atol = 1e-5
     # populate_with_defaults shouldn't change the solution
     TulipaEnergyModel.populate_with_defaults!(connection)
     energy_problem = TulipaEnergyModel.run_scenario(connection; show_log = false)
-    @test energy_problem.objective_value ≈ 499.24509272162777 atol = 1e-5
+    @test energy_problem.objective_value ≈ 512.84209 atol = 1e-5
 end
 
 @testitem "Tutorial CVaR objective value" setup = [CommonSetup, TutorialSetup] tags =


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

**Summary**
Updates the economic representation to align the annualized investment cost with the standard capital recovery factor (CRF) convention used by OPERA and other capacity-expansion models. 

Currently we discount the first payment, so a single-year run would charge _annualized cost / (1 + discount rate)_, instead of _annualized cost_. After this change, the CRF convention makes the single-year result consistent with OPERA and comparable models, and the same formula applies uniformly to multi-year horizons - no single-year special case is needed as in #1495.

**Changes**

- Remove (1+ discount rate) in the denominator from annualized cost
- Add (1+ discount rate) to the investment discounting factor
- Apply both to assets, transport flows, and vintage flows
- Add `test-objective-discounting-factors.jl` 
- Update affected objective values in `test-case-studies.jl` and `test-tutorial-files.jl`
- Regenerate affected MPS files 

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Refactor #1495 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
