### PR TITLE
Fix typos in the documentation

### DIFF
--- a/docs/src/10-tutorials/14-fully-flexible-time.md
+++ b/docs/src/10-tutorials/14-fully-flexible-time.md
@@ -255,7 +255,7 @@ The parameter `specification` allows three values: `uniform`,`math`, or `explici
 
 Some examples on how to set it up are in the docs for the [`TulipaEnergyModel._parse_rp_partition`](https://tulipaenergy.github.io/TulipaEnergyModel.jl/v0.10/95-reference/#TulipaEnergyModel._parse_rp_partition) function.
 
-What is the equialent of a partition of 6 in a `uniform` specification in a `math` specification?
+What is the equivalent of a partition of 6 in a `uniform` specification in a `math` specification?
 
 ### Compare with the hourly case from the Assets & Flows tutorial
 

--- a/docs/src/10-tutorials/16-storage.md
+++ b/docs/src/10-tutorials/16-storage.md
@@ -58,7 +58,7 @@ energy_problem = TEM.run_scenario(connection)
 !!! tip
     Remember that you can always define and create the output directory if it doesn't exist to export the results to csv files. Then you can use the `output_folder` keyword argument in the `run_scenario` function to save the results in that folder.
 
-At this point, everything should work similiar as Tutorial 4.
+At this point, everything should work similar as Tutorial 4.
 
 ## Results
 

--- a/docs/src/10-tutorials/17-multi-year-investments.md
+++ b/docs/src/10-tutorials/17-multi-year-investments.md
@@ -4,7 +4,7 @@ Let's explore the multi-year investments in Tulipa. We will talk about discount 
 
 ## 1. Set up
 
-1. Paste the code below that add the packages and instantiate your enviroment (if you don't have it already)
+1. Paste the code below that add the packages and instantiate your environment (if you don't have it already)
 
 ```julia
 using Pkg: Pkg       # Julia package manager (like pip for Python)

--- a/docs/src/10-tutorials/18-stochastic.md
+++ b/docs/src/10-tutorials/18-stochastic.md
@@ -21,7 +21,7 @@ Let's see how to implement two-stage stochastic optimization with TulipaEnergyMo
 We import the necessary packages, and load the data in the DuckDB.
 
 !!! tip "Remember!"
-    1. Activate your local enviroment and instantiate the project, if you haven't already.
+    1. Activate your local environment and instantiate the project, if you haven't already.
     2. Adjust the path to where you have the data stored.
 
 ```@example stochastic

--- a/docs/src/10-tutorials/31-rolling-horizon.md
+++ b/docs/src/10-tutorials/31-rolling-horizon.md
@@ -480,7 +480,7 @@ nice_query("FROM rolling_solution_var_flow ORDER BY RANDOM() LIMIT 5")
 
 ### `full_%` (intermediate)
 
-During the execution of the rolling horizon, we also created intermediate tables to store the full problem. These are named `full_X` for each varable table `X`, and for the `rep_periods_data` table.
+During the execution of the rolling horizon, we also created intermediate tables to store the full problem. These are named `full_X` for each variable table `X`, and for the `rep_periods_data` table.
 
 The `rep_periods_data` is modified to pretend that the horizon is limited to the optimisation window, thus the `full_X` version of these tables serve as backup.
 

--- a/docs/src/20-user-guide/30-configuring-model-features.md
+++ b/docs/src/20-user-guide/30-configuring-model-features.md
@@ -42,7 +42,7 @@ inter-period storage level trajectory:
   This option is recommended for long-duration storage without modeling short-duration fluctuations.
 - `inter_and_intra_rep_period` adds increase/decrease envelopes so
   the bounds also protect the trajectory within every mapped representative period. These bounds are more conservative when there is `storage_loss_from_stored_energy` values different from zero, and can lead to a larger model size, but they ensure that the storage level never exceeds the limits.
-  This option is recommended for long-duration storage with short-duration fluctuations as well. An use case, for example, is a battery that can shift energy between the represenative periods, so we want to model it as a seasonal asset that uses the inter period constraints. But, due to its capacity limitations, we want to impose extra bounds to ensure it stays within limits inside the representative periods.
+  This option is recommended for long-duration storage with short-duration fluctuations as well. An use case, for example, is a battery that can shift energy between the representative periods, so we want to model it as a seasonal asset that uses the inter period constraints. But, due to its capacity limitations, we want to impose extra bounds to ensure it stays within limits inside the representative periods.
 - `none` creates no additional inter-period minimum or maximum storage-level
   constraints. This option is only recommended for testing, debugging, or very specific cases (e.g., CO2 emissions modelled as storage asset without a specific limit), as it can lead to unbounded storage levels.
 

--- a/docs/src/30-concepts.md
+++ b/docs/src/30-concepts.md
@@ -398,7 +398,7 @@ Let's now take a look at the resulting constraints in the model.
 \end{aligned}
 ```
 
-For the maximum ramp down we have similiar constraints as the ones shown above.
+For the maximum ramp down we have similar constraints as the ones shown above.
 
 ### Unit Commitment in Assets with Constant Time Resolution
 
@@ -602,7 +602,7 @@ filtered_assets = assets[assets.type .== "storage", ["asset", "type", "capacity"
 
 The `use_inter_period_constraints` parameter specifies whether a storage asset employs inter-period constraints. The `phs` has a capacity of 100 MW and a storage capacity of 4,800 MWh, corresponding to a 48-hour discharge duration, and utilizes `inter_period_only` bounds. The `flow_battery` has a capacity of 50 MW and 500 MWh of storage capacity, equating to a 10-hour discharge duration, and employs `inter_and_intra_rep_period` because it manages energy both within and across periods. This option applies conservative intra-representative-period envelopes on top of the inter-period storage bounds, enabling the mid-duration flow battery to use the inter-period storage-level formulation while maintaining intra-period chronological tracking. As a result, the 10-hour flow battery can transfer energy between periods while keeping storage levels within the specified bounds inside each period.
 
-In contrast, the `battery` and the `caes` only use rep-period constraints with rep-period-storage level variables (i.e., $v^{\text{rep-period-storage}}_{\text{battery},k,b_k}$ and $v^{\text{rep-period-storage}}_{\text{caes},k,b_k}$), so they cannot shift energy between periods. In addition, both have 10 MW capacity with 20 MWh of storage capacity (i.e., 2-hour discharge duration). The `caes` also has an auxiliary output that is kept out of its storage balance to represent its CO2 emmissions; see the [flow coefficients](@ref coefficient-for-storage-constraints) section of the user guide.
+In contrast, the `battery` and the `caes` only use rep-period constraints with rep-period-storage level variables (i.e., $v^{\text{rep-period-storage}}_{\text{battery},k,b_k}$ and $v^{\text{rep-period-storage}}_{\text{caes},k,b_k}$), so they cannot shift energy between periods. In addition, both have 10 MW capacity with 20 MWh of storage capacity (i.e., 2-hour discharge duration). The `caes` also has an auxiliary output that is kept out of its storage balance to represent its CO2 emissions; see the [flow coefficients](@ref coefficient-for-storage-constraints) section of the user guide.
 
 The `rep-periods-data` file has information on the representative periods in the example. We have three representative periods, each with 24 timesteps and hourly resolution, representing a day. The figure below shows the availability profile of the renewable energy sources in the example.
 
@@ -970,7 +970,7 @@ In this section, we show how flexible time resolution is applied when considerin
 
 ![mimo-example](./figs/mimo-example.png)
 
-The example has two sources of energy `biomass` and `gas_market`, three conversion assets `power_plant`, `chp_backpressure`, and `chp_extraction`, two demands of energy represented by `electricity_demand` and `heat_demand`, and finally a by-product CO2 emmisions that goes to the asset `atmosphere`. The table below shows the type of each asset. Notice that the `biomass` asset is modeled as a storage and the `atmosphere` as a consumer. We will return to these definitions later in this section, but bear with us and keep this in mind.
+The example has two sources of energy `biomass` and `gas_market`, three conversion assets `power_plant`, `chp_backpressure`, and `chp_extraction`, two demands of energy represented by `electricity_demand` and `heat_demand`, and finally a by-product CO2 emissions that goes to the asset `atmosphere`. The table below shows the type of each asset. Notice that the `biomass` asset is modeled as a storage and the `atmosphere` as a consumer. We will return to these definitions later in this section, but bear with us and keep this in mind.
 
 ```@example mimo
 using DataFrames # hide
@@ -1087,7 +1087,7 @@ That looks cool 🤓 but, wait a minute! What about the flexible temporal resolu
 
 It's straightforward: When it comes to the constraints created by the flow relationships, the resulting resolution follows the highest resolution of the flows involved in the relationship. In simpler terms, this means it is determined by `max(flow1 resolution, flow2 resolution)`. Consequently, the resulting constraints are considered as energy constraints. Where do I find this information? Remember, the table in the section titled [`flexible time resolution`](@ref flex-time-res) summarizes all the rules 😉 .Now, let’s examine each relationship ($x \in \mathcal{X}$) closely:
 
-- Relationship $x_1$ = **flow_1(power_plant, electricity_demand) and flow_2(power_plant, heat_demand)**: both flows have an hourly resolution (i.e., deafult value) since they don't have any definition in the `flows-rep-periods-partitions` file. Therefore, the flows relationship constraint is also hourly.
+- Relationship $x_1$ = **flow_1(power_plant, electricity_demand) and flow_2(power_plant, heat_demand)**: both flows have an hourly resolution (i.e., default value) since they don't have any definition in the `flows-rep-periods-partitions` file. Therefore, the flows relationship constraint is also hourly.
 
 ```math
 \begin{aligned}
@@ -1174,7 +1174,7 @@ It's straightforward: When it comes to the constraints created by the flow relat
 \end{aligned}
 ```
 
-- Relationship $x_9$ = **flow_1(chp_extraction, heat_demand) and flow_2(chp_extraction, electricity_demand)**: both flows have an hourly resolution (i.e., deafult value). Therefore, the flows relationship constraint is also hourly. This constraint reprsents a simple limit for the maximum heat flow.
+- Relationship $x_9$ = **flow_1(chp_extraction, heat_demand) and flow_2(chp_extraction, electricity_demand)**: both flows have an hourly resolution (i.e., deafult value). Therefore, the flows relationship constraint is also hourly. This constraint represents a simple limit for the maximum heat flow.
 
 ```math
 \begin{aligned}
@@ -1249,7 +1249,7 @@ consumers = assets_data[!,"type"] .== "consumer" #hide
 filtered_df_joined = df_joined[consumers, ["asset", "consumer_balance_sense", "peak_demand"]] # hide
 ```
 
-In addition, the resolution of all the flows comming into the `atmosphere` asset is 24h, i.e., daily, meaning that the resolution of the consumer balance for this asset is also 24h:
+In addition, the resolution of all the flows coming into the `atmosphere` asset is 24h, i.e., daily, meaning that the resolution of the consumer balance for this asset is also 24h:
 
 ```math
 \begin{aligned}

--- a/docs/src/40-scientific-foundation/40-formulation.md
+++ b/docs/src/40-scientific-foundation/40-formulation.md
@@ -276,7 +276,7 @@ The parameter $p^{\text{min operating point}}_{a,y}$ is also used for producer a
 
 There are two types of vintage methods for multi-year investment modelling: the aggregated method and the compact method. The aggregated method (`vintage_method = "aggregated"`) aggregates all units available in a year, regardless of when they were invested. The compact method (`vintage_method = "compact_profiles"` or `"compact_efficiencies"`) tracks availability by investment and operational year, enabling vintage-specific constraints while reducing model size. For more information on this topic, refer to the [vintage modeling](@ref vintage-modeling) concept, the [How to use](@ref multi-year-setup) guide, or [Wang and Morales-España (2025)](@ref scientific-refs).
 
-For available units across years, we define the following expresssions:
+For available units across years, we define the following expressions:
 
 ```math
 \begin{aligned}


### PR DESCRIPTION
Fixes 13 spelling mistakes across the docs, found with `codespell`.

Prose only, no code identifiers, variable names or LaTeX touched.