### PR TITLE
Add print to console log for Tulipa steps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,14 @@
 name = "TulipaEnergyModel"
 uuid = "5d7bd171-d18e-45a5-9111-f1f11ac5d04d"
 version = "0.22.2"
-authors = [
-  "Abel Soares Siqueira <abel.s.siqueira@gmail.com>",
-  "Diego A. Tejada-Arango <diego.tejadaarango@tno.nl>",
-  "Germán Morales-España <german.morales@tno.nl>",
-  "Grigory Neustroev <G.Neustroev@tudelft.nl>",
-  "Juha Kiviluoma <Juha.Kiviluoma@vtt.fi>",
-  "Lauren Clisby <lauren.clisby@tno.nl>",
-  "Maaike Elgersma <m.b.elgersma@tudelft.nl>",
-  "Ni Wang <ni.wang@tno.nl>",
-  "Suvayu Ali <s.ali@esciencecenter.nl>",
-  "Zhi Gao <z.gao1@uu.nl>",
-]
+authors = ["Abel Soares Siqueira <abel.s.siqueira@gmail.com>", "Diego A. Tejada-Arango <diego.tejadaarango@tno.nl>", "Germán Morales-España <german.morales@tno.nl>", "Grigory Neustroev <G.Neustroev@tudelft.nl>", "Juha Kiviluoma <Juha.Kiviluoma@vtt.fi>", "Lauren Clisby <lauren.clisby@tno.nl>", "Maaike Elgersma <m.b.elgersma@tudelft.nl>", "Ni Wang <ni.wang@tno.nl>", "Suvayu Ali <s.ali@esciencecenter.nl>", "Zhi Gao <z.gao1@uu.nl>"]
+
+[workspace]
+projects = ["test", "docs", "benchmark"]
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DuckDB = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -30,6 +23,7 @@ TulipaIO = "7b3808b7-0819-42d4-885c-978ba173db11"
 
 [compat]
 CSV = "0.10"
+Dates = "1.11.0"
 DuckDB = "1"
 HiGHS = "1"
 JSON = "0.21.4, 1"
@@ -42,6 +36,3 @@ TOML = "1"
 TimerOutputs = "0.5, 1.1"
 TulipaIO = "0.5"
 julia = "1.10"
-
-[workspace]
-projects = ["test", "docs", "benchmark"]

--- a/src/TulipaEnergyModel.jl
+++ b/src/TulipaEnergyModel.jl
@@ -18,11 +18,13 @@ using MathOptInterface: MathOptInterface
 using ParametricOptInterface: ParametricOptInterface as POI
 
 ## Others
+using Dates: Dates
 using OrderedCollections: OrderedDict
 using Statistics: Statistics
 using TimerOutputs: TimerOutput, @timeit, reset_timer!
 
 const to = TimerOutput()
+const LOG_DATE_FORMAT = Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sss"
 
 # Public API
 export

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -3,13 +3,16 @@
 
 Create the internal model of a [`TulipaEnergyModel.EnergyProblem`](@ref).
 Any keyword argument will be passed to the underlying [`create_model`](@ref).
+     Set `show_log = false` to silence progress logging.
 """
-function create_model!(energy_problem; kwargs...)
+function create_model!(energy_problem; show_log = true, kwargs...)
+    show_log && @info "[$(timestamp())] Creating optimization model"
     energy_problem.model, energy_problem.expressions = @timeit to "create_model" create_model(
         energy_problem.db_connection,
         energy_problem.variables,
         energy_problem.constraints,
         energy_problem.profiles;
+        show_log = show_log,
         kwargs...,
     )
     energy_problem.termination_status = JuMP.OPTIMIZE_NOT_CALLED
@@ -30,6 +33,7 @@ end
         model_file_name = "",
         enable_names = true
         direct_model = false,
+        show_log = true,
     )
 
 Create the energy model manually. We recommend using [`create_model!`](@ref) instead.
@@ -53,6 +57,8 @@ For more information, see [`JuMP.set_string_names_on_creation`](https://jump.dev
 Set `direct_model = true` to create a JuMP `direct_model` using `optimizer_with_attributes`, which has memory improvements.
 For more information, see [`JuMP.direct_model`](https://jump.dev/JuMP.jl/stable/api/JuMP/#direct_model).
 
+Set `show_log = false` to silence progress logging.
+
 """
 function create_model(
     connection,
@@ -66,7 +72,9 @@ function create_model(
     direct_model = false,
     rolling_horizon = false,
     rolling_horizon_window_length = 0,
+    show_log = true,
 )
+    show_log && @info "[$(timestamp())] Preparing optimization model"
     if rolling_horizon
         @assert rolling_horizon_window_length > 0
     end
@@ -96,28 +104,39 @@ function create_model(
     end
 
     ## Model Parameters
+    show_log && @info "[$(timestamp())] Preparing model parameters"
     @timeit to "get_model_parameters!" model_parameters = get_model_parameters(connection)
 
     ## Variables
+    show_log && @info "[$(timestamp())] Adding flow variables"
     @timeit to "add_flow_variables!" add_flow_variables!(connection, model, variables)
+    show_log && @info "[$(timestamp())] Adding vintage flow variables"
     @timeit to "add_vintage_flow_variables!" add_vintage_flow_variables!(
         connection,
         model,
         variables,
     )
+    show_log && @info "[$(timestamp())] Adding investment variables"
     @timeit to "add_investment_variables!" add_investment_variables!(model, variables)
+    show_log && @info "[$(timestamp())] Adding decommission variables"
     @timeit to "add_decommission_variables!" add_decommission_variables!(model, variables)
+    show_log && @info "[$(timestamp())] Adding unit commitment variables"
     @timeit to "add_unit_commitment_variables!" add_unit_commitment_variables!(model, variables)
+    show_log && @info "[$(timestamp())] Adding start-up and shut-down variables"
     @timeit to "add_start_up_and_shut_down_variables!" add_start_up_and_shut_down_variables!(
         model,
         variables,
     )
+    show_log && @info "[$(timestamp())] Adding power flow variables"
     @timeit to "add_power_flow_variables!" add_power_flow_variables!(model, variables)
+    show_log && @info "[$(timestamp())] Adding storage variables"
     @timeit to "add_storage_variables!" add_storage_variables!(connection, model, variables)
+    show_log && @info "[$(timestamp())] Adding conditional value-at-risk variables"
     @timeit to "add_conditional_value_at_risk_variables!" add_conditional_value_at_risk_variables!(
         model,
         variables,
     )
+    show_log && @info "[$(timestamp())] Adding expressions to constraints"
     @timeit to "add_expressions_to_constraints!" add_expressions_to_constraints!(
         connection,
         variables,
@@ -125,9 +144,11 @@ function create_model(
     )
 
     ## Expressions
+    show_log && @info "[$(timestamp())] Creating model expressions"
     expressions = Dict{Symbol,TulipaExpression}()
 
     ## Expressions for multi-year investment
+    show_log && @info "[$(timestamp())] Creating multi-year expressions"
     @timeit to "create_multi_year_expressions!" create_multi_year_expressions!(
         connection,
         model,
@@ -136,6 +157,7 @@ function create_model(
     )
 
     ## Expressions for storage assets
+    show_log && @info "[$(timestamp())] Adding storage expressions"
     @timeit to "add_storage_expressions!" add_storage_expressions!(connection, model, expressions)
 
     ## Rolling Horizon Parameters
@@ -150,9 +172,11 @@ function create_model(
     end
 
     ## Tables for the objective function
+    show_log && @info "[$(timestamp())] Preparing objective tables"
     @timeit to "prepare_objective_tables!" prepare_objective_tables!(connection, model_parameters)
 
     ## Expressions for operational costs
+    show_log && @info "[$(timestamp())] Adding operational cost expressions"
     @timeit to "add_operational_cost_expressions!" add_operational_cost_expressions!(
         connection,
         model,
@@ -162,6 +186,7 @@ function create_model(
     )
 
     ## Expressions for the objective function
+    show_log && @info "[$(timestamp())] Adding objective"
     @timeit to "add_objective!" add_objective!(
         connection,
         model,
@@ -171,6 +196,7 @@ function create_model(
     )
 
     ## Expressions for the scenario tail excess (conditional value at risk constraints)
+    show_log && @info "[$(timestamp())] Adding scenario tail excess expressions"
     @timeit to "add_scenario_tail_excess_expressions!" add_scenario_tail_excess_expressions!(
         connection,
         model,
@@ -179,6 +205,7 @@ function create_model(
     )
 
     ## Constraints
+    show_log && @info "[$(timestamp())] Adding capacity constraints"
     @timeit to "add_capacity_constraints!" add_capacity_constraints!(
         connection,
         model,
@@ -187,6 +214,7 @@ function create_model(
         profiles,
     )
 
+    show_log && @info "[$(timestamp())] Adding energy constraints"
     @timeit to "add_energy_constraints!" add_energy_constraints!(
         connection,
         model,
@@ -194,6 +222,7 @@ function create_model(
         profiles,
     )
 
+    show_log && @info "[$(timestamp())] Adding consumer constraints"
     @timeit to "add_consumer_constraints!" add_consumer_constraints!(
         connection,
         model,
@@ -202,6 +231,7 @@ function create_model(
         profiles,
     )
 
+    show_log && @info "[$(timestamp())] Adding storage constraints"
     @timeit to "add_storage_constraints!" add_storage_constraints!(
         connection,
         model,
@@ -212,12 +242,14 @@ function create_model(
         rolling_horizon,
     )
 
+    show_log && @info "[$(timestamp())] Adding conversion constraints"
     @timeit to "add_conversion_constraints!" add_conversion_constraints!(
         connection,
         model,
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding transport constraints"
     @timeit to "add_transport_constraints!" add_transport_constraints!(
         connection,
         model,
@@ -227,6 +259,7 @@ function create_model(
         profiles,
     )
 
+    show_log && @info "[$(timestamp())] Adding investment group constraints"
     @timeit to "add_investment_group_constraints!" add_investment_group_constraints!(
         connection,
         model,
@@ -235,6 +268,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding available asset units constraints"
     @timeit to "add_available_asset_units_constraints!" add_available_asset_units_constraints!(
         connection,
         model,
@@ -242,6 +276,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding ramping constraints"
     @timeit to "add_ramping_constraints!" add_ramping_constraints!(
         connection,
         model,
@@ -251,6 +286,7 @@ function create_model(
         profiles,
     )
 
+    show_log && @info "[$(timestamp())] Adding minimum output flow constraints"
     @timeit to "add_min_output_flow_without_unit_commitment_constraints!" add_min_output_flow_without_unit_commitment_constraints!(
         connection,
         model,
@@ -258,6 +294,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding flow relationship constraints"
     @timeit to "add_flows_relationships_constraints!" add_flows_relationships_constraints!(
         connection,
         model,
@@ -265,6 +302,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding DC power flow constraints"
     @timeit to "add_dc_power_flow_constraints!" add_dc_power_flow_constraints!(
         connection,
         model,
@@ -272,6 +310,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding vintage flow sum constraints"
     @timeit to "add_vintage_flow_sum_constraints!" add_vintage_flow_sum_constraints!(
         connection,
         model,
@@ -279,6 +318,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding start-up upper bound constraints"
     @timeit to "add_start_up_upper_bound_constraints!" add_start_up_upper_bound_constraints!(
         connection,
         model,
@@ -287,6 +327,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding shut-down upper bound constraints"
     @timeit to "add_shut_down_upper_bound_constraints!" add_shut_down_upper_bound_constraints!(
         connection,
         model,
@@ -295,6 +336,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding unit commitment logic constraints"
     @timeit to "add_uc_logic_constraints!" add_uc_logic_constraints!(
         connection,
         model,
@@ -303,6 +345,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding scenario tail excess constraints"
     @timeit to "add_scenario_tail_excess_constraints!" add_scenario_tail_excess_constraints!(
         connection,
         model,
@@ -328,8 +371,10 @@ function create_model(
     )
 
     if model_file_name != ""
+        show_log && @info "[$(timestamp())] Writing model file to $model_file_name"
         @timeit to "save model file" JuMP.write_to_file(model, model_file_name)
     end
 
+    show_log && @info "[$(timestamp())] Optimization model creation finished"
     return model, expressions
 end

--- a/src/create-model.jl
+++ b/src/create-model.jl
@@ -354,6 +354,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding minimum up time constraints"
     @timeit to "add_minimum_up_time_constraints!" add_minimum_up_time_constraints!(
         connection,
         model,
@@ -362,6 +363,7 @@ function create_model(
         constraints,
     )
 
+    show_log && @info "[$(timestamp())] Adding minimum down time constraints"
     @timeit to "add_minimum_down_time_constraints!" add_minimum_down_time_constraints!(
         connection,
         model,

--- a/src/io.jl
+++ b/src/io.jl
@@ -63,11 +63,11 @@ end
 Saves the solution from `energy_problem` in CSV files inside `output_file`.
 Notice that this assumes that the solution has been computed by [`save_solution!`](@ref).
 """
-function export_solution_to_csv_files(output_folder, energy_problem::EnergyProblem)
+function export_solution_to_csv_files(output_folder, energy_problem::EnergyProblem; show_log = true)
     if !energy_problem.solved
         error("The energy_problem has not been solved yet.")
     end
-    export_solution_to_csv_files(output_folder, energy_problem.db_connection)
+    export_solution_to_csv_files(output_folder, energy_problem.db_connection; show_log)
     return
 end
 
@@ -78,7 +78,7 @@ Saves the solution in CSV files inside `output_folder`.
 Notice that this assumes that the solution has already been computed (e.g., by
 [`save_solution!`](@ref), or using rolling horizon).
 """
-function export_solution_to_csv_files(output_folder, connection)
+function export_solution_to_csv_files(output_folder, connection; show_log = true)
     # Save each variable and constraint
     for prefix in ("var", "cons", "obj")
         for table_name in [

--- a/src/rolling-horizon/rolling-horizon.jl
+++ b/src/rolling-horizon/rolling-horizon.jl
@@ -62,6 +62,7 @@ function run_rolling_horizon(
     reset_timer!(to)
 
     # Validation that the input data must satisfy to run rolling horizon
+    show_log && @info "[$(timestamp())] Validating rolling horizon input"
     @timeit to "Validate rolling horizon input" validate_rolling_horizon_input(
         connection,
         move_forward,
@@ -87,8 +88,9 @@ function run_rolling_horizon(
     )
 
     # Create no-rolling problem
+    show_log && @info "[$(timestamp())] Creating full EnergyProblem"
     full_energy_problem =
-        @timeit to "Create Rolling Horizon EnergyProblem" EnergyProblem(connection)
+        @timeit to "Create Rolling Horizon EnergyProblem" EnergyProblem(connection; show_log)
 
     # These are all the non-empty variable tables
     variable_tables = [
@@ -105,6 +107,7 @@ function run_rolling_horizon(
         )
     ]
 
+    show_log && @info "[$(timestamp())] Preparing rolling horizon tables"
     @timeit to "Prepare table for rolling horizon" prepare_rolling_horizon_tables!(
         connection,
         variable_tables,
@@ -113,11 +116,15 @@ function run_rolling_horizon(
         opt_window_length,
     )
 
-    energy_problem =
-        @timeit to "Create internal EnergyProblem for rolling horizon" EnergyProblem(connection)
+    show_log && @info "[$(timestamp())] Creating rolling horizon EnergyProblem"
+    energy_problem = @timeit to "Create internal EnergyProblem for rolling horizon" EnergyProblem(
+        connection;
+        show_log,
+    )
 
     # The rolling horizon Parameters are created here. The model has the size of
     # the `opt_window_length`.
+    show_log && @info "[$(timestamp())] Creating rolling horizon model"
     @timeit to "Create internal rolling horizon model" create_model!(
         energy_problem;
         optimizer,
@@ -127,18 +134,21 @@ function run_rolling_horizon(
         direct_model,
         rolling_horizon = true,
         rolling_horizon_window_length = opt_window_length,
+        show_log,
     )
 
     # Loop over the windows, solve, save, update, repeat
     solved = true
     for (window_id, window_start) in enumerate(1:move_forward:horizon_length)
         # Update Parameters in the model (even for the first time)
+        show_log && @info "[$(timestamp())] Updating rolling horizon profiles for window $window_id"
         @timeit to "update rolling horizon profiles" update_rolling_horizon_profiles!(
             energy_problem.profiles,
             window_start,
             window_start + opt_window_length - 1,
         )
         if window_id > 1 # Don't try to update the first initial values
+            show_log && @info "[$(timestamp())] Updating scalar parameters for window $window_id"
             @timeit to "update scalar parameters" update_scalar_parameters!(
                 energy_problem.variables,
                 energy_problem.expressions,
@@ -147,6 +157,7 @@ function run_rolling_horizon(
             )
         end
 
+        show_log && @info "[$(timestamp())] Solving rolling horizon window $window_id"
         @timeit to "Solve internal rolling horizon model" solve_model!(energy_problem)
 
         # Save window to table rolling_horizon_window
@@ -168,6 +179,7 @@ function run_rolling_horizon(
             break
         end
 
+        show_log && @info "[$(timestamp())] Saving rolling horizon window $window_id"
         @timeit to "Save window solution" save_solution_into_tables!(
             energy_problem,
             variable_tables,
@@ -191,6 +203,7 @@ function run_rolling_horizon(
     full_energy_problem.rolling_horizon_energy_problem = energy_problem
 
     # Undo the changes to rep_periods_data
+    show_log && @info "[$(timestamp())] Restoring rolling horizon tables"
     @timeit to "undo changes to rolling horizon tables" prepare_tables_to_leave_rolling_horizon!(
         connection,
         variable_tables,
@@ -200,9 +213,12 @@ function run_rolling_horizon(
     # Export solution
     if output_folder != ""
         if energy_problem.solved
+            show_log &&
+                @info "[$(timestamp())] Exporting rolling horizon solution to $output_folder"
             @timeit to "export_solution_to_csv_files" export_solution_to_csv_files(
                 output_folder,
-                energy_problem,
+                energy_problem;
+                show_log,
             )
         else
             @warn "The energy problem has not been solved yet. Skipping export solution."

--- a/src/run-scenario.jl
+++ b/src/run-scenario.jl
@@ -35,8 +35,11 @@ function run_scenario(
 )
     reset_timer!(to)
 
-    energy_problem = @timeit to "create EnergyProblem from connection" EnergyProblem(connection)
+    show_log && @info "[$(timestamp())] Starting TulipaEnergyModel"
+    energy_problem =
+        @timeit to "create EnergyProblem from connection" EnergyProblem(connection; show_log)
 
+    show_log && @info "[$(timestamp())] Creating model"
     @timeit to "create_model!" create_model!(
         energy_problem;
         optimizer,
@@ -44,17 +47,22 @@ function run_scenario(
         model_file_name,
         enable_names,
         direct_model,
+        show_log,
     )
 
+    show_log && @info "[$(timestamp())] Solving model"
     @timeit to "solve_model!" solve_model!(energy_problem)
 
+    show_log && @info "[$(timestamp())] Saving solution"
     @timeit to "save_solution!" save_solution!(energy_problem)
 
     if output_folder != ""
         if energy_problem.solved
+            show_log && @info "[$(timestamp())] Exporting solution tables to $output_folder"
             @timeit to "export_solution_to_csv_files" export_solution_to_csv_files(
                 output_folder,
-                energy_problem,
+                energy_problem;
+                show_log,
             )
         else
             @warn "The energy problem has not been solved yet. Skipping export solution."

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -264,15 +264,20 @@ mutable struct EnergyProblem
 
     Constructs a new EnergyProblem object using the `connection`.
     This will call relevant functions to generate all input that is required for the model creation.
+        Set `show_log = false` to silence progress logging.
     """
-    function EnergyProblem(connection)
+    function EnergyProblem(connection; show_log = true)
+        show_log && @info "[$(timestamp())] Creating EnergyProblem internal tables"
         @timeit to "create_internal_structure" create_internal_tables!(connection)
 
+        show_log && @info "[$(timestamp())] Computing variable indices"
         variables = @timeit to "compute_variables_indices" compute_variables_indices(connection)
 
+        show_log && @info "[$(timestamp())] Computing constraint indices"
         constraints =
             @timeit to "compute_constraints_indices" compute_constraints_indices(connection)
 
+        show_log && @info "[$(timestamp())] Preparing profiles"
         profiles = @timeit to "prepare_profiles_structure" prepare_profiles_structure(connection)
 
         energy_problem = new(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -267,3 +267,13 @@ function _append_available_units_shut_down_compact_method(connection, table_name
         ",
     )
 end
+
+"""
+    timestamp()
+
+Return the current UTC time formatted for log messages.
+The returned string ends with `UTC` to make the timezone explicit.
+"""
+function timestamp()
+    return string(Dates.format(Dates.now(Dates.UTC), LOG_DATE_FORMAT), " UTC")
+end


### PR DESCRIPTION
This pull request introduces a configurable, timestamped progress logging system to the model creation and rolling horizon workflows. It adds a `show_log` parameter (defaulting to `true`) to key functions, enabling users to toggle detailed progress messages throughout the model building, rolling horizon, and solution export processes. The log messages provide clear, timestamped updates for each major step, improving transparency and debugging capabilities, while allowing users to silence logs if desired.

The most important changes are:

**Progress Logging Enhancements:**
* Added `show_log` parameter (default: `true`) to `create_model!`, `create_model`, `export_solution_to_csv_files`, and rolling horizon functions, allowing users to enable or disable progress logging.
* Inserted timestamped `@info` log statements before all major steps in `create_model` and rolling horizon code, providing clear progress updates (e.g., "Adding flow variables", "Solving rolling horizon window $window_id"). 
**Documentation Updates:**
* Updated docstrings for affected functions to document the new `show_log` parameter and its effect.

**Utility Improvements:**
* Introduced a constant `LOG_DATE_FORMAT` for consistent timestamp formatting in log messages.

This makes the modeling process more transparent and user-friendly, especially for debugging large or complex optimization problems.

## Related issues

Closes #1669 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
