### PR TITLE
Wrap orcid in quotes hopefully fixing Zenodo integration

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,7 +42,7 @@ authors:
       family-names: Elgersma
       email: m.b.elgersma@tudelft.nl
       affiliation: TU Delft
-      orcid: https://orcid.org/0009-0007-1417-8757
+      orcid: "https://orcid.org/0009-0007-1417-8757"
     - given-names: Ni
       family-names: Wang
       email: ni.wang@tno.nl


### PR DESCRIPTION
@gnawin, @datejada, the Zenodo integration did not trigger with release v0.23.2 (ref: https://zenodo.org/account/settings/github/repository/TulipaEnergy/TulipaEnergyModel.jl).
I'm not sure what happened, but I have a guess, which is this small change in here. It's not documented anywhere, but the other ORCIDs follow this.
This is a valid CITATION.CFF, which is why the pre-commit CFF validation passed, but I guess Zenodo's internal conversion does its own thing.

After this is merged, I'll manually create a `v0.23.2-zenodo` release just to trigger it and avoid creating a whole new Julia release unnecessarily, if you're ok with it.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
